### PR TITLE
feat: add ecosystem reference page

### DIFF
--- a/app/ecosystem/page.tsx
+++ b/app/ecosystem/page.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import type { Metadata } from 'next'
+import Link from "next/link"
+
+export const metadata: Metadata = {
+  title: 'Our Ecosystem',
+  description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+  openGraph: {
+    title: 'Our Ecosystem',
+    description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+    type: 'website',
+    url: 'https://fundloop.org/ecosystem',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Our Ecosystem',
+    description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+  },
+  alternates: {
+    canonical: 'https://fundloop.org/ecosystem',
+  },
+}
+
+export default function EcosystemPage() {
+  const sites = [
+    { name: "ChainCrew", url: "https://chaincrew.xyz", desc: "Team up in Crews to manage memberships, events, and community treasuries." },
+    { name: "ClearPass", url: "https://clearpass.app", desc: "KYC verification with NFC-enabled passports and driver’s licenses." },
+    { name: "Cubid", url: "https://cubid.me", desc: "Privacy-preserving identity layer with proofs and stamps." },
+    { name: "EquityFlow", url: "https://equityflow.xyz", desc: "Tools for equity and commitment-sharing among founders and teams." },
+    { name: "Firebelly", url: "https://firebelly.xyz", desc: "Innovation studio supporting regenerative and Web3 ventures." },
+    { name: "FundLoop", url: "https://fundloop.org", desc: "Collaborative incubator and funding network for early-stage projects." },
+    { name: "GreenPill Canada", url: "https://greenpill.ca", desc: "Building local regenerative economies across Canada." },
+    { name: "GreenPill Toronto", url: "https://greenpill.to", desc: "Toronto node of the global GreenPill Network." },
+    { name: "Procent Foundation", url: "https://procentfoundation.com", desc: "Nonprofit supporting public goods and open innovation." },
+    { name: "Safe2Meet", url: "https://safe2meet.me", desc: "Safer in-person meetups for real estate, classifieds, and dating." },
+    { name: "SmarTrust", url: "https://smartrust.me", desc: "AI-powered escrow & arbitration for freelancers, agencies, and B2B." },
+    { name: "SnapVote", url: "https://snapvote.org", desc: "Fast, trustworthy decision-making and polls for communities." },
+    { name: "SpareChange", url: "https://sparechange.tips", desc: "Tip anyone with QR codes and digital micro-payments." },
+    { name: "TCOIN", url: "https://tcoin.me", desc: "Toronto’s local community currency pegged to transit tokens." },
+    { name: "UBI Finder", url: "https://ubifinder.org", desc: "Global directory of Universal Basic Income projects." },
+    { name: "FreeForm", url: "https://usefreeform.com", desc: "Next-gen form builder with voting, branching, and identity options." },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 text-slate-800 dark:text-slate-100">
+      <div className="max-w-5xl mx-auto py-16 px-6">
+        <h1 className="text-4xl font-bold text-center mb-10">
+          Our Ecosystem
+        </h1>
+        <p className="text-center text-lg mb-12">
+          Explore the interconnected projects we’re building across identity, payments, coordination, and regenerative economies.
+        </p>
+        <div className="grid md:grid-cols-2 gap-6">
+          {sites.map((site) => (
+            <div key={site.url} className="p-6 bg-white dark:bg-slate-800 rounded-2xl shadow hover:shadow-lg transition">
+              <h2 className="text-2xl font-semibold mb-2">
+                <Link href={site.url} target="_blank" className="hover:underline">
+                  {site.name}
+                </Link>
+              </h2>
+              <p>{site.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/ecosystem/page.tsx
+++ b/app/ecosystem/page.tsx
@@ -54,7 +54,12 @@ export default function EcosystemPage() {
           {sites.map((site) => (
             <div key={site.url} className="p-6 bg-white dark:bg-slate-800 rounded-2xl shadow hover:shadow-lg transition">
               <h2 className="text-2xl font-semibold mb-2">
-                <Link href={site.url} target="_blank" className="hover:underline">
+                <Link
+                  href={site.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:underline"
+                >
                   {site.name}
                 </Link>
               </h2>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import Link from "next/link"
 import { CircleDollarSign, Github, Twitter, Linkedin, Mail } from "lucide-react"
 
@@ -108,6 +109,14 @@ export default function Footer() {
                   className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
                 >
                   Blog
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/ecosystem"
+                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+                >
+                  Ecosystem
                 </Link>
               </li>
             </ul>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://fundloop.org/</loc></url>
+  <url><loc>https://fundloop.org/about</loc></url>
+  <url><loc>https://fundloop.org/analytics</loc></url>
+  <url><loc>https://fundloop.org/api</loc></url>
+  <url><loc>https://fundloop.org/blog</loc></url>
+  <url><loc>https://fundloop.org/cookies</loc></url>
+  <url><loc>https://fundloop.org/documentation</loc></url>
+  <url><loc>https://fundloop.org/faq</loc></url>
+  <url><loc>https://fundloop.org/join</loc></url>
+  <url><loc>https://fundloop.org/pledge</loc></url>
+  <url><loc>https://fundloop.org/privacy</loc></url>
+  <url><loc>https://fundloop.org/projects</loc></url>
+  <url><loc>https://fundloop.org/support</loc></url>
+  <url><loc>https://fundloop.org/terms</loc></url>
+  <url><loc>https://fundloop.org/users</loc></url>
+  <url><loc>https://fundloop.org/ecosystem</loc></url>
+</urlset>

--- a/tests/ecosystem-page.test.tsx
+++ b/tests/ecosystem-page.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import EcosystemPage, { metadata } from '../app/ecosystem/page'
+
+describe('EcosystemPage', () => {
+  it('renders ecosystem heading and sites', () => {
+    render(<EcosystemPage />)
+    expect(screen.getByRole('heading', { name: /Our Ecosystem/i })).toBeDefined()
+    expect(screen.getByText('ChainCrew')).toBeDefined()
+  })
+
+  it('exports correct metadata', () => {
+    expect(metadata).toMatchObject({
+      title: 'Our Ecosystem',
+      description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+      openGraph: {
+        title: 'Our Ecosystem',
+        description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+        type: 'website',
+        url: 'https://fundloop.org/ecosystem',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: 'Our Ecosystem',
+        description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+      },
+      alternates: {
+        canonical: 'https://fundloop.org/ecosystem',
+      },
+    })
+  })
+})

--- a/tests/ecosystem-page.test.tsx
+++ b/tests/ecosystem-page.test.tsx
@@ -10,6 +10,12 @@ describe('EcosystemPage', () => {
     expect(screen.getByText('ChainCrew')).toBeDefined()
   })
 
+  it('adds rel noopener noreferrer to external links', () => {
+    render(<EcosystemPage />)
+    const link = screen.getByRole('link', { name: 'ChainCrew' })
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
   it('exports correct metadata', () => {
     expect(metadata).toMatchObject({
       title: 'Our Ecosystem',

--- a/tests/footer.test.tsx
+++ b/tests/footer.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import Footer from '@/components/footer'
+
+describe('Footer', () => {
+  it('links to ecosystem page', () => {
+    render(<Footer />)
+    const link = screen.getByRole('link', { name: /ecosystem/i })
+    expect(link.getAttribute('href')).toBe('/ecosystem')
+  })
+})

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,10 @@
+import fs from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+describe('sitemap', () => {
+  it('includes ecosystem page', () => {
+    const sitemap = fs.readFileSync(path.join(process.cwd(), 'public', 'sitemap.xml'), 'utf-8')
+    expect(sitemap).toMatch('/ecosystem')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
+import path from 'path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add SEO-focused ecosystem directory page
- test ecosystem page rendering
- support `@` path alias in vitest
- add metadata, footer link, and sitemap for stronger SEO

## Testing
- `pnpm lint`
- `pnpm test --run`
- `NEXT_PUBLIC_SUPABASE_URL=foo NEXT_PUBLIC_SUPABASE_ANON_KEY=bar pnpm build` *(fails: Failed to fetch font files from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7813caf4c83248ae72371a20c2f50