### PR TITLE
[codex] refresh public marketing site and participation flow

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,4 +1,37 @@
 ---
+
+### session v22: Reimagine the public marketing site and participant journey
+- timestamp: 2026-03-27T15:07:38Z
+- agent: **Codex (GPT-5)**
+- branch: **codex/participation-marketing-refresh**
+- head: dbbb921140a99d33ddede83b00c7d0b27c22f68b - feat(marketing): add ecosystem entry and refine brand badge
+
+#### Objective
+Refresh the FundLoop public site into a cohesive marketing surface, add a real participant explainer page, fix the public navigation and onboarding regressions surfaced during review, and package the updated landing experience for a PR into `dev`.
+
+#### Actions Taken
+- Rebuilt the public-page presentation system with new shared marketing primitives, refreshed typography and motion, and updated the homepage, about, pricing, FAQ, ecosystem, API, documentation, support, join, and use-case pages to match the new visual language.
+- Updated the public navigation, footer, dropdowns, and mobile menu to support the redesigned site structure, improved responsive behavior on tablet/mobile breakpoints, and added a homepage CTA that can open the header use-case chooser directly.
+- Added local-environment safety fallbacks so public pages and onboarding query params still produce usable UI when Supabase or wallet config is missing instead of failing silently or throwing.
+- Added `I Am Human` to the ecosystem directory, curated the homepage ecosystem preview to highlight `SmarTrust`, `TCOIN`, and `Solar Village`, and strengthened the `Network Thesis` overlay so the constellation animation no longer collides with its copy.
+- Added the new `/participation` page to explain the participant lifecycle, proof/privacy controls, and payout preferences, then repointed the homepage, support, FAQ, and shared resource navigation to that new explainer.
+
+#### Tests and Validation Notes
+- Ran `pnpm lint`.
+- Ran `pnpm test`.
+- Ran `pnpm typecheck`.
+- Ran `pnpm build`.
+- Ran `pnpm --dir contracts test`.
+- Browser-smoke-tested the refreshed public pages, responsive breakpoints, onboarding query params, desktop/mobile use-case CTA behavior, and the new `/participation` page with Playwright against the local dev server.
+- `pnpm build` still emitted the existing non-failing Recharts width/height warnings during static generation on analytics-related pages.
+
+#### Reflections
+- The redesign held together best once the public pages shared a single marketing layout system instead of each page evolving its own chrome and spacing rules.
+- Treating the homepage ecosystem preview as an explicit editorial selection is safer than relying on array order, because content curation and directory order are different concerns.
+
+#### Suggested Next Steps
+- Review the new public copy as a group, especially the participant language and ecosystem/project descriptions, to make sure the tone matches FundLoop’s intended voice before wider launch.
+- If more public-site polish is coming, consider a follow-up pass on the remaining non-marketing routes such as `/blog`, `/projects`, and `/users` so their local-env behavior and visual language match the refreshed shell more closely.
 description: Session log for agent coding sessions
 alwaysApply: hybrid = one log entry per commit or session in the most appropriate session-log file
 ---

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,4 +1,49 @@
 ---
+description: Session log for agent coding sessions
+alwaysApply: hybrid = one log entry per commit or session in the most appropriate session-log file
+---
+
+# session-log.md
+Agents populate one level-3 heading for each coding session, following the same format each time. Each session bumps the version and includes plain text descriptions of:
+- objective
+- summary of actions taken
+- reflections
+- suggested next steps
+
+---
+
+### session v23: Address PR #17 public-site review comments
+- timestamp: 2026-03-27T15:45:06Z
+- agent: **Codex (GPT-5)**
+- branch: **codex/participation-marketing-refresh**
+- head: b54f8134cc2095a4dbff2fdb268dda3c8d89f6ad - feat(marketing): refresh public site and participation flow
+
+#### Objective
+Address the actionable PR review comments on the public-site marketing refresh by fixing the broken session-log frontmatter, restoring an old homepage deep link, tightening navigation behavior, and resolving the runtime/performance concerns in the new client-side components.
+
+#### Actions Taken
+- Moved the `session v22` entry out of the YAML frontmatter block in `agent-context/session-log.md` so the file metadata stays valid for tooling.
+- Split the desktop navbar’s explore data from its top-level blog link in `components/navbar.tsx` so `Blog` no longer appears twice.
+- Restored the homepage `/#project-signup` compatibility anchor in `app/page.tsx` so the pledge page CTA still lands on the project onboarding entry point.
+- Added `overflow-y-auto` to the mobile navigation overlay in `components/mobile-menu.tsx` so the expanded menu remains reachable on shorter screens.
+- Reworked `components/marketing/network-constellation.tsx` to use `requestAnimationFrame` plus CSS custom properties instead of React state updates on every pointer move.
+- Moved AppKit initialization in `components/web3-provider.tsx` into an effect so render stays free of SDK side effects.
+
+#### Tests and Validation Notes
+- Ran `pnpm lint -- app/page.tsx components/navbar.tsx components/mobile-menu.tsx components/marketing/network-constellation.tsx components/web3-provider.tsx`.
+- Ran `pnpm typecheck`.
+- Ran `pnpm build`.
+- Browser-smoke-tested `/#project-signup`, the desktop `Explore` dropdown, and the mobile navigation overlay with Playwright.
+- Confirmed the mobile overlay now has `overflowY: auto` and a larger `scrollHeight` than `clientHeight`, making the lower links reachable on short screens.
+- `pnpm build` still emitted the existing non-failing Recharts width/height warnings during analytics static generation.
+
+#### Reflections
+- Most of the review feedback was high-signal boundary work: preserving legacy deep links, keeping render paths pure, and making navigation robust across smaller screens.
+- The constellation effect reads the same visually after the `requestAnimationFrame` change, which is a good sign that the lighter implementation path did not compromise the intended feel.
+
+#### Suggested Next Steps
+- Push this review-response commit to PR #17 and reply on each addressed thread with the concrete fix.
+- If more interactions are added to the homepage hero, prefer CSS-variable or `requestAnimationFrame` driven motion before introducing new high-frequency React state updates.
 
 ### session v22: Reimagine the public marketing site and participant journey
 - timestamp: 2026-03-27T15:07:38Z
@@ -32,18 +77,6 @@ Refresh the FundLoop public site into a cohesive marketing surface, add a real p
 #### Suggested Next Steps
 - Review the new public copy as a group, especially the participant language and ecosystem/project descriptions, to make sure the tone matches FundLoop’s intended voice before wider launch.
 - If more public-site polish is coming, consider a follow-up pass on the remaining non-marketing routes such as `/blog`, `/projects`, and `/users` so their local-env behavior and visual language match the refreshed shell more closely.
-description: Session log for agent coding sessions
-alwaysApply: hybrid = one log entry per commit or session in the most appropriate session-log file
----
-
-# session-log.md
-Agents populate one level-3 heading for each coding session, following the same format each time. Each session bumps the version and includes plain text descriptions of:
-- objective
-- summary of actions taken
-- reflections
-- suggested next steps
-
----
 
 ### session v21: Address PR #16 inline review comments
 - timestamp: 2026-03-26T23:32:13Z

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,162 +1,154 @@
 import Link from "next/link"
-import Image from "next/image"
+import { ArrowLeft, ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { ArrowLeft, ArrowRight, Users, Building2, Globe2 } from "lucide-react"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+
+const principles = [
+  {
+    title: "Mutual prosperity",
+    body: "Projects should be able to grow without extracting all of the upside from the people creating their momentum.",
+  },
+  {
+    title: "Better signal",
+    body: "Proof-of-humanity, participation, and payout logic get stronger when the ecosystem can share context instead of operating in silos.",
+  },
+  {
+    title: "Operational alignment",
+    body: "Values should show up as actual payment flows, contribution models, and onboarding behavior, not just brand language.",
+  },
+] as const
+
+const timeline = [
+  {
+    step: "Origin",
+    body: "FundLoop started from a simple frustration: the internet keeps generating value through communities, yet the value rarely loops back to those communities in a principled way.",
+  },
+  {
+    step: "Model",
+    body: "The answer is not another subscription moat. It is a network where projects can pledge a small share of upside, people can build signal through real use, and value can return with better context.",
+  },
+  {
+    step: "Direction",
+    body: "That means FundLoop acts as an application shell, funding layer, and coordination surface for a broader regenerative economy rather than a single standalone product.",
+  },
+] as const
 
 export default function AboutPage() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="flex items-center gap-2 mb-8">
-        <Button asChild variant="ghost" size="sm" className="gap-1">
-          <Link href="/">
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back to Home</span>
-          </Link>
-        </Button>
-      </div>
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
 
-      <div className="max-w-3xl mx-auto">
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">About FundLoop</h1>
-        <p className="text-slate-600 dark:text-slate-300 text-lg mb-8">
-          FundLoop is a revolutionary network state that creates a sustainable economic ecosystem through mutual aid and
-          shared prosperity.
-        </p>
+      <MarketingSection className="pt-0">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
+          <Reveal>
+            <SectionEyebrow>About FundLoop</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">
+              FundLoop is building the operating logic for a network economy that shares value back out.
+            </SectionTitle>
+            <SectionBody className="mt-6 max-w-2xl">
+              The point is not to charge people to participate. The point is to help projects, communities, and funding
+              flows align so contribution can be noticed, trusted, and rewarded more fairly.
+            </SectionBody>
+          </Reveal>
 
-        <div className="relative w-full h-64 md:h-80 rounded-xl overflow-hidden mb-8">
-          <Image src="/placeholder.svg?height=400&width=800" alt="FundLoop Community" fill className="object-cover" />
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/52 p-6 dark:bg-white/[0.03]">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                In plain language
+              </p>
+              <div className="mt-6 space-y-5">
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em]">Projects contribute</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Teams can pledge 1% or more back into the loop.
+                  </p>
+                </div>
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em]">People build signal</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Real participation becomes legible across a wider ecosystem.
+                  </p>
+                </div>
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em]">Value returns</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Shared upside can flow back to people, operators, and aligned new projects.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Reveal>
         </div>
+      </MarketingSection>
 
-        <div className="space-y-8 mb-12">
-          <section>
-            <h2 className="text-2xl font-bold mb-4">Our Mission</h2>
-            <p className="text-slate-600 dark:text-slate-300 mb-4">
-              FundLoop's mission is to create a self-sustaining digital nation with shared prosperity, demonstrating a
-              new model for economic cooperation in the digital age.
-            </p>
-            <p className="text-slate-600 dark:text-slate-300">
-              We believe that by connecting projects and users in a mutually beneficial ecosystem, we can create a more
-              equitable distribution of resources and opportunities for all participants.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold mb-4">How It Works</h2>
-            <div className="grid md:grid-cols-3 gap-6 mb-6">
-              <Card>
-                <CardContent className="pt-6">
-                  <div className="flex flex-col items-center text-center">
-                    <div className="bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4">
-                      <Building2 className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-                    </div>
-                    <h3 className="font-bold mb-2">Projects Pledge 1%</h3>
-                    <p className="text-sm text-slate-600 dark:text-slate-300">
-                      Projects join FundLoop by pledging to contribute 1% of their revenue to the ecosystem.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardContent className="pt-6">
-                  <div className="flex flex-col items-center text-center">
-                    <div className="bg-cyan-100 dark:bg-cyan-900/30 p-3 rounded-full mb-4">
-                      <Users className="h-6 w-6 text-cyan-600 dark:text-cyan-400" />
-                    </div>
-                    <h3 className="font-bold mb-2">Users Participate</h3>
-                    <p className="text-sm text-slate-600 dark:text-slate-300">
-                      Users join the ecosystem and actively participate in aligned projects.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardContent className="pt-6">
-                  <div className="flex flex-col items-center text-center">
-                    <div className="bg-blue-100 dark:bg-blue-900/30 p-3 rounded-full mb-4">
-                      <Globe2 className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-                    </div>
-                    <h3 className="font-bold mb-2">Citizen Salary</h3>
-                    <p className="text-sm text-slate-600 dark:text-slate-300">
-                      Active users receive a monthly citizen salary funded by project contributions.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-            <p className="text-slate-600 dark:text-slate-300">
-              This creates a virtuous cycle: as more projects join, more funds are available for citizen salaries,
-              attracting more users to the ecosystem, which in turn benefits the projects through increased engagement
-              and growth.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold mb-4">Our Vision</h2>
-            <p className="text-slate-600 dark:text-slate-300 mb-4">
-              We envision a future where network states like FundLoop demonstrate new models of economic cooperation and
-              governance, creating more equitable and sustainable systems for all participants.
-            </p>
-            <p className="text-slate-600 dark:text-slate-300">
-              By aligning incentives between projects and users, we're building a community that values contribution,
-              participation, and mutual support—creating prosperity that's shared by all.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold mb-4">Join the Movement</h2>
-            <p className="text-slate-600 dark:text-slate-300 mb-6">
-              Whether you're a project looking to grow your user base while making a positive impact, or an individual
-              seeking to participate in a new economic model, FundLoop welcomes you to join our community.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4">
-              <Button
-                asChild
-                className="bg-gradient-to-r from-emerald-600 to-cyan-600 hover:from-emerald-700 hover:to-cyan-700"
-              >
-                <Link href="/#project-signup">
-                  Join as a Project <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/#user-signup">
-                  Join as a User <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-            </div>
-          </section>
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-10 lg:grid-cols-3">
+          {principles.map((principle, index) => (
+            <Reveal key={principle.title} delay={index * 90}>
+              <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em]">{principle.title}</p>
+                <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{principle.body}</p>
+              </div>
+            </Reveal>
+          ))}
         </div>
+      </MarketingSection>
 
-        <section className="border-t pt-8">
-          <h2 className="text-2xl font-bold mb-4">Our Team</h2>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="flex flex-col items-center text-center">
-              <div className="relative w-24 h-24 rounded-full overflow-hidden mb-4">
-                <Image src="/placeholder.svg?height=100&width=100" alt="Team Member" fill className="object-cover" />
-              </div>
-              <h3 className="font-bold">Alex Rivera</h3>
-              <p className="text-sm text-slate-600 dark:text-slate-300">Founder & CEO</p>
-            </div>
-
-            <div className="flex flex-col items-center text-center">
-              <div className="relative w-24 h-24 rounded-full overflow-hidden mb-4">
-                <Image src="/placeholder.svg?height=100&width=100" alt="Team Member" fill className="object-cover" />
-              </div>
-              <h3 className="font-bold">Jamie Chen</h3>
-              <p className="text-sm text-slate-600 dark:text-slate-300">CTO</p>
-            </div>
-
-            <div className="flex flex-col items-center text-center">
-              <div className="relative w-24 h-24 rounded-full overflow-hidden mb-4">
-                <Image src="/placeholder.svg?height=100&width=100" alt="Team Member" fill className="object-cover" />
-              </div>
-              <h3 className="font-bold">Sam Washington</h3>
-              <p className="text-sm text-slate-600 dark:text-slate-300">Community Lead</p>
-            </div>
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)]">
+          <Reveal>
+            <SectionEyebrow>Story</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Why this exists.</SectionTitle>
+          </Reveal>
+          <div className="space-y-8">
+            {timeline.map((item, index) => (
+              <Reveal key={item.step} delay={index * 80}>
+                <div className="grid gap-4 border-t border-[color:var(--marketing-line)] pt-5 sm:grid-cols-[9rem_minmax(0,1fr)]">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-muted)]">{item.step}</p>
+                  <p className="text-base leading-7 text-[var(--marketing-muted-strong)]">{item.body}</p>
+                </div>
+              </Reveal>
+            ))}
           </div>
-        </section>
-      </div>
-    </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-10">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>Next step</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">If your project wants a better loop, start inside the system that is trying to build one.</SectionTitle>
+            <SectionBody className="mt-5">
+              Project onboarding already saves drafts automatically, so teams can start the process without losing
+              their place.
+            </SectionBody>
+            <Button
+              asChild
+              size="lg"
+              className="mt-8 rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+            >
+              <Link href="/?onboarding=project">
+                Start a project profile
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/api/page.tsx
+++ b/app/api/page.tsx
@@ -1,273 +1,142 @@
 import Link from "next/link"
+import { ArrowLeft, ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { ArrowLeft, Code, Key, Database } from "lucide-react"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+
+const surfaces = [
+  {
+    title: "Data access",
+    body: "Project, user, and contribution data are the core integration surface developers expect from FundLoop.",
+  },
+  {
+    title: "Identity-aware workflows",
+    body: "Proof-of-humanity and attribution are most useful when they are available as product primitives, not one-off exports.",
+  },
+  {
+    title: "Events and notifications",
+    body: "Webhooks and real-time updates matter once payouts, onboarding, and network activity need to move across systems.",
+  },
+] as const
+
+const examples = [
+  {
+    label: "REST style",
+    snippet: `GET /projects\nGET /users/:id\nGET /contributions/stats`,
+  },
+  {
+    label: "Graph style",
+    snippet: `query {\n  projects {\n    id\n    name\n    users { id }\n  }\n}`,
+  },
+  {
+    label: "Event style",
+    snippet: `project.created\npayment.sent\nanalytics.updated`,
+  },
+] as const
 
 export default function APIPage() {
   return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="flex items-center gap-2 mb-8">
-        <Button asChild variant="ghost" size="sm" className="gap-1">
-          <Link href="/">
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back to Home</span>
-          </Link>
-        </Button>
-      </div>
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
 
-      <div className="max-w-5xl mx-auto">
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">API Documentation</h1>
-        <p className="text-slate-600 dark:text-slate-300 text-lg mb-8">
-          Integrate your applications with the FundLoop ecosystem using our comprehensive API.
-        </p>
+      <MarketingSection className="pt-0">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
+          <Reveal>
+            <SectionEyebrow>Developer preview</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">
+              The FundLoop API is a product surface in progress, not yet a finished public platform.
+            </SectionTitle>
+            <SectionBody className="mt-6 max-w-2xl">
+              This page describes the integration shape FundLoop is growing toward: data access, identity-aware
+              workflows, and event-driven coordination for projects building inside the loop.
+            </SectionBody>
+          </Reveal>
 
-        <div className="grid md:grid-cols-3 gap-6 mb-12">
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <Key className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>API Keys</CardTitle>
-              <CardDescription>Manage your API credentials</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-slate-600 dark:text-slate-300 mb-4">
-                Generate and manage API keys for secure access to FundLoop services.
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/52 p-6 dark:bg-white/[0.03]">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Current state
               </p>
-              <Button variant="outline">Manage Keys</Button>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <Code className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>SDKs</CardTitle>
-              <CardDescription>Client libraries for developers</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-slate-600 dark:text-slate-300 mb-4">
-                Download our SDKs for easy integration with various programming languages.
+              <p className="mt-4 text-base leading-7 text-[var(--marketing-muted-strong)]">
+                Developer-facing APIs, SDKs, and webhooks are still being shaped. Today, the clearest next step is to
+                review the documentation or contact support about your intended integration.
               </p>
-              <Button variant="outline">View SDKs</Button>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <Database className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>Webhooks</CardTitle>
-              <CardDescription>Real-time event notifications</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-slate-600 dark:text-slate-300 mb-4">
-                Configure webhooks to receive real-time notifications about ecosystem events.
-              </p>
-              <Button variant="outline">Configure Webhooks</Button>
-            </CardContent>
-          </Card>
+            </div>
+          </Reveal>
         </div>
+      </MarketingSection>
 
-        <Tabs defaultValue="rest-api" className="w-full mb-12">
-          <TabsList className="grid w-full grid-cols-3 mb-8">
-            <TabsTrigger value="rest-api">REST API</TabsTrigger>
-            <TabsTrigger value="graphql">GraphQL</TabsTrigger>
-            <TabsTrigger value="websockets">WebSockets</TabsTrigger>
-          </TabsList>
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-10 lg:grid-cols-3">
+          {surfaces.map((surface, index) => (
+            <Reveal key={surface.title} delay={index * 90}>
+              <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em]">{surface.title}</p>
+                <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{surface.body}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </MarketingSection>
 
-          <TabsContent value="rest-api">
-            <Card>
-              <CardHeader>
-                <CardTitle>REST API Reference</CardTitle>
-                <CardDescription>Our RESTful API provides comprehensive access to FundLoop resources</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Authentication</h3>
-                    <p className="text-slate-600 dark:text-slate-300 mb-2">
-                      All API requests require authentication using API keys. Include your API key in the request
-                      header:
-                    </p>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      Authorization: Bearer YOUR_API_KEY
-                    </div>
-                  </div>
+      <MarketingSection>
+        <div className="grid gap-8 lg:grid-cols-3">
+          {examples.map((example, index) => (
+            <Reveal key={example.label} delay={index * 80}>
+              <div className="rounded-[1.75rem] border border-[color:var(--marketing-line)] bg-[rgba(12,20,20,0.94)] p-5 text-[var(--marketing-paper)] shadow-[0_20px_60px_rgba(15,23,23,0.12)]">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-accent-soft)]">
+                  {example.label}
+                </p>
+                <pre className="mt-4 overflow-x-auto whitespace-pre-wrap font-mono text-sm leading-6 text-[var(--marketing-paper)]/90">
+                  {example.snippet}
+                </pre>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </MarketingSection>
 
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Base URL</h3>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      https://api.fundloop.org/v1
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Endpoints</h3>
-                    <div className="space-y-4">
-                      <div>
-                        <h4 className="font-medium">Projects</h4>
-                        <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                          <li>GET /projects - List all projects</li>
-                          <li>GET /projects/:slug - Get project details</li>
-                          <li>POST /projects - Create a new project</li>
-                          <li>PUT /projects/:slug - Update project details</li>
-                        </ul>
-                      </div>
-
-                      <div>
-                        <h4 className="font-medium">Users</h4>
-                        <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                          <li>GET /users - List all users</li>
-                          <li>GET /users/:id - Get user details</li>
-                          <li>POST /users - Create a new user</li>
-                          <li>PUT /users/:id - Update user details</li>
-                        </ul>
-                      </div>
-
-                      <div>
-                        <h4 className="font-medium">Contributions</h4>
-                        <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                          <li>GET /contributions - List all contributions</li>
-                          <li>GET /contributions/:id - Get contribution details</li>
-                          <li>POST /contributions - Record a new contribution</li>
-                          <li>GET /contributions/stats - Get contribution statistics</li>
-                        </ul>
-                      </div>
-
-                      <div>
-                        <h4 className="font-medium">Payments</h4>
-                        <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                          <li>GET /payments - List all payments</li>
-                          <li>GET /payments/:id - Get payment details</li>
-                          <li>POST /payments - Create a new payment</li>
-                          <li>GET /payments/stats - Get payment statistics</li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="graphql">
-            <Card>
-              <CardHeader>
-                <CardTitle>GraphQL API</CardTitle>
-                <CardDescription>
-                  Our GraphQL API provides flexible querying capabilities for FundLoop data
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Endpoint</h3>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      https://api.fundloop.org/graphql
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Example Query</h3>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      {`query {
-  projects {
-    id
-    name
-    description
-    users {
-      id
-      name
-    }
-    contributions {
-      amount
-      date
-    }
-  }
-}`}
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Schema</h3>
-                    <p className="text-slate-600 dark:text-slate-300 mb-2">
-                      Our GraphQL schema includes the following main types:
-                    </p>
-                    <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                      <li>Project - Project information</li>
-                      <li>User - User profiles</li>
-                      <li>Contribution - Project contributions</li>
-                      <li>Payment - Citizen salary payments</li>
-                      <li>Analytics - Ecosystem analytics</li>
-                    </ul>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="websockets">
-            <Card>
-              <CardHeader>
-                <CardTitle>WebSockets API</CardTitle>
-                <CardDescription>Real-time communication with the FundLoop ecosystem</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Connection</h3>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      wss://api.fundloop.org/ws
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Authentication</h3>
-                    <p className="text-slate-600 dark:text-slate-300 mb-2">
-                      Include your API key as a query parameter when connecting:
-                    </p>
-                    <div className="bg-slate-100 dark:bg-slate-800 p-3 rounded-md font-mono text-sm">
-                      wss://api.fundloop.org/ws?api_key=YOUR_API_KEY
-                    </div>
-                  </div>
-
-                  <div>
-                    <h3 className="text-lg font-medium mb-2">Events</h3>
-                    <p className="text-slate-600 dark:text-slate-300 mb-2">
-                      Subscribe to real-time events from the FundLoop ecosystem:
-                    </p>
-                    <ul className="list-disc list-inside text-slate-600 dark:text-slate-300 space-y-1">
-                      <li>project.created - New project joined</li>
-                      <li>user.created - New user joined</li>
-                      <li>contribution.received - New contribution received</li>
-                      <li>payment.sent - Citizen salary payment sent</li>
-                      <li>analytics.updated - Ecosystem analytics updated</li>
-                    </ul>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
-
-        <div className="text-center">
-          <p className="text-slate-600 dark:text-slate-300 mb-4">
-            Need help with the API? Check out our developer documentation or contact support.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild variant="outline">
-              <Link href="/documentation">Developer Docs</Link>
-            </Button>
-            <Button asChild>
-              <Link href="/support">Contact Support</Link>
-            </Button>
+      <MarketingSection className="pb-24 pt-10">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>Need a technical path?</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">Start with the docs, then tell us what you need your integration to do.</SectionTitle>
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/documentation">Open documentation</Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/support">
+                  Contact support
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
           </div>
-        </div>
-      </div>
-    </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/documentation/page.tsx
+++ b/app/documentation/page.tsx
@@ -1,12 +1,13 @@
 "use client"
 
-import { useEffect, useMemo, useState, useRef } from "react"
+import { useEffect, useMemo, useState } from "react"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
-import { getSupabaseBrowserClient } from "@/lib/supabase"
-import ArticlePage from "@/components/ArticlePage"
 import { Button } from "@/components/ui/button"
-import type { Database } from "@/types/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
+import Markdown from "@/components/markdown"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
 
 interface DocPost {
   id: number
@@ -23,145 +24,185 @@ interface DocPost {
   sort_order_within_category: number | null
 }
 
+function formatDate(dateString: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(dateString))
+}
+
 export default function DocumentationPage() {
+  const supabaseConfigured = isSupabaseConfigured()
   const [posts, setPosts] = useState<DocPost[]>([])
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(supabaseConfigured)
   const [currentSlug, setCurrentSlug] = useState<string | null>(null)
-  const articleRef = useRef<HTMLDivElement>(null)
   const getSupabase = () => getSupabaseBrowserClient()
 
   useEffect(() => {
+    if (!supabaseConfigured) {
+      return
+    }
+
     const fetchDocs = async () => {
       const supabase = getSupabase()
       setLoading(true)
-      const { data, error } = await supabase
+      const { data } = await supabase
         .from("blog_posts")
         .select(
           "id, title, subtitle, slug, excerpt, content, category, picture, published_at, created_at, updated_at, sort_order_within_category"
         )
         .eq("is_support", true)
-      if (!error) setPosts(data || [])
+
+      setPosts(data || [])
       setLoading(false)
     }
-    fetchDocs()
-  }, [])
+
+    void fetchDocs()
+  }, [supabaseConfigured])
 
   const categories = useMemo(() => {
-    return Array.from(new Set(posts.map((p) => p.category).filter(Boolean)))
+    return Array.from(new Set(posts.map((post) => post.category).filter(Boolean)))
       .sort((a, b) => (b ?? "").localeCompare(a ?? ""))
-      .filter((c): c is string => Boolean(c))
+      .filter((category): category is string => Boolean(category))
   }, [posts])
 
   const postsByCategory = useMemo(() => {
     const map: Record<string, DocPost[]> = {}
-    categories.forEach((cat) => {
-      map[cat] = posts
-        .filter((p) => p.category === cat)
+    categories.forEach((category) => {
+      map[category] = posts
+        .filter((post) => post.category === category)
         .sort((a, b) => {
           const aOrder = a.sort_order_within_category
           const bOrder = b.sort_order_within_category
+
           if (aOrder != null && bOrder != null) return aOrder - bOrder
           if (aOrder != null) return -1
           if (bOrder != null) return 1
-          const aDate = a.created_at || ""
-          const bDate = b.created_at || ""
-          return aDate.localeCompare(bDate)
+
+          return (a.created_at || "").localeCompare(b.created_at || "")
         })
     })
     return map
   }, [posts, categories])
 
-  const flatPosts = useMemo(() => {
-    return categories.flatMap((cat) => postsByCategory[cat])
-  }, [categories, postsByCategory])
-
+  const flatPosts = useMemo(() => categories.flatMap((category) => postsByCategory[category]), [categories, postsByCategory])
   const activeSlug = currentSlug ?? flatPosts[0]?.slug ?? null
-
-  const currentIndex = flatPosts.findIndex((p) => p.slug === activeSlug)
-  const currentPost = currentIndex >= 0 ? flatPosts[currentIndex] : null
-  const prevPost = currentIndex > 0 ? flatPosts[currentIndex - 1] : null
-  const nextPost =
-    currentIndex >= 0 && currentIndex < flatPosts.length - 1
-      ? flatPosts[currentIndex + 1]
-      : null
+  const currentPost = flatPosts.find((post) => post.slug === activeSlug) ?? null
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="flex items-center gap-2 mb-8">
-        <Button asChild variant="ghost" size="sm" className="gap-1">
-          <Link href="/">
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back to Home</span>
-          </Link>
-        </Button>
-      </div>
-      <div className="grid md:grid-cols-[16rem_1fr] gap-8 h-[calc(100vh-12rem)]">
-        <nav className="overflow-y-auto pr-4 space-y-4">
-          {categories.map((cat) => (
-            <div key={cat}>
-              <p className="font-semibold capitalize mb-1">{cat}</p>
-              <ul className="space-y-1 pl-2">
-                {postsByCategory[cat].map((post) => (
-                  <li key={post.id}>
-                    <button
-                      onClick={() => setCurrentSlug(post.slug)}
-                      className={`text-left w-full hover:underline ${
-                        activeSlug === post.slug
-                          ? "text-emerald-600 dark:text-emerald-400 font-medium"
-                          : ""
-                      }`}
-                    >
-                      {post.title}
-                    </button>
-                  </li>
-                ))}
-              </ul>
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pt-0">
+        <Reveal>
+          <SectionEyebrow>Documentation</SectionEyebrow>
+          <SectionTitle className="mt-4 max-w-5xl text-5xl sm:text-6xl lg:text-7xl">
+            Guides and support articles for navigating FundLoop.
+          </SectionTitle>
+          <SectionBody className="mt-6 max-w-3xl">
+            Browse help content by category, then read the article that best matches the part of the product you are
+            trying to understand or troubleshoot.
+          </SectionBody>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-12">
+        <div className="grid gap-8 lg:grid-cols-[18rem_minmax(0,1fr)]">
+          <Reveal>
+            <aside className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/52 p-5 dark:bg-white/[0.03] lg:sticky lg:top-28">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Browse topics
+              </p>
+              {loading ? (
+                <p className="mt-5 text-sm text-[var(--marketing-muted-strong)]">Loading articles...</p>
+              ) : !supabaseConfigured ? (
+                <p className="mt-5 text-sm text-[var(--marketing-muted-strong)]">
+                  Documentation content needs a configured Supabase backend in this local environment.
+                </p>
+              ) : categories.length === 0 ? (
+                <p className="mt-5 text-sm text-[var(--marketing-muted-strong)]">No documentation articles are published yet.</p>
+              ) : (
+                <div className="mt-6 space-y-6">
+                  {categories.map((category) => (
+                    <div key={category}>
+                      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--marketing-muted)]">
+                        {category}
+                      </p>
+                      <div className="mt-3 space-y-2">
+                        {postsByCategory[category].map((post) => (
+                          <button
+                            key={post.id}
+                            type="button"
+                            onClick={() => setCurrentSlug(post.slug)}
+                            className={`w-full rounded-2xl border px-4 py-3 text-left text-sm transition-colors ${
+                              activeSlug === post.slug
+                                ? "border-[color:var(--marketing-line-strong)] bg-[rgba(204,92,44,0.12)] text-[var(--marketing-accent)]"
+                                : "border-[color:var(--marketing-line)] bg-transparent text-[var(--marketing-muted-strong)] hover:bg-black/[0.03] dark:hover:bg-white/[0.04]"
+                            }`}
+                          >
+                            {post.title}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </aside>
+          </Reveal>
+
+          <Reveal delay={100}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/58 p-6 shadow-[0_24px_70px_rgba(15,23,23,0.08)] dark:bg-white/[0.03] sm:p-8">
+              {loading ? (
+                <p className="text-sm text-[var(--marketing-muted-strong)]">Loading article...</p>
+              ) : !supabaseConfigured ? (
+                <p className="text-sm text-[var(--marketing-muted-strong)]">
+                  Configure Supabase environment variables to load live documentation content locally.
+                </p>
+              ) : currentPost ? (
+                <article>
+                  <header className="border-b border-[color:var(--marketing-line)] pb-6">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                      {currentPost.category || "Documentation"}
+                    </p>
+                    <h1 className="mt-4 font-display text-4xl leading-none tracking-[-0.04em] sm:text-5xl">
+                      {currentPost.title}
+                    </h1>
+                    {currentPost.subtitle ? (
+                      <p className="mt-4 text-lg leading-7 text-[var(--marketing-muted-strong)]">{currentPost.subtitle}</p>
+                    ) : null}
+                    {currentPost.updated_at ? (
+                      <p className="mt-4 text-sm text-[var(--marketing-muted)]">
+                        Last updated {formatDate(currentPost.updated_at)}
+                      </p>
+                    ) : null}
+                  </header>
+
+                  <div className="prose prose-slate mt-8 max-w-none dark:prose-invert">
+                    <Markdown content={currentPost.content} />
+                  </div>
+                </article>
+              ) : (
+                <p className="text-sm text-[var(--marketing-muted-strong)]">Choose an article from the left to begin.</p>
+              )}
             </div>
-          ))}
-        </nav>
-        <div className="flex-1 overflow-y-auto" ref={articleRef}>
-          {loading && <p>Loading...</p>}
-          {!loading && currentPost && (
-            <>
-              <ArticlePage
-                post={currentPost}
-                backHref="/documentation"
-                backText="Back to Support"
-                showBack={false}
-                showImage={false}
-                dateKey="updated_at"
-                datePrefix="Last edited: "
-              />
-              <div className="flex justify-between mt-8">
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (prevPost) {
-                      setCurrentSlug(prevPost.slug)
-                      articleRef.current?.scrollTo({ top: 0 })
-                    }
-                  }}
-                  disabled={!prevPost}
-                >
-                  ← Back
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    if (nextPost) {
-                      setCurrentSlug(nextPost.slug)
-                      articleRef.current?.scrollTo({ top: 0 })
-                    }
-                  }}
-                  disabled={!nextPost}
-                >
-                  Next Page →
-                </Button>
-              </div>
-            </>
-          )}
+          </Reveal>
         </div>
-      </div>
-    </div>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/ecosystem/page.tsx
+++ b/app/ecosystem/page.tsx
@@ -1,74 +1,83 @@
-import React from 'react'
-import type { Metadata } from 'next'
+import type { Metadata } from "next"
 import Link from "next/link"
+import { ArrowLeft, ExternalLink } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+import { ecosystemSites } from "@/lib/public-site"
 
 export const metadata: Metadata = {
-  title: 'Our Ecosystem',
-  description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+  title: "Our Ecosystem",
+  description: "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
   openGraph: {
-    title: 'Our Ecosystem',
-    description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
-    type: 'website',
-    url: 'https://fundloop.org/ecosystem',
+    title: "Our Ecosystem",
+    description: "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+    type: "website",
+    url: "https://fundloop.org/ecosystem",
   },
   twitter: {
-    card: 'summary_large_image',
-    title: 'Our Ecosystem',
-    description: 'Explore our interconnected projects across identity, payments, coordination, and regenerative economies.',
+    card: "summary_large_image",
+    title: "Our Ecosystem",
+    description: "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
   },
   alternates: {
-    canonical: 'https://fundloop.org/ecosystem',
+    canonical: "https://fundloop.org/ecosystem",
   },
 }
 
 export default function EcosystemPage() {
-  const sites = [
-    { name: "ChainCrew", url: "https://chaincrew.xyz", desc: "Team up in Crews to manage memberships, events, and community treasuries." },
-    { name: "ClearPass", url: "https://clearpass.app", desc: "KYC verification with NFC-enabled passports and driver’s licenses." },
-    { name: "Cubid", url: "https://cubid.me", desc: "Privacy-preserving identity layer with proofs and stamps." },
-    { name: "EquityFlow", url: "https://equityflow.xyz", desc: "Tools for equity and commitment-sharing among founders and teams." },
-    { name: "Firebelly", url: "https://firebelly.xyz", desc: "Innovation studio supporting regenerative and Web3 ventures." },
-    { name: "FundLoop", url: "https://fundloop.org", desc: "Collaborative incubator and funding network for early-stage projects." },
-    { name: "GreenPill Canada", url: "https://greenpill.ca", desc: "Building local regenerative economies across Canada." },
-    { name: "GreenPill Toronto", url: "https://greenpill.to", desc: "Toronto node of the global GreenPill Network." },
-    { name: "Procent Foundation", url: "https://procentfoundation.com", desc: "Nonprofit supporting public goods and open innovation." },
-    { name: "Safe2Meet", url: "https://safe2meet.me", desc: "Safer in-person meetups for real estate, classifieds, and dating." },
-    { name: "Solar Village", url: "https://solarvillage.xyz", desc: "Carbon credits for off-grid solar projects in Africa." },
-    { name: "SmarTrust", url: "https://smartrust.me", desc: "AI-powered escrow & arbitration for freelancers, agencies, and B2B." },
-    { name: "SnapVote", url: "https://snapvote.org", desc: "Fast, trustworthy decision-making and polls for communities." },
-    { name: "SpareChange", url: "https://sparechange.tips", desc: "Tip anyone with QR codes and digital micro-payments." },
-    { name: "TCOIN", url: "https://tcoin.me", desc: "Toronto’s local community currency pegged to transit tokens." },
-    { name: "UBI Finder", url: "https://ubifinder.org", desc: "Global directory of Universal Basic Income projects." },
-    { name: "FreeForm", url: "https://usefreeform.com", desc: "Next-gen form builder with voting, branching, and identity options." },
-  ]
-
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900 text-slate-800 dark:text-slate-100">
-      <div className="max-w-5xl mx-auto py-16 px-6">
-        <h1 className="text-4xl font-bold text-center mb-10">
-          Our Ecosystem
-        </h1>
-        <p className="text-center text-lg mb-12">
-          Explore the interconnected projects we’re building across identity, payments, coordination, and regenerative economies.
-        </p>
-        <div className="grid md:grid-cols-2 gap-6">
-          {sites.map((site) => (
-            <div key={site.url} className="p-6 bg-white dark:bg-slate-800 rounded-2xl shadow hover:shadow-lg transition">
-              <h2 className="text-2xl font-semibold mb-2">
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pt-0">
+        <Reveal>
+          <SectionEyebrow>Ecosystem</SectionEyebrow>
+          <SectionTitle className="mt-4 max-w-5xl text-5xl sm:text-6xl lg:text-7xl">Our Ecosystem</SectionTitle>
+          <SectionBody className="mt-6 max-w-3xl">
+            Identity, payments, governance, local economies, safer trust rails, and public-goods infrastructure are all
+            taking shape around the same thesis: better systems should make cooperation easier, not harder.
+          </SectionBody>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="space-y-4">
+          {ecosystemSites.map((site, index) => (
+            <Reveal key={site.url} delay={index * 40}>
+              <div className="grid gap-5 border-t border-[color:var(--marketing-line)] py-6 sm:grid-cols-[4rem_minmax(0,0.9fr)_minmax(0,1.1fr)_auto] sm:items-start">
+                <p className="font-display text-4xl leading-none text-[var(--marketing-muted)]">{String(index + 1).padStart(2, "0")}</p>
                 <Link
                   href={site.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="hover:underline"
+                  className="group inline-flex items-start font-display text-3xl leading-none tracking-[-0.04em] transition-colors hover:text-[var(--marketing-accent)] sm:text-4xl"
                 >
                   {site.name}
                 </Link>
-              </h2>
-              <p>{site.desc}</p>
-            </div>
+                <p className="max-w-2xl text-sm leading-6 text-[var(--marketing-muted-strong)]">{site.desc}</p>
+                <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                  Open
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </span>
+              </div>
+            </Reveal>
           ))}
         </div>
-      </div>
-    </div>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link"
 import { ArrowLeft, ArrowRight, Bot, Building2, Users } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
 
 const projectFaqs = [
   {
@@ -28,7 +30,7 @@ const projectFaqs = [
     answer:
       "Yes. When fiat moves, payment processor fees apply. When crypto moves, gas fees apply. Those costs come out of the funds transferred out from the platform rather than being framed as a separate subscription fee.",
   },
-]
+] as const
 
 const humanFaqs = [
   {
@@ -55,7 +57,7 @@ const humanFaqs = [
     answer:
       "We are very privacy focused. All data in FundLoop is entirely anonymized. You do not even need to tell us who you are before you withdraw payments, though if you withdraw fiat then the payment provider will need to know who you are. The goal is to support identity-aware and activity-aware coordination without turning personal identity into something projects can casually inspect.",
   },
-]
+] as const
 
 const botFaqs = [
   {
@@ -82,7 +84,7 @@ const botFaqs = [
     answer:
       "Because we believe in honesty and inclusivity. Providing a path for bots encourages them to participate openly, and it also reduces the imperative to break our system by pretending to be human just to access rewards.",
   },
-]
+] as const
 
 function FAQSection({
   icon: Icon,
@@ -93,94 +95,135 @@ function FAQSection({
   icon: typeof Building2
   title: string
   description: string
-  items: { value: string; question: string; answer: string }[]
+  items: readonly { value: string; question: string; answer: string }[]
 }) {
   return (
-    <section className="mt-8 first:mt-0">
-      <div className="mb-5 flex items-start gap-4">
-        <div className="mt-1 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
-          <Icon className="h-5 w-5" />
-        </div>
+    <div className="border-t border-[color:var(--marketing-line)] pt-6">
+      <div className="mb-6 flex items-start gap-4">
+        <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 dark:bg-white/[0.04]">
+          <Icon className="h-4 w-4" />
+        </span>
         <div>
-          <h2 className="text-2xl font-bold text-slate-900 dark:text-white">{title}</h2>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">{description}</p>
+          <h2 className="font-display text-4xl leading-none tracking-[-0.04em]">{title}</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-[var(--marketing-muted-strong)]">{description}</p>
         </div>
       </div>
 
-      <Accordion type="single" collapsible className="w-full space-y-4">
+      <Accordion type="single" collapsible className="space-y-4">
         {items.map((faq) => (
-          <AccordionItem key={faq.value} value={faq.value} className="rounded-lg border px-6">
-            <AccordionTrigger className="py-4 text-left text-lg font-medium">{faq.question}</AccordionTrigger>
-            <AccordionContent className="pb-4 leading-7 text-slate-600 dark:text-slate-300">
+          <AccordionItem key={faq.value} value={faq.value} className="border-b border-[color:var(--marketing-line)]">
+            <AccordionTrigger className="py-5 text-left text-lg font-semibold tracking-[-0.02em] hover:no-underline">
+              {faq.question}
+            </AccordionTrigger>
+            <AccordionContent className="pb-5 text-base leading-7 text-[var(--marketing-muted-strong)]">
               {faq.answer}
             </AccordionContent>
           </AccordionItem>
         ))}
       </Accordion>
-    </section>
+    </div>
   )
 }
 
 export default function FAQPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-emerald-50/30 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
-      <div className="container mx-auto px-4 py-12 md:py-20">
-        <div className="mx-auto max-w-5xl">
-          <div className="mb-8 flex items-center gap-2">
-            <Button asChild variant="ghost" size="sm" className="gap-2">
-              <Link href="/">
-                <ArrowLeft className="h-4 w-4" />
-                Back to Home
-              </Link>
-            </Button>
-          </div>
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
 
-          <div className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950/80 md:p-12">
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl">Frequently Asked Questions</h1>
-            <p className="mb-8 text-lg leading-8 text-slate-600 dark:text-slate-300">
-              The short version of FundLoop is simple: users should not have to pay to join the network, projects can
-              support the ecosystem voluntarily, and the platform exists to help coordinate fairer value flow across
-              humans, projects, and even honest bots.
-            </p>
+      <MarketingSection className="pt-0">
+        <Reveal>
+          <SectionEyebrow>FAQ</SectionEyebrow>
+          <SectionTitle className="mt-4 max-w-5xl text-5xl sm:text-6xl lg:text-7xl">
+            Straight answers for projects, participants, and honest bots.
+          </SectionTitle>
+          <SectionBody className="mt-6 max-w-3xl">
+            The short version is simple: users do not pay to join the network, projects can support the ecosystem
+            voluntarily, and FundLoop exists to coordinate fairer value flow across humans, projects, and truthful
+            software agents.
+          </SectionBody>
+        </Reveal>
+      </MarketingSection>
 
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="space-y-12">
+          <Reveal>
             <FAQSection
               icon={Building2}
-              title="Projects and Founders"
+              title="Projects and founders"
               description="Questions from teams deciding whether to join, support, or build with FundLoop."
               items={projectFaqs}
             />
-
+          </Reveal>
+          <Reveal delay={80}>
             <FAQSection
               icon={Users}
-              title="Humans and Community Members"
+              title="Humans and community members"
               description="Questions from the people participating in the network and earning through it."
               items={humanFaqs}
             />
-
+          </Reveal>
+          <Reveal delay={160}>
             <FAQSection
               icon={Bot}
               title="Bots"
               description="Questions about how bots fit into a system that values honesty, human verification, and aligned participation."
               items={botFaqs}
             />
+          </Reveal>
+        </div>
+      </MarketingSection>
 
-            <div className="mt-12 flex flex-col gap-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-6 py-8 text-center dark:border-emerald-900/60 dark:bg-emerald-950/20">
-              <p className="text-slate-600 dark:text-slate-300">Need a pricing answer or a product clarification we did not cover?</p>
-              <div className="flex flex-col justify-center gap-3 sm:flex-row">
-                <Button asChild variant="outline">
-                  <Link href="/pricing">View Pricing</Link>
-                </Button>
-                <Button asChild>
-                  <Link href="/support">
-                    Contact Support
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Link>
-                </Button>
-              </div>
+      <MarketingSection className="pb-24 pt-14">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>Still need help?</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl">
+              The next best stop is participation, pricing, or support, depending on what you are trying to resolve.
+            </SectionTitle>
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/participation">View participation</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/pricing">View pricing</Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/support">
+                  Contact support
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --font-sans: var(--font-inter);
+  --font-sans: var(--font-manrope);
+  --font-display: var(--font-fraunces);
 
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));
@@ -47,6 +48,30 @@
   --animate-accordion-up: accordion-up 0.2s ease-out;
   --animate-collapsible-down: collapsible-down 0.2s ease-out;
   --animate-collapsible-up: collapsible-up 0.2s ease-out;
+}
+
+@keyframes constellation-float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate3d(0, -12px, 0) scale(1.01);
+  }
+}
+
+@keyframes constellation-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.88;
+  }
+
+  50% {
+    transform: scale(1.18);
+    opacity: 1;
+  }
 }
 
 @keyframes accordion-down {
@@ -138,6 +163,16 @@
     --sidebar-accent-foreground: 222.2 47.4% 11.2%;
     --sidebar-border: 214.3 31.8% 91.4%;
     --sidebar-ring: 162 47% 50%;
+
+    --marketing-paper: #f3ebdd;
+    --marketing-ink: #162121;
+    --marketing-muted: #746b5d;
+    --marketing-muted-strong: #4c4b43;
+    --marketing-accent: #cc5c2c;
+    --marketing-accent-soft: #f4cb8d;
+    --marketing-moss: #637056;
+    --marketing-line: rgba(22, 33, 33, 0.12);
+    --marketing-line-strong: rgba(22, 33, 33, 0.28);
   }
 
   .dark {
@@ -174,6 +209,16 @@
     --sidebar-accent-foreground: 210 40% 98%;
     --sidebar-border: 217.2 32.6% 17.5%;
     --sidebar-ring: 162 47% 40%;
+
+    --marketing-paper: #efe3d2;
+    --marketing-ink: #0d1515;
+    --marketing-muted: #b8ad9c;
+    --marketing-muted-strong: #d7ccbb;
+    --marketing-accent: #ef8b57;
+    --marketing-accent-soft: #ffd690;
+    --marketing-moss: #8a9875;
+    --marketing-line: rgba(239, 227, 210, 0.12);
+    --marketing-line-strong: rgba(239, 227, 210, 0.28);
   }
 
   * {
@@ -182,5 +227,11 @@
 
   body {
     @apply bg-background text-foreground;
+    font-feature-settings: "ss01" 1, "cv02" 1, "cv11" 1;
+  }
+
+  ::selection {
+    background: rgba(204, 92, 44, 0.18);
+    color: inherit;
   }
 }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -3,17 +3,19 @@
 import { useEffect, useState } from "react"
 import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "@/components/ui/use-toast"
-import { getSupabaseBrowserClient } from "@/lib/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
 import { buildUrl } from "@/lib/url"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
 
 export default function JoinPage() {
   const pathname = usePathname()
   const router = useRouter()
+  const supabaseConfigured = isSupabaseConfigured()
 
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(supabaseConfigured)
   const [inviterName, setInviterName] = useState<string | null>(null)
   const [inviteCode, setInviteCode] = useState<string | null>(null)
   const [inviteReady, setInviteReady] = useState(false)
@@ -25,6 +27,10 @@ export default function JoinPage() {
   }, [])
 
   useEffect(() => {
+    if (!supabaseConfigured) {
+      return
+    }
+
     const validateInviteCode = async () => {
       const supabase = getSupabaseBrowserClient()
 
@@ -34,6 +40,7 @@ export default function JoinPage() {
       }
 
       setLoading(true)
+
       try {
         const { data, error } = await supabase
           .from("invitation_codes")
@@ -41,14 +48,10 @@ export default function JoinPage() {
           .eq("code", inviteCode)
           .single()
 
-        if (error) {
-          throw error
-        }
-
+        if (error) throw error
         if (data.expires_at && new Date(data.expires_at) < new Date()) {
           throw new Error("This invitation code has expired.")
         }
-
         if (data.max_uses && data.usage_count >= data.max_uses) {
           throw new Error("This invitation code has reached its maximum number of uses.")
         }
@@ -70,12 +73,9 @@ export default function JoinPage() {
       }
     }
 
-    if (!inviteReady) {
-      return
-    }
-
+    if (!inviteReady) return
     void validateInviteCode()
-  }, [inviteCode, inviteReady, router])
+  }, [inviteCode, inviteReady, router, supabaseConfigured])
 
   const openOnboarding = () => {
     const nextParams = new URLSearchParams(window.location.search)
@@ -83,48 +83,60 @@ export default function JoinPage() {
     router.push(buildUrl(pathname, nextParams), { scroll: false })
   }
 
-  if (loading) {
-    return (
-      <div className="container mx-auto flex justify-center px-4 py-24">
-        <Card className="w-full max-w-md">
-          <CardHeader className="text-center">
-            <CardTitle>Validating invitation</CardTitle>
-            <CardDescription>Please wait while FundLoop validates your invitation code.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4 py-4">
-            <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <Skeleton className="h-10 w-full" />
-          </CardContent>
-        </Card>
-      </div>
-    )
-  }
-
   return (
-    <div className="container mx-auto flex justify-center px-4 py-24">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle>Join FundLoop</CardTitle>
-          <CardDescription>
-            {inviterName ? `You've been invited by ${inviterName} to join FundLoop.` : "You've been invited to join FundLoop."}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4 py-6 text-center">
-          <p>
-            FundLoop helps projects and people build regenerative economic loops. Your invitation code is preloaded, and
-            your onboarding draft will save as you go.
-          </p>
-          <p className="text-sm text-slate-600 dark:text-slate-300">
-            Invitation code: <span className="font-mono font-medium">{inviteCode}</span>
-          </p>
-        </CardContent>
-        <CardFooter>
-          <Button className="w-full bg-gradient-to-r from-emerald-600 to-cyan-600 hover:from-emerald-700 hover:to-cyan-700" onClick={openOnboarding}>
-            Continue onboarding
-          </Button>
-        </CardFooter>
-      </Card>
-    </div>
+    <MarketingPage>
+      <MarketingSection className="flex min-h-[calc(100svh-5.5rem)] items-center pb-20 pt-16">
+        <div className="mx-auto max-w-4xl">
+          {loading ? (
+            <Reveal>
+              <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/58 p-8 shadow-[0_24px_70px_rgba(15,23,23,0.08)] dark:bg-white/[0.03] sm:p-10">
+                <SectionEyebrow>Invitation</SectionEyebrow>
+                <SectionTitle className="mt-4 text-5xl sm:text-6xl">Validating your invitation.</SectionTitle>
+                <div className="mt-8 space-y-4">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-5 w-72" />
+                  <Skeleton className="h-12 w-full rounded-full" />
+                </div>
+              </div>
+            </Reveal>
+          ) : !supabaseConfigured ? (
+            <Reveal>
+              <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/58 p-8 shadow-[0_24px_70px_rgba(15,23,23,0.08)] dark:bg-white/[0.03] sm:p-10">
+                <SectionEyebrow>Invitation</SectionEyebrow>
+                <SectionTitle className="mt-4 text-5xl sm:text-6xl">Invitations need a configured backend.</SectionTitle>
+                <SectionBody className="mt-6 max-w-2xl">
+                  Configure Supabase environment variables to validate invitation codes and continue onboarding locally.
+                </SectionBody>
+              </div>
+            </Reveal>
+          ) : (
+            <Reveal>
+              <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 shadow-[0_24px_70px_rgba(15,23,23,0.08)] dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+                <SectionEyebrow>Invitation accepted</SectionEyebrow>
+                <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">Join FundLoop and pick up where the loop is forming.</SectionTitle>
+                <SectionBody className="mt-6 max-w-2xl">
+                  {inviterName
+                    ? `${inviterName} invited you into FundLoop.`
+                    : "You've been invited into FundLoop."} Your invitation code is preloaded, and your onboarding draft will save as you go.
+                </SectionBody>
+                <div className="mt-8 rounded-[1.5rem] border border-[color:var(--marketing-line)] bg-white/58 p-5 dark:bg-white/[0.04]">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                    Invitation code
+                  </p>
+                  <p className="mt-3 font-mono text-xl">{inviteCode}</p>
+                </div>
+                <Button
+                  size="lg"
+                  className="mt-8 rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+                  onClick={openOnboarding}
+                >
+                  Continue onboarding
+                </Button>
+              </div>
+            </Reveal>
+          )}
+        </div>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react"
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
+import { Fraunces, Manrope } from "next/font/google"
 import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import Navbar from "@/components/navbar"
@@ -9,7 +9,8 @@ import Footer from "@/components/footer"
 import { OnboardingModalManager } from "@/components/onboarding-modal-manager"
 import { Web3Provider } from "@/components/web3-provider"
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
+const manrope = Manrope({ subsets: ["latin"], variable: "--font-manrope" })
+const fraunces = Fraunces({ subsets: ["latin"], variable: "--font-fraunces" })
 
 export const metadata: Metadata = {
   title: "FundLoop - A Network State for Mutual Prosperity",
@@ -24,7 +25,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.className} ${inter.variable}`}>
+      <body className={`${manrope.className} ${manrope.variable} ${fraunces.variable}`}>
         <Web3Provider>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <Navbar />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -87,7 +87,7 @@ export default function Home() {
               FundLoop helps teams reward real contribution, grow with stronger proof-of-humanity signal, and route
               part of success back to the communities that make the whole system work.
             </SectionBody>
-            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+            <div id="project-signup" className="mt-10 flex scroll-mt-28 flex-col gap-4 sm:flex-row">
               <Button
                 asChild
                 size="lg"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,35 +1,337 @@
-import Hero from "@/components/hero"
-import Benefits from "@/components/benefits"
-import ProjectSignup from "@/components/project-signup"
-import UserSignup from "@/components/user-signup"
-import AlignedProjects from "@/components/aligned-projects"
-import AlignedUsers from "@/components/aligned-users"
-import Analytics from "@/components/analytics"
-import SupportWidget from "@/components/support-widget"
-import BlogPreview from "@/components/blog-preview"
-import NewsletterSignup from "@/components/newsletter-signup"
-import UseCasesSection from "@/components/use-cases-section"
+import Link from "next/link"
+import { ArrowRight, ExternalLink, HeartHandshake, ShieldCheck, Sparkles, Users } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { OpenUseCasesCta } from "@/components/marketing/open-use-cases-cta"
+import { Reveal } from "@/components/marketing/reveal"
+import { NetworkConstellation } from "@/components/marketing/network-constellation"
+import { ecosystemSites, resourceLinks } from "@/lib/public-site"
+import { useCases } from "@/lib/use-cases"
+
+const loopSteps = [
+  {
+    step: "01",
+    title: "Projects pledge part of the upside.",
+    body: "Teams route a small share of revenue, treasury, or distribution value back into the loop instead of treating community support as free extraction.",
+  },
+  {
+    step: "02",
+    title: "People create signal through real participation.",
+    body: "FundLoop tracks meaningful engagement, identity confidence, and project context so the network can see more than a single wallet snapshot.",
+  },
+  {
+    step: "03",
+    title: "Value returns with more context and less guesswork.",
+    body: "Payout, proof, and growth programs can be grounded in actual contribution rather than vanity metrics, bot noise, or flat one-size-fits-all rewards.",
+  },
+] as const
+
+type EntryPath =
+  | {
+      eyebrow: string
+      title: string
+      body: string
+      cta: string
+      ctaAction: "open-use-cases-menu"
+    }
+  | {
+      eyebrow: string
+      title: string
+      body: string
+      cta: string
+      href: string
+    }
+
+const entryPaths: EntryPath[] = [
+  {
+    eyebrow: "For founders and operators",
+    title: "Turn participation into a fair distribution engine.",
+    body: "Use FundLoop for fAirdrops, proof-of-humanity confidence, community incentives, and the kind of give-back mechanics that make your product feel aligned instead of extractive.",
+    cta: "See founder use cases",
+    ctaAction: "open-use-cases-menu",
+  },
+  {
+    eyebrow: "For people in the network",
+    title: "Join early, show up consistently, and get counted.",
+    body: "FundLoop is designed so people can create a profile, accumulate reputation through real usage, and eventually withdraw value from a system built to notice contribution.",
+    href: "/participation",
+    cta: "Read how participation works",
+  },
+] as const
+
+const iconMap = {
+  fairdrops: Sparkles,
+  "proof-of-humanity": ShieldCheck,
+  "community-engagement": Users,
+  "give-back": HeartHandshake,
+} as const
+
+const ecosystemPreviewNames = ["ChainCrew", "ClearPass", "Cubid", "SmarTrust", "TCOIN", "Solar Village"] as const
+
+const ecosystemPreviewSites = ecosystemPreviewNames
+  .map((name) => ecosystemSites.find((site) => site.name === name))
+  .filter((site): site is (typeof ecosystemSites)[number] => Boolean(site))
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900">
-      <Hero />
-      <Benefits id="benefits" />
-      <div className="container mx-auto px-4 py-12 md:py-24 grid gap-12 md:gap-24">
-        <div className="grid md:grid-cols-2 gap-8">
-          <ProjectSignup />
-          <UserSignup />
+    <MarketingPage>
+      <section className="relative min-h-[calc(100svh-5.5rem)]">
+        <div className="mx-auto grid min-h-[calc(100svh-5.5rem)] max-w-7xl items-end gap-12 px-6 pb-14 pt-10 sm:px-8 lg:grid-cols-[minmax(0,1.02fr)_minmax(22rem,0.98fr)] lg:px-12">
+          <Reveal className="max-w-3xl pb-4">
+            <SectionEyebrow>Mutual prosperity, made operational</SectionEyebrow>
+            <p className="mt-6 font-display text-[clamp(4rem,12vw,8.5rem)] leading-none tracking-[-0.07em]">FundLoop</p>
+            <h1 className="mt-6 max-w-2xl text-4xl font-semibold leading-[1.02] tracking-[-0.05em] sm:text-5xl lg:text-6xl">
+              A networked economy where projects feed the loop and people share in the upside.
+            </h1>
+            <SectionBody className="mt-6 max-w-xl">
+              FundLoop helps teams reward real contribution, grow with stronger proof-of-humanity signal, and route
+              part of success back to the communities that make the whole system work.
+            </SectionBody>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/?onboarding=project">
+                  Start a project profile
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 text-[var(--marketing-ink)] hover:bg-black/[0.04] dark:text-[var(--marketing-paper)] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/?onboarding=user">
+                  Join as a participant
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+            <div className="mt-10 grid gap-3 text-sm text-[var(--marketing-muted-strong)] sm:grid-cols-3">
+              <p className="border-t border-[color:var(--marketing-line)] pt-3">Projects pledge 1%+ into the loop.</p>
+              <p className="border-t border-[color:var(--marketing-line)] pt-3">People create signal through use.</p>
+              <p className="border-t border-[color:var(--marketing-line)] pt-3">Value returns with more context.</p>
+            </div>
+          </Reveal>
+
+          <Reveal delay={120} className="lg:pb-6">
+            <NetworkConstellation />
+          </Reveal>
         </div>
-        <div id="use-cases">
-          <UseCasesSection />
+      </section>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
+          <Reveal className="lg:sticky lg:top-28 lg:self-start">
+            <SectionEyebrow>How the loop works</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-xl text-5xl sm:text-6xl">A funding model built to compound alignment.</SectionTitle>
+            <SectionBody className="mt-5">
+              Each layer has one job: projects contribute, people participate, and FundLoop turns the resulting signal
+              into fairer flows of proof, payouts, and growth.
+            </SectionBody>
+          </Reveal>
+
+          <div className="space-y-10">
+            {loopSteps.map((item, index) => (
+              <Reveal key={item.step} delay={index * 90}>
+                <div className="grid gap-5 border-t border-[color:var(--marketing-line)] pt-6 sm:grid-cols-[5rem_minmax(0,1fr)]">
+                  <p className="font-display text-4xl leading-none text-[var(--marketing-accent)]">{item.step}</p>
+                  <div>
+                    <h2 className="text-2xl font-semibold tracking-[-0.04em] sm:text-3xl">{item.title}</h2>
+                    <p className="mt-3 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{item.body}</p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
         </div>
-        <AlignedProjects />
-        <AlignedUsers />
-        <Analytics />
-        <BlogPreview />
-        <SupportWidget />
-      </div>
-      <NewsletterSignup />
-    </div>
+      </MarketingSection>
+
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-2">
+          {entryPaths.map((path, index) => (
+            <Reveal key={path.title} delay={index * 120}>
+              <div className="flex h-full flex-col justify-between border-t border-[color:var(--marketing-line)] pt-6">
+                <div>
+                  <SectionEyebrow>{path.eyebrow}</SectionEyebrow>
+                  <h2 className="mt-4 max-w-lg font-display text-4xl leading-none tracking-[-0.04em] sm:text-5xl">
+                    {path.title}
+                  </h2>
+                  <p className="mt-5 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{path.body}</p>
+                </div>
+                {"ctaAction" in path ? (
+                  <OpenUseCasesCta className="group mt-10 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                    {path.cta}
+                    <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
+                  </OpenUseCasesCta>
+                ) : (
+                  <Link
+                    href={path.href}
+                    className="group mt-10 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]"
+                  >
+                    {path.cta}
+                    <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
+                  </Link>
+                )}
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </MarketingSection>
+
+      <MarketingSection id="use-cases" className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+          <Reveal className="lg:sticky lg:top-28 lg:self-start">
+            <SectionEyebrow>Use cases</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Five concrete ways to put FundLoop to work.</SectionTitle>
+            <SectionBody className="mt-5">
+              FundLoop is not a vague ecosystem story. It is a practical layer for better distributions, stronger
+              anti-bot confidence, more durable community incentives, and shared upside.
+            </SectionBody>
+          </Reveal>
+
+          <div className="space-y-5">
+            {useCases.map((useCase, index) => {
+              const Icon = iconMap[useCase.slug as keyof typeof iconMap] ?? Sparkles
+
+              return (
+                <Reveal key={useCase.slug} delay={index * 80}>
+                  <Link
+                    href={useCase.href}
+                    className="group block border-t border-[color:var(--marketing-line)] px-1 py-6 transition-colors hover:text-[var(--marketing-accent)]"
+                  >
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="max-w-2xl">
+                        <div className="flex items-center gap-3">
+                          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 dark:bg-white/[0.04]">
+                            <Icon className="h-4 w-4" />
+                          </span>
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                            {useCase.eyebrow}
+                          </p>
+                        </div>
+                        <h2 className="mt-4 font-display text-4xl leading-none tracking-[-0.04em]">{useCase.label}</h2>
+                        <p className="mt-4 text-base leading-7 text-[var(--marketing-muted-strong)]">{useCase.description}</p>
+                      </div>
+                      <span className="mt-1 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em]">
+                        Explore
+                        <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
+                      </span>
+                    </div>
+                  </Link>
+                </Reveal>
+              )
+            })}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection>
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.86fr)_minmax(0,1.14fr)]">
+          <Reveal>
+            <SectionEyebrow>Ecosystem preview</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">FundLoop grows stronger inside an aligned orbit.</SectionTitle>
+            <SectionBody className="mt-5">
+              Identity, coordination, local economies, voting, escrow, and regenerative finance are already taking
+              shape around the loop. FundLoop is designed to sit inside that network, not above it.
+            </SectionBody>
+            <Link
+              href="/ecosystem"
+              className="group mt-8 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]"
+            >
+              View the full ecosystem
+              <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
+            </Link>
+          </Reveal>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {ecosystemPreviewSites.map((site, index) => (
+              <Reveal key={site.url} delay={index * 70}>
+                <Link
+                  href={site.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex h-full flex-col justify-between rounded-[1.75rem] border border-[color:var(--marketing-line)] bg-white/58 p-5 transition-transform duration-200 hover:-translate-y-1 dark:bg-white/[0.03]"
+                >
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.18em]">{site.name}</p>
+                    <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{site.desc}</p>
+                  </div>
+                  <span className="mt-6 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                    Visit site
+                    <ExternalLink className="h-3.5 w-3.5 transition-transform duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                  </span>
+                </Link>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]">
+          <Reveal>
+            <SectionEyebrow>Resources</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Keep going.</SectionTitle>
+          </Reveal>
+          <div className="grid gap-5 sm:grid-cols-2">
+            {resourceLinks.map((resource, index) => (
+              <Reveal key={resource.href} delay={index * 70}>
+                <Link href={resource.href} className="group block border-t border-[color:var(--marketing-line)] pt-5">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em]">{resource.label}</p>
+                  <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{resource.description}</p>
+                  <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                    Open page
+                    <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-1" />
+                  </span>
+                </Link>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-20">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.86),rgba(244,203,141,0.26))] p-8 shadow-[0_30px_90px_rgba(15,23,23,0.08)] dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-12">
+            <SectionEyebrow>Start where you are</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">
+              FundLoop already saves onboarding drafts, supports project profiles, and is ready for the next wave of
+              aligned builders.
+            </SectionTitle>
+            <SectionBody className="mt-5">
+              If you are building a project, join the loop. If you are a participant, create your profile and be ready
+              when value starts moving through the network.
+            </SectionBody>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/?onboarding=project">
+                  Join as a project
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/?onboarding=user">
+                  Join as a participant
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/participation/page.tsx
+++ b/app/participation/page.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link"
+import { ArrowLeft, ArrowRight, ExternalLink } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+
+const participationBeats = [
+  {
+    step: "01",
+    title: "Start with one project, or better yet a few.",
+    body: "Join participating projects you genuinely care about. If you are already active in one, you have already started creating signal.",
+  },
+  {
+    step: "02",
+    title: "Show up in a real way.",
+    body: "FundLoop works best when participation looks like actual contribution, curiosity, support, and follow-through instead of click-farming or empty activity.",
+  },
+  {
+    step: "03",
+    title: "Come back and widen your orbit.",
+    body: "When you have time, return to FundLoop, discover another aligned project, and keep building a fuller picture of how you participate across the network.",
+  },
+  {
+    step: "04",
+    title: "Check your total reward each month.",
+    body: "FundLoop aggregates what the network has seen and turns it into a clearer monthly view of the value you have earned across participating projects.",
+  },
+] as const
+
+const controlPoints = [
+  {
+    label: "Humanity proof",
+    body: "The algorithm is designed to reward real humans. If you prove your humanity in one participating app, that can strengthen how the wider network understands your participation.",
+  },
+  {
+    label: "Privacy controls",
+    body: "You decide how much information to share with FundLoop and with each participating app. Stronger proof does not have to mean giving away more than you want to.",
+  },
+  {
+    label: "Payout preferences",
+    body: "Leave rewards in your FundLoop account, withdraw them when you want, and update your preferred currencies or tokens whenever your needs change.",
+  },
+] as const
+
+export default function ParticipationPage() {
+  return (
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pt-0">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.76fr)]">
+          <Reveal>
+            <SectionEyebrow>Participation</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">
+              Participate across real projects, then come back monthly to see what the network says it was worth.
+            </SectionTitle>
+            <SectionBody className="mt-6 max-w-2xl">
+              FundLoop is for people who join aligned projects, engage with them sincerely, and want rewards to reflect
+              real presence instead of shallow activity. You do not grind one app forever. You build a record of
+              participation across the loop.
+            </SectionBody>
+            <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/?onboarding=user">
+                  Join as a participant
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/projects">
+                  Browse participating projects
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          </Reveal>
+
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.8),rgba(244,203,141,0.24))] p-6 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.9),rgba(239,139,87,0.1))] sm:p-8">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Participation rhythm
+              </p>
+              <div className="mt-6 space-y-5">
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="font-display text-4xl leading-none tracking-[-0.04em]">Join</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Start with one project or several that feel genuinely relevant to you.
+                  </p>
+                </div>
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="font-display text-4xl leading-none tracking-[-0.04em]">Engage</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Participate in ways that create real context, not just noisy activity.
+                  </p>
+                </div>
+                <div className="border-t border-[color:var(--marketing-line)] pt-4">
+                  <p className="font-display text-4xl leading-none tracking-[-0.04em]">Return</p>
+                  <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    Come back monthly to review your total reward and decide what to do with it.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Reveal>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.74fr)_minmax(0,1.26fr)]">
+          <Reveal className="lg:sticky lg:top-28 lg:self-start">
+            <SectionEyebrow>How it works</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">A loop built around genuine participation.</SectionTitle>
+            <SectionBody className="mt-5">
+              The goal is simple: make it easier for people to move through an ecosystem of aligned projects and have
+              their contribution recognized with more nuance than one app could see on its own.
+            </SectionBody>
+          </Reveal>
+
+          <div className="space-y-10">
+            {participationBeats.map((beat, index) => (
+              <Reveal key={beat.step} delay={index * 80}>
+                <div className="grid gap-5 border-t border-[color:var(--marketing-line)] pt-6 sm:grid-cols-[5rem_minmax(0,1fr)]">
+                  <p className="font-display text-4xl leading-none text-[var(--marketing-accent)]">{beat.step}</p>
+                  <div>
+                    <h2 className="text-2xl font-semibold tracking-[-0.04em] sm:text-3xl">{beat.title}</h2>
+                    <p className="mt-3 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{beat.body}</p>
+                  </div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+          <Reveal>
+            <SectionEyebrow>Proof and privacy</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">FundLoop rewards humans, not just activity.</SectionTitle>
+            <SectionBody className="mt-5">
+              Humanity proof can come from participating apps you already use, and you can always strengthen it later.
+              The important thing is that you stay in control of what gets shared and where.
+            </SectionBody>
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className="mt-8 rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+            >
+              <Link href="https://passport.cubid.me" target="_blank" rel="noreferrer">
+                Manage your Cubid Passport
+                <ExternalLink className="h-4 w-4" />
+              </Link>
+            </Button>
+          </Reveal>
+
+          <div className="space-y-8">
+            {controlPoints.map((point, index) => (
+              <Reveal key={point.label} delay={index * 90}>
+                <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                  <p className="text-sm font-semibold uppercase tracking-[0.18em]">{point.label}</p>
+                  <p className="mt-3 max-w-2xl text-base leading-7 text-[var(--marketing-muted-strong)]">{point.body}</p>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-10">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>What you can do with rewards</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl">
+              Keep them in FundLoop, withdraw when it suits you, and change payout preferences whenever you want.
+            </SectionTitle>
+            <SectionBody className="mt-5 max-w-3xl">
+              Rewards are not meant to trap you. Leave them in your FundLoop account if that is convenient, withdraw on
+              your own timing, and update the currencies or tokens you prefer as your circumstances change.
+            </SectionBody>
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+              >
+                <Link href="/?onboarding=user">
+                  Create your profile
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
+              >
+                <Link href="/projects">Find another project</Link>
+              </Button>
+            </div>
+          </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
+  )
+}

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,145 +1,146 @@
 import Link from "next/link"
-import { ArrowLeft, ArrowRight, Coins, HeartHandshake, Users } from "lucide-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+
+const principles = [
+  {
+    title: "Users pay nothing to participate.",
+    body: "Profiles, exploration, and eventual eligibility should not come with a platform subscription.",
+  },
+  {
+    title: "Projects support the loop voluntarily.",
+    body: "FundLoop asks aligned projects to contribute when they can instead of gating entry behind SaaS pricing.",
+  },
+  {
+    title: "Payment rails carry their own execution costs.",
+    body: "Fiat processor fees and crypto gas costs come out of money movement, not out of a separate recurring platform charge.",
+  },
+] as const
+
+const fundingFlows = [
+  {
+    label: "1%+ to operators",
+    body: "Supports the people, infrastructure, and review flows required to operate FundLoop reliably.",
+  },
+  {
+    label: "1%+ to the treasury",
+    body: "Helps aligned new projects get far enough to eventually contribute back into the loop.",
+  },
+] as const
 
 export default function PricingPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-emerald-50/30 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
-      <div className="container mx-auto px-4 py-12 md:py-20">
-        <div className="mx-auto max-w-5xl">
-          <div className="mb-8">
-            <Button asChild variant="ghost" size="sm" className="gap-2">
-              <Link href="/">
-                <ArrowLeft className="h-4 w-4" />
-                Back to Home
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pt-0">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
+          <Reveal>
+            <SectionEyebrow>Pricing</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">
+              Free for people. Supported by aligned projects. Honest about transfer costs.
+            </SectionTitle>
+            <SectionBody className="mt-6 max-w-2xl">
+              FundLoop is the place people come to receive value, not another product that charges them for access. The
+              model is designed to keep participation open while letting projects support the system in a principled way.
+            </SectionBody>
+          </Reveal>
+
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/52 p-6 dark:bg-white/[0.03]">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Core rule
+              </p>
+              <p className="mt-4 font-display text-4xl leading-none tracking-[-0.04em]">Users should never have to pay just to be in the loop.</p>
+            </div>
+          </Reveal>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-10 lg:grid-cols-3">
+          {principles.map((item, index) => (
+            <Reveal key={item.title} delay={index * 90}>
+              <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em]">{item.title}</p>
+                <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{item.body}</p>
+              </div>
+            </Reveal>
+          ))}
+        </div>
+      </MarketingSection>
+
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+          <Reveal>
+            <SectionEyebrow>How project support works</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Voluntary support keeps the platform sustainable without turning it into a paywall.</SectionTitle>
+            <SectionBody className="mt-5">
+              FundLoop recommends a simple split for teams that want to help keep the loop healthy today while also
+              helping new aligned projects survive long enough to join it.
+            </SectionBody>
+          </Reveal>
+
+          <div className="space-y-8">
+            {fundingFlows.map((flow, index) => (
+              <Reveal key={flow.label} delay={index * 90}>
+                <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                  <p className="font-display text-4xl leading-none tracking-[-0.04em]">{flow.label}</p>
+                  <p className="mt-4 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{flow.body}</p>
+                </div>
+              </Reveal>
+            ))}
+
+            <Reveal delay={180}>
+              <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em]">Transfer fees</p>
+                <p className="mt-3 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">
+                  When money actually moves, there are direct network costs. Payment processor fees apply to fiat rails
+                  and gas fees apply to crypto rails. Those costs come out of the transferred funds themselves.
+                </p>
+              </div>
+            </Reveal>
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-10">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>Join the loop</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">If your team wants to support shared prosperity, start with a project profile.</SectionTitle>
+            <SectionBody className="mt-5">
+              FundLoop already supports resumable onboarding drafts, so you can begin now and finish when your team is
+              ready.
+            </SectionBody>
+            <Button
+              asChild
+              size="lg"
+              className="mt-8 rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+            >
+              <Link href="/?onboarding=project">
+                Join as a project
+                <ArrowRight className="h-4 w-4" />
               </Link>
             </Button>
           </div>
-
-          <section className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950/80 md:p-12">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-emerald-600">Pricing</p>
-            <h1 className="mt-4 text-4xl font-bold tracking-tight text-slate-900 dark:text-white md:text-5xl">
-              FundLoop is free to use forever for users.
-            </h1>
-            <p className="mt-5 max-w-3xl text-lg leading-8 text-slate-600 dark:text-slate-300">
-              This is the platform you come to to get money, not pay money. If you are a user participating in the
-              ecosystem, creating a profile, exploring projects, and becoming eligible for distributions should never
-              come with a FundLoop platform fee.
-            </p>
-          </section>
-
-          <section className="mt-8 grid gap-6 lg:grid-cols-3">
-            <Card className="border-slate-200/80 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
-              <CardHeader>
-                <div className="mb-3 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
-                  <Users className="h-5 w-5" />
-                </div>
-                <CardTitle>For Users</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  Free forever. FundLoop is designed so users can receive value, not be charged for access to the
-                  network.
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card className="border-slate-200/80 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
-              <CardHeader>
-                <div className="mb-3 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
-                  <HeartHandshake className="h-5 w-5" />
-                </div>
-                <CardTitle>For Projects</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  FundLoop is funded on a voluntary basis. We ask projects to support the system when they are able,
-                  rather than gating participation behind mandatory SaaS pricing.
-                </p>
-              </CardContent>
-            </Card>
-
-            <Card className="border-slate-200/80 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
-              <CardHeader>
-                <div className="mb-3 inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
-                  <Coins className="h-5 w-5" />
-                </div>
-                <CardTitle>Transfer Costs</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  Payment processor fees for fiat and gas fees for crypto are real network costs and come out of the
-                  funds transferred out from the platform.
-                </p>
-              </CardContent>
-            </Card>
-          </section>
-
-          <section className="mt-8 rounded-[2rem] border border-slate-200/80 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950/80 md:p-10">
-            <div className="max-w-4xl">
-              <h2 className="text-2xl font-bold text-slate-900 dark:text-white md:text-3xl">How project funding works</h2>
-              <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-                FundLoop is funded on a voluntary basis. We recommend that projects allow us to divert 1% or more of
-                their distributed funds to the community of people who work to operate FundLoop, and another 1% or more
-                to the treasury used to fund promising new projects that have taken the 1% pledge but have not yet
-                become profitable.
-              </p>
-              <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-                That structure is meant to keep the platform sustainable without turning FundLoop into a paywall. It
-                supports the operators keeping the system alive today while also helping new aligned projects get far
-                enough to contribute back into the loop.
-              </p>
-            </div>
-
-            <div className="mt-8 grid gap-4 md:grid-cols-2">
-              <div className="rounded-2xl bg-slate-50 p-5 dark:bg-slate-900">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">1%+ to operators</p>
-                <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  Supports the people and workflows required to operate FundLoop, maintain infrastructure, and help the
-                  ecosystem function reliably.
-                </p>
-              </div>
-              <div className="rounded-2xl bg-slate-50 p-5 dark:bg-slate-900">
-                <p className="text-sm font-semibold text-slate-900 dark:text-white">1%+ to the treasury</p>
-                <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  Funds promising new projects that have already taken the pledge but have not yet reached profitability,
-                  helping the network grow in a principled way.
-                </p>
-              </div>
-            </div>
-          </section>
-
-          <section className="mt-8 rounded-[2rem] border border-amber-200 bg-amber-50/70 p-8 shadow-sm dark:border-amber-900/60 dark:bg-amber-950/20 md:p-10">
-            <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Fees on money movement</h2>
-            <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-              Towards the point where money actually moves, there are unavoidable transaction costs. Payment processor
-              fees apply when moving fiat money, and gas fees apply when moving crypto. Those costs come out of the
-              funds transferred out from our platform rather than being charged as a separate subscription.
-            </p>
-            <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-              We want the pricing model to stay easy to understand: users do not pay to participate, projects are asked
-              to support the ecosystem voluntarily, and transfer rails carry their own direct execution costs.
-            </p>
-          </section>
-
-          <section className="mt-8 flex flex-col gap-4 rounded-[2rem] border border-emerald-200 bg-emerald-50 px-6 py-8 dark:border-emerald-900/60 dark:bg-emerald-950/20 md:flex-row md:items-center md:justify-between">
-            <div className="max-w-2xl">
-              <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Want to join as a project?</h2>
-              <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-                If your team wants to participate in the loop and support shared prosperity, start with a project
-                profile.
-              </p>
-            </div>
-            <Button asChild className="bg-emerald-600 text-white hover:bg-emerald-700">
-              <Link href="/#project-signup">
-                Join as a Project
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-          </section>
-        </div>
-      </div>
-    </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -4,18 +4,58 @@ import type React from "react"
 
 import { useState } from "react"
 import Link from "next/link"
+import { ArrowLeft, Mail, MessageSquare, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
-import { ArrowLeft, Mail, MessageSquare, User } from "lucide-react"
-import { getSupabaseBrowserClient } from "@/lib/supabase"
-import type { Database } from "@/types/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
+
+const helpPaths = [
+  {
+    title: "Participation",
+    body: "Use this when you want the clearest walkthrough of how people join projects, build signal, and receive rewards.",
+    href: "/participation",
+  },
+  {
+    title: "FAQ",
+    body: "Use this when you want the shortest answer to common questions about pricing, bots, or participation.",
+    href: "/faq",
+  },
+  {
+    title: "Documentation",
+    body: "Use this when you need walkthroughs, setup details, or support articles tied to product workflows.",
+    href: "/documentation",
+  },
+] as const
+
+const supportChannels = [
+  {
+    icon: User,
+    title: "Founder call",
+    body: "Coming soon for teams that need higher-touch guidance.",
+  },
+  {
+    icon: Mail,
+    title: "Email support",
+    body: "Reach us at support@fundloop.org for account, onboarding, or payment questions.",
+    href: "mailto:support@fundloop.org?subject=Support%20Request&body=Please%20describe%20your%20issue%20here.",
+  },
+  {
+    icon: MessageSquare,
+    title: "Live chat",
+    body: "Planned for future support hours once the public flows are live at a larger scale.",
+  },
+] as const
+
+type SupportChannel = (typeof supportChannels)[number]
 
 export default function SupportPage() {
+  const supabaseConfigured = isSupabaseConfigured()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [formData, setFormData] = useState({
     name: "",
@@ -25,28 +65,31 @@ export default function SupportPage() {
     message: "",
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
+
   const getSupabase = () => getSupabaseBrowserClient()
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { id, value } = e.target
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { id, value } = event.target
     setFormData((prev) => ({ ...prev, [id]: value }))
     setErrors((prev) => {
-      const newErr = { ...prev }
+      const nextErrors = { ...prev }
+
       switch (id) {
         case "name":
-          if (value.trim()) delete newErr.name
+          if (value.trim()) delete nextErrors.name
           break
         case "email":
-          if (/^\S+@\S+\.\S+$/.test(value)) delete newErr.email
+          if (/^\S+@\S+\.\S+$/.test(value)) delete nextErrors.email
           break
         case "subject":
-          if (value.trim()) delete newErr.subject
+          if (value.trim()) delete nextErrors.subject
           break
         case "message":
-          if (value.trim()) delete newErr.message
+          if (value.trim()) delete nextErrors.message
           break
       }
-      return newErr
+
+      return nextErrors
     })
   }
 
@@ -59,36 +102,53 @@ export default function SupportPage() {
     })
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const supabase = getSupabase()
-    const newErrors: Record<string, string> = {}
-    if (!formData.name.trim()) newErrors.name = "Name is required"
-    if (!formData.email.trim()) {
-      newErrors.email = "Email is required"
-    } else if (!/^\S+@\S+\.\S+$/.test(formData.email)) {
-      newErrors.email = "Invalid email address"
-    }
-    if (!formData.subject.trim()) newErrors.subject = "Subject is required"
-    if (!formData.category) newErrors.category = "Category is required"
-    if (!formData.message.trim()) newErrors.message = "Message is required"
-    if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors)
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    if (!supabaseConfigured) {
+      toast({
+        title: "Support is unavailable locally",
+        description: "Configure Supabase environment variables to submit support requests from this checkout.",
+        variant: "destructive",
+      })
       return
     }
+
+    const supabase = getSupabase()
+    const nextErrors: Record<string, string> = {}
+
+    if (!formData.name.trim()) nextErrors.name = "Name is required"
+    if (!formData.email.trim()) {
+      nextErrors.email = "Email is required"
+    } else if (!/^\S+@\S+\.\S+$/.test(formData.email)) {
+      nextErrors.email = "Invalid email address"
+    }
+    if (!formData.subject.trim()) nextErrors.subject = "Subject is required"
+    if (!formData.category) nextErrors.category = "Category is required"
+    if (!formData.message.trim()) nextErrors.message = "Message is required"
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
+      return
+    }
+
     setErrors({})
     setIsSubmitting(true)
+
     let ip = ""
+
     try {
-      const res = await fetch("https://api.ipify.org?format=json")
-      const data = await res.json()
+      const response = await fetch("https://api.ipify.org?format=json")
+      const data = await response.json()
       ip = data.ip
-    } catch (err) {
-      console.error("Failed to get IP", err)
+    } catch (error) {
+      console.error("Failed to get IP", error)
     }
+
     const {
       data: { user },
     } = await supabase.auth.getUser()
+
     const { error } = await supabase.from("support_requests").insert([
       {
         name: formData.name,
@@ -100,11 +160,14 @@ export default function SupportPage() {
         user_id: user?.id ?? null,
       },
     ])
+
     setIsSubmitting(false)
+
     if (error) {
       toast({ title: "Submission failed", description: error.message })
       return
     }
+
     toast({
       title: "Support request submitted",
       description: "We'll get back to you as soon as possible.",
@@ -113,208 +176,176 @@ export default function SupportPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="flex items-center gap-2 mb-8">
-        <Button asChild variant="ghost" size="sm" className="gap-1">
-          <Link href="/">
-            <ArrowLeft className="h-4 w-4" />
-            <span>Back to Home</span>
-          </Link>
-        </Button>
-      </div>
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/">
+              <ArrowLeft className="h-4 w-4" />
+              Back to home
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
 
-      <div className="max-w-5xl mx-auto">
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">Start Here</h1>
-        <p className="text-slate-600 dark:text-slate-300 text-lg mb-8">
-          Need help with FundLoop? Our support team is here to assist you.
-        </p>
+      <MarketingSection className="pt-0">
+        <Reveal>
+          <SectionEyebrow>Support</SectionEyebrow>
+          <SectionTitle className="mt-4 max-w-5xl text-5xl sm:text-6xl lg:text-7xl">
+            Start with the fastest path, then reach out if you still need a human.
+          </SectionTitle>
+          <SectionBody className="mt-6 max-w-3xl">
+            FundLoop support works best when we can route you quickly: FAQ for short answers, documentation for product
+            details, and the contact form when you are blocked by a real account or onboarding issue.
+          </SectionBody>
+        </Reveal>
+      </MarketingSection>
 
-        <div className="grid md:grid-cols-2 gap-8 mb-12">
-          <div className="text-center">
-            <h2 className="text-2xl font-bold mb-4">Frequently Asked Questions</h2>
-            <p className="text-slate-600 dark:text-slate-300 mb-6">
-              Find quick answers to common questions before contacting support.
-            </p>
-            <Button asChild variant="outline">
-              <Link href="/faq">View FAQ</Link>
-            </Button>
-          </div>
-          <div className="text-center">
-            <h2 className="text-2xl font-bold mb-4">Read Our Docs</h2>
-            <p className="text-slate-600 dark:text-slate-300 mb-6">
-              Explore our documentation for detailed guides and answers.
-            </p>
-            <Button asChild variant="outline">
-              <Link href="/documentation">View Documentation</Link>
-            </Button>
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]">
+          <Reveal>
+            <SectionEyebrow>Quick routes</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Usually, one of these gets you unstuck fastest.</SectionTitle>
+          </Reveal>
+          <div className="grid gap-6 sm:grid-cols-2">
+            {helpPaths.map((path, index) => (
+              <Reveal key={path.href} delay={index * 90}>
+                <Link href={path.href} className="group block border-t border-[color:var(--marketing-line)] pt-5">
+                  <p className="font-display text-3xl leading-none tracking-[-0.04em]">{path.title}</p>
+                  <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{path.body}</p>
+                  <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                    Open page
+                    <ArrowLeft className="h-3.5 w-3.5 rotate-180 transition-transform duration-200 group-hover:translate-x-1" />
+                  </span>
+                </Link>
+              </Reveal>
+            ))}
           </div>
         </div>
+      </MarketingSection>
 
-        <h1 className="text-3xl md:text-4xl font-bold mb-4">Still Need Support?</h1>
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+          <Reveal className="space-y-6">
+            <div>
+              <SectionEyebrow>Channels</SectionEyebrow>
+              <SectionTitle className="mt-4 text-5xl sm:text-6xl">Ways to get help.</SectionTitle>
+            </div>
+            {supportChannels.map((channel: SupportChannel, index) => {
+              const Icon = channel.icon
+              const channelHref = "href" in channel ? channel.href : undefined
 
-        <div className="grid md:grid-cols-3 gap-8 mb-12">
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <User className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>Chat With Our Founder</CardTitle>
-              <CardDescription>Schedule a quick call</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-slate-600 dark:text-slate-300 mb-4">Coming Soon</p>
-            </CardContent>
-          </Card>
+              return (
+                <Reveal key={channel.title} delay={index * 70}>
+                  <div className="border-t border-[color:var(--marketing-line)] pt-5">
+                    <div className="flex items-center gap-3">
+                      <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 dark:bg-white/[0.04]">
+                        <Icon className="h-4 w-4" />
+                      </span>
+                      <p className="text-sm font-semibold uppercase tracking-[0.18em]">{channel.title}</p>
+                    </div>
+                    {channelHref ? (
+                      <Link
+                        href={channelHref}
+                        className="mt-4 inline-flex text-sm font-semibold text-[var(--marketing-accent)] underline-offset-4 hover:underline"
+                      >
+                        support@fundloop.org
+                      </Link>
+                    ) : null}
+                    <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">{channel.body}</p>
+                  </div>
+                </Reveal>
+              )
+            })}
+          </Reveal>
 
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <Mail className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>Email Support</CardTitle>
-              <CardDescription>Get help via email</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <a
-                href="mailto:support@fundloop.org?subject=Support%20Request&body=Please%20describe%20your%20issue%20here."
-                className="text-emerald-600 dark:text-emerald-400 font-medium"
-              >
-                support@fundloop.org
-              </a>
-            </CardContent>
-          </Card>
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/58 p-6 shadow-[0_24px_70px_rgba(15,23,23,0.08)] dark:bg-white/[0.03] sm:p-8">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Contact form
+              </p>
+              <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Name</Label>
+                    <Input id="name" value={formData.name} onChange={handleInputChange} placeholder="Your name" required />
+                    {errors.name ? <p className="text-sm text-red-500">{errors.name}</p> : null}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={handleInputChange}
+                      placeholder="you@example.com"
+                      required
+                    />
+                    {errors.email ? <p className="text-sm text-red-500">{errors.email}</p> : null}
+                  </div>
+                </div>
 
-          <Card>
-            <CardHeader className="text-center">
-              <div className="mx-auto bg-emerald-100 dark:bg-emerald-900/30 p-3 rounded-full mb-4 w-12 h-12 flex items-center justify-center">
-                <MessageSquare className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>Live Chat (coming soon)</CardTitle>
-              <CardDescription>Chat with our support team</CardDescription>
-            </CardHeader>
-            <CardContent className="text-center">
-              <p className="text-slate-600 dark:text-slate-300 mb-4">Available Monday to Friday, 9am to 5pm UTC.</p>
-              <Button variant="outline" className="gap-1" disabled>
-                <MessageSquare className="h-4 w-4" />
-                Start Chat
-              </Button>
-            </CardContent>
-          </Card>
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="subject">Subject</Label>
+                    <Input
+                      id="subject"
+                      value={formData.subject}
+                      onChange={handleInputChange}
+                      placeholder="What do you need help with?"
+                      required
+                    />
+                    {errors.subject ? <p className="text-sm text-red-500">{errors.subject}</p> : null}
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="category">Category</Label>
+                    <Select value={formData.category} onValueChange={handleSelectChange}>
+                      <SelectTrigger id="category">
+                        <SelectValue placeholder="Select category" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="general">General inquiry</SelectItem>
+                        <SelectItem value="technical">Technical support</SelectItem>
+                        <SelectItem value="billing">Billing and payments</SelectItem>
+                        <SelectItem value="account">Account issues</SelectItem>
+                        <SelectItem value="feature">Feature request</SelectItem>
+                        <SelectItem value="other">Other</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {errors.category ? <p className="text-sm text-red-500">{errors.category}</p> : null}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="message">Message</Label>
+                  <Textarea
+                    id="message"
+                    value={formData.message}
+                    onChange={handleInputChange}
+                    placeholder="Please describe your issue or question in detail."
+                    className="min-h-[170px]"
+                    required
+                  />
+                  {errors.message ? <p className="text-sm text-red-500">{errors.message}</p> : null}
+                </div>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  className="w-full rounded-full bg-[var(--marketing-accent)] text-white hover:bg-[color:var(--marketing-accent)]/92"
+                  disabled={isSubmitting || !supabaseConfigured}
+                >
+                  {!supabaseConfigured ? "Support unavailable locally" : isSubmitting ? "Submitting..." : "Submit request"}
+                </Button>
+              </form>
+            </div>
+          </Reveal>
         </div>
-
-        <Card className="mb-12">
-          <CardHeader>
-            <CardTitle>Contact Form</CardTitle>
-            <CardDescription>Fill out the form below and we'll get back to you as soon as possible.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="name">Name</Label>
-                  <Input
-                    id="name"
-                    placeholder="Your name"
-                    value={formData.name}
-                    onChange={handleInputChange}
-                    required
-                  />
-                  {errors.name && (
-                    <p className="text-sm text-red-500">{errors.name}</p>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    placeholder="Your email"
-                    value={formData.email}
-                    onChange={handleInputChange}
-                    required
-                  />
-                  {errors.email && (
-                    <p className="text-sm text-red-500">{errors.email}</p>
-                  )}
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="subject">Subject</Label>
-                  <Input
-                    id="subject"
-                    placeholder="Subject of your inquiry"
-                    value={formData.subject}
-                    onChange={handleInputChange}
-                    required
-                    aria-invalid={!!errors.subject}
-                    aria-describedby="subject-error"
-                  />
-                  {errors.subject && (
-                    <p id="subject-error" className="text-sm text-red-500">
-                      {errors.subject}
-                    </p>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="category">Category</Label>
-                  <Select value={formData.category} onValueChange={handleSelectChange}>
-                    <SelectTrigger id="category">
-                      <SelectValue placeholder="Select category" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="general">General Inquiry</SelectItem>
-                      <SelectItem value="technical">Technical Support</SelectItem>
-                      <SelectItem value="billing">Billing & Payments</SelectItem>
-                      <SelectItem value="account">Account Issues</SelectItem>
-                      <SelectItem value="feature">Feature Request</SelectItem>
-                      <SelectItem value="other">Other</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  {errors.category && (
-                    <p id="category-error" className="text-sm text-red-500">
-                      {errors.category}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="message">Message</Label>
-                <Textarea
-                  id="message"
-                  placeholder="Please describe your issue or question in detail"
-                  className="min-h-[150px]"
-                  value={formData.message}
-                  onChange={handleInputChange}
-                  required
-                  aria-invalid={!!errors.message}
-                  aria-describedby="message-error"
-                />
-                {errors.message && (
-                  <p id="message-error" className="text-sm text-red-500">
-                    {errors.message}
-                  </p>
-                )}
-              </div>
-            </form>
-          </CardContent>
-          <CardFooter>
-            <Button
-              type="submit"
-              className="w-full bg-gradient-to-r from-emerald-600 to-cyan-600 hover:from-emerald-700 hover:to-cyan-700"
-              onClick={handleSubmit}
-              disabled={isSubmitting}
-            >
-              {isSubmitting ? "Submitting..." : "Submit"}
-            </Button>
-          </CardFooter>
-        </Card>
-
-      </div>
-    </div>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/app/use-cases/[slug]/page.tsx
+++ b/app/use-cases/[slug]/page.tsx
@@ -2,7 +2,8 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { ArrowLeft, ArrowRight, Building2, HeartHandshake, ShieldCheck, Sparkles, Users } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
+import { Reveal } from "@/components/marketing/reveal"
 import { getUseCaseBySlug, useCases } from "@/lib/use-cases"
 
 const iconMap = {
@@ -26,88 +27,132 @@ export default async function UseCasePage({ params }: { params: Promise<{ slug: 
   }
 
   const Icon = iconMap[useCase.slug]
+  const relatedCases = useCases.filter((entry) => entry.slug !== useCase.slug).slice(0, 3)
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-emerald-50/40 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
-      <div className="container mx-auto px-4 py-12 md:py-20">
-        <div className="mx-auto max-w-5xl">
-          <div className="mb-8">
-            <Button asChild variant="ghost" size="sm" className="gap-2">
-              <Link href="/#use-cases">
-                <ArrowLeft className="h-4 w-4" />
-                Back to Use Cases
+    <MarketingPage>
+      <MarketingSection className="pb-10 pt-10">
+        <Reveal>
+          <Button
+            asChild
+            variant="ghost"
+            className="rounded-full px-0 text-[var(--marketing-muted-strong)] hover:bg-transparent hover:text-[var(--marketing-accent)]"
+          >
+            <Link href="/#use-cases">
+              <ArrowLeft className="h-4 w-4" />
+              Back to use cases
+            </Link>
+          </Button>
+        </Reveal>
+      </MarketingSection>
+
+      <MarketingSection className="pt-0">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.72fr)]">
+          <Reveal>
+            <div className="flex items-center gap-3">
+              <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 dark:bg-white/[0.04]">
+                <Icon className="h-4 w-4" />
+              </span>
+              <SectionEyebrow>{useCase.eyebrow}</SectionEyebrow>
+            </div>
+            <SectionTitle className="mt-6 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">{useCase.label}</SectionTitle>
+            <SectionBody className="mt-6 max-w-2xl">{useCase.hero}</SectionBody>
+          </Reveal>
+
+          <Reveal delay={120}>
+            <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-white/52 p-6 dark:bg-white/[0.03]">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                What this unlocks
+              </p>
+              <ul className="mt-6 space-y-4">
+                {useCase.outcomes.map((outcome) => (
+                  <li key={outcome} className="border-t border-[color:var(--marketing-line)] pt-4 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+                    {outcome}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Reveal>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+          <Reveal>
+            <SectionEyebrow>How it works</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Operational detail, not vague promise.</SectionTitle>
+          </Reveal>
+          <div className="space-y-8">
+            {useCase.body.map((paragraph, index) => (
+              <Reveal key={paragraph} delay={index * 70}>
+                <p className="border-t border-[color:var(--marketing-line)] pt-5 text-base leading-7 text-[var(--marketing-muted-strong)]">
+                  {paragraph}
+                </p>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection>
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
+          <Reveal>
+            <SectionEyebrow>Why teams use it</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">What makes this useful in practice.</SectionTitle>
+          </Reveal>
+          <div className="space-y-5">
+            {useCase.reasons.map((reason, index) => (
+              <Reveal key={reason} delay={index * 70}>
+                <p className="border-t border-[color:var(--marketing-line)] pt-5 text-base leading-7 text-[var(--marketing-muted-strong)]">
+                  {reason}
+                </p>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]">
+          <Reveal>
+            <SectionEyebrow>Related use cases</SectionEyebrow>
+            <SectionTitle className="mt-4 text-5xl sm:text-6xl">Keep exploring the loop.</SectionTitle>
+          </Reveal>
+          <div className="space-y-4">
+            {relatedCases.map((entry, index) => (
+              <Reveal key={entry.slug} delay={index * 60}>
+                <Link href={entry.href} className="group block border-t border-[color:var(--marketing-line)] py-5">
+                  <p className="font-display text-3xl leading-none tracking-[-0.04em]">{entry.label}</p>
+                  <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--marketing-muted-strong)]">{entry.description}</p>
+                  <span className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
+                    Read more
+                    <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-1" />
+                  </span>
+                </Link>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="pb-24 pt-14">
+        <Reveal>
+          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
+            <SectionEyebrow>Ready to apply it?</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-3xl text-5xl sm:text-6xl">Create a project profile and connect the right onboarding, identity, and payout workflows.</SectionTitle>
+            <Button
+              asChild
+              size="lg"
+              className="mt-8 rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
+            >
+              <Link href="/?onboarding=project">
+                Start a project profile
+                <ArrowRight className="h-4 w-4" />
               </Link>
             </Button>
           </div>
-
-          <section className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-8 shadow-sm dark:border-slate-800 dark:bg-slate-950/80 md:p-12">
-            <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
-              <div>
-                <div className="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:bg-emerald-950/60 dark:text-emerald-300">
-                  <Icon className="h-3.5 w-3.5" />
-                  {useCase.eyebrow}
-                </div>
-                <h1 className="mt-5 text-4xl font-bold tracking-tight text-slate-900 dark:text-white md:text-5xl">
-                  {useCase.label}
-                </h1>
-                <p className="mt-5 text-lg leading-8 text-slate-600 dark:text-slate-300">{useCase.hero}</p>
-              </div>
-
-              <Card className="border-slate-200/80 bg-slate-50 shadow-none dark:border-slate-800 dark:bg-slate-900">
-                <CardContent className="p-6">
-                  <p className="text-sm font-semibold text-slate-900 dark:text-white">What this unlocks</p>
-                  <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-600 dark:text-slate-300">
-                    {useCase.outcomes.map((outcome) => (
-                      <li key={outcome}>{outcome}</li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-            </div>
-          </section>
-
-          <section className="mt-8 grid gap-6 lg:grid-cols-2">
-            <Card className="border-slate-200/80 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
-              <CardContent className="p-8">
-                <h2 className="text-2xl font-bold text-slate-900 dark:text-white">How it works</h2>
-                <div className="mt-4 space-y-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-                  {useCase.body.map((paragraph) => (
-                    <p key={paragraph}>{paragraph}</p>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
-            <Card className="border-slate-200/80 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-950/80">
-              <CardContent className="p-8">
-                <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Why teams use it</h2>
-                <ul className="mt-4 space-y-4 text-base leading-7 text-slate-600 dark:text-slate-300">
-                  {useCase.reasons.map((reason) => (
-                    <li key={reason}>{reason}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          </section>
-
-          <section className="mt-8 rounded-[2rem] border border-emerald-200 bg-emerald-50 px-6 py-8 dark:border-emerald-900/60 dark:bg-emerald-950/20 md:px-8">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div className="max-w-2xl">
-                <h2 className="text-2xl font-bold text-slate-900 dark:text-white">Ready to apply this in your project?</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
-                  Create a project profile and we can connect the right onboarding, identity, and payout workflows.
-                </p>
-              </div>
-              <Button asChild className="bg-emerald-600 text-white hover:bg-emerald-700">
-                <Link href="/#project-signup">
-                  Join as a Project
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
+        </Reveal>
+      </MarketingSection>
+    </MarketingPage>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,45 +1,60 @@
-import React from 'react'
 import Link from "next/link"
-import { CircleDollarSign, FolderGit2, Globe, BriefcaseBusiness, Mail } from "lucide-react"
+import { ArrowRight, CircleDollarSign, FolderGit2, Globe, BriefcaseBusiness, Mail } from "lucide-react"
+import { publicExploreLinks, resourceLinks } from "@/lib/public-site"
 
 export default function Footer() {
   return (
-    <footer className="border-t bg-slate-50 dark:bg-slate-950">
-      <div className="container px-4 py-10 sm:px-6 md:py-12">
-        <div className="grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-12 lg:gap-x-8">
-          <div className="col-span-2 md:col-span-5 lg:col-span-4">
-            <Link href="/" className="flex items-center gap-2 mb-4">
-              <CircleDollarSign className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
-              <span className="text-lg font-bold">FundLoop</span>
+    <footer className="border-t border-[color:var(--marketing-line)] bg-[var(--marketing-paper)] text-[var(--marketing-ink)] dark:bg-[var(--marketing-ink)] dark:text-[var(--marketing-paper)]">
+      <div className="mx-auto max-w-7xl px-6 py-14 sm:px-8 lg:px-12">
+        <div className="grid gap-12 border-b border-[color:var(--marketing-line)] pb-12 lg:grid-cols-[minmax(0,1.2fr)_repeat(3,minmax(0,0.7fr))]">
+          <div className="max-w-md">
+            <Link href="/" className="flex items-center gap-3">
+              <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-[rgba(204,92,44,0.14)] text-[var(--marketing-accent)]">
+                <CircleDollarSign className="h-5 w-5" />
+              </span>
+              <div>
+                <p className="font-display text-3xl leading-none tracking-[-0.04em]">FundLoop</p>
+                <p className="mt-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-[var(--marketing-muted)]">
+                  Build the loop
+                </p>
+              </div>
             </Link>
-            <p className="mb-4 max-w-xs text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
-              A network state for mutual prosperity, connecting projects and users in a sustainable economic ecosystem.
+            <p className="mt-6 text-sm leading-7 text-[var(--marketing-muted-strong)]">
+              FundLoop connects projects, people, and proof into a shared economic loop where real participation can
+              compound into real upside.
             </p>
-            <div className="flex gap-4">
+            <Link
+              href="/?onboarding=project"
+              className="mt-6 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]"
+            >
+              Start a project profile
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <div className="mt-8 flex gap-4">
               <Link
                 href="https://twitter.com"
-                className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+                className="text-[var(--marketing-muted)] transition-colors hover:text-[var(--marketing-accent)]"
               >
                 <Globe className="h-4 w-4 sm:h-5 sm:w-5" />
                 <span className="sr-only">Twitter</span>
               </Link>
               <Link
                 href="https://github.com"
-                className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+                className="text-[var(--marketing-muted)] transition-colors hover:text-[var(--marketing-accent)]"
               >
                 <FolderGit2 className="h-4 w-4 sm:h-5 sm:w-5" />
                 <span className="sr-only">GitHub</span>
               </Link>
               <Link
                 href="https://linkedin.com"
-                className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+                className="text-[var(--marketing-muted)] transition-colors hover:text-[var(--marketing-accent)]"
               >
                 <BriefcaseBusiness className="h-4 w-4 sm:h-5 sm:w-5" />
                 <span className="sr-only">LinkedIn</span>
               </Link>
               <Link
                 href="mailto:info@fundloop.org"
-                className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
+                className="text-[var(--marketing-muted)] transition-colors hover:text-[var(--marketing-accent)]"
               >
                 <Mail className="h-4 w-4 sm:h-5 sm:w-5" />
                 <span className="sr-only">Email</span>
@@ -47,165 +62,81 @@ export default function Footer() {
             </div>
           </div>
 
-          <div className="md:col-span-2">
-            <h3 className="mb-3 text-sm font-semibold">Platform</h3>
-            <ul className="space-y-1.5 text-xs sm:text-sm">
+          <div>
+            <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+              Explore
+            </h3>
+            <ul className="mt-5 space-y-3 text-sm">
+              {publicExploreLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
               <li>
-                <Link
-                  href="/projects"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Projects
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/users"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Users
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/analytics"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Analytics
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/about"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  About
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/blog"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/blog" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   Blog
                 </Link>
               </li>
               <li>
-                <Link
-                  href="/ecosystem"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/ecosystem" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   Ecosystem
                 </Link>
               </li>
             </ul>
           </div>
 
-          <div className="md:col-span-2">
-            <h3 className="mb-3 text-sm font-semibold">Resources</h3>
-            <ul className="space-y-1.5 text-xs sm:text-sm">
-              <li>
-                <Link
-                  href="/documentation"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Documentation
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/faq"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  FAQ
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/support"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Support
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/api"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  API
-                </Link>
-              </li>
+          <div>
+            <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+              Resources
+            </h3>
+            <ul className="mt-5 space-y-3 text-sm">
+              {resourceLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
 
-          <div className="md:col-span-2">
-            <h3 className="mb-3 text-sm font-semibold">Legal</h3>
-            <ul className="space-y-1.5 text-xs sm:text-sm">
+          <div>
+            <h3 className="text-[0.7rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+              Legal
+            </h3>
+            <ul className="mt-5 space-y-3 text-sm">
               <li>
-                <Link
-                  href="/pledge"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/pledge" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   The FundLoop Pledge
                 </Link>
               </li>
               <li>
-                <Link
-                  href="/terms"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/terms" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   Terms of Service
                 </Link>
               </li>
               <li>
-                <Link
-                  href="/privacy"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/privacy" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   Privacy Policy
                 </Link>
               </li>
               <li>
-                <Link
-                  href="/cookies"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
+                <Link href="/cookies" className="text-[var(--marketing-muted-strong)] transition-colors hover:text-[var(--marketing-accent)]">
                   Cookie Policy
-                </Link>
-              </li>
-            </ul>
-          </div>
-
-          <div className="md:col-span-1 md:justify-self-end lg:col-span-2">
-            <h3 className="mb-3 text-sm font-semibold">Temporary</h3>
-            <ul className="space-y-1.5 text-xs sm:text-sm">
-              <li>
-                <Link
-                  href="/admin"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Admin
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/admin/superadmin"
-                  className="text-slate-600 hover:text-emerald-600 dark:text-slate-300 dark:hover:text-emerald-400"
-                >
-                  Super Admin
                 </Link>
               </li>
             </ul>
           </div>
         </div>
 
-        <div className="mt-10 flex flex-col items-center justify-between border-t pt-5 sm:flex-row">
-          <p className="text-xs text-slate-500 dark:text-slate-400">
+        <div className="mt-6 flex flex-col gap-3 text-xs text-[var(--marketing-muted)] sm:flex-row sm:items-center sm:justify-between">
+          <p>
             &copy; {new Date().getFullYear()} FundLoop. All rights reserved.
           </p>
-          <p className="text-xs text-slate-500 dark:text-slate-400 mt-2 sm:mt-0">
-            A network state for mutual prosperity
+          <p>
+            A network state for mutual prosperity.
           </p>
         </div>
       </div>

--- a/components/marketing/network-constellation.tsx
+++ b/components/marketing/network-constellation.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { useState, type CSSProperties, type PointerEvent } from "react"
+
+const nodes = [
+  { label: "Projects", x: 18, y: 24, size: "lg", tone: "accent" },
+  { label: "People", x: 52, y: 16, size: "md", tone: "moss" },
+  { label: "Proof", x: 80, y: 28, size: "sm", tone: "accent" },
+  { label: "Payouts", x: 22, y: 67, size: "sm", tone: "ink" },
+  { label: "Treasury", x: 54, y: 56, size: "xl", tone: "accent" },
+  { label: "Growth", x: 78, y: 72, size: "md", tone: "moss" },
+] as const
+
+const links = [
+  [0, 1],
+  [1, 2],
+  [0, 3],
+  [1, 4],
+  [3, 4],
+  [4, 5],
+  [2, 4],
+] as const
+
+const toneClasses = {
+  accent: "border-[rgba(204,92,44,0.4)] bg-[rgba(204,92,44,0.14)] text-[var(--marketing-ink)]",
+  moss: "border-[rgba(99,112,86,0.36)] bg-[rgba(99,112,86,0.14)] text-[var(--marketing-ink)]",
+  ink: "border-[rgba(22,33,33,0.18)] bg-[rgba(255,248,238,0.72)] text-[var(--marketing-ink)] dark:text-[var(--marketing-paper)]",
+} as const
+
+const dotClasses = {
+  sm: "h-3 w-3",
+  md: "h-4 w-4",
+  lg: "h-5 w-5",
+  xl: "h-6 w-6",
+} as const
+
+export function NetworkConstellation() {
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const nextX = ((event.clientX - rect.left) / rect.width - 0.5) * 20
+    const nextY = ((event.clientY - rect.top) / rect.height - 0.5) * 20
+
+    setOffset({ x: nextX, y: nextY })
+  }
+
+  const resetOffset = () => setOffset({ x: 0, y: 0 })
+
+  return (
+    <div
+      className="relative aspect-[5/4] min-h-[22rem] overflow-hidden rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(180deg,rgba(255,248,238,0.76),rgba(248,238,223,0.48))] p-6 shadow-[0_40px_120px_rgba(15,23,23,0.12)] dark:bg-[linear-gradient(180deg,rgba(18,27,25,0.92),rgba(10,18,17,0.84))]"
+      onPointerLeave={resetOffset}
+      onPointerMove={handlePointerMove}
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(204,92,44,0.22),transparent_30%),radial-gradient(circle_at_80%_30%,rgba(120,138,101,0.18),transparent_28%),radial-gradient(circle_at_55%_75%,rgba(255,214,144,0.18),transparent_26%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(22,33,33,0.07)_1px,transparent_1px),linear-gradient(90deg,rgba(22,33,33,0.07)_1px,transparent_1px)] bg-[size:3.5rem_3.5rem] opacity-35 dark:opacity-20" />
+
+      <div
+        className="absolute inset-0 transition-transform duration-500 ease-out"
+        style={{ transform: `translate(${offset.x * 0.32}px, ${offset.y * 0.32}px)` }}
+      >
+        <svg viewBox="0 0 100 100" className="absolute inset-0 h-full w-full">
+          {links.map(([from, to]) => (
+            <line
+              key={`${from}-${to}`}
+              x1={nodes[from].x}
+              y1={nodes[from].y}
+              x2={nodes[to].x}
+              y2={nodes[to].y}
+              stroke="rgba(22,33,33,0.22)"
+              strokeDasharray="4 5"
+              strokeWidth="0.7"
+            />
+          ))}
+        </svg>
+      </div>
+
+      <div
+        className="absolute inset-0 animate-[constellation-float_18s_ease-in-out_infinite] transition-transform duration-500 ease-out"
+        style={{ transform: `translate(${offset.x * -0.28}px, ${offset.y * -0.28}px)` }}
+      >
+        {nodes.map((node, index) => {
+          const style = {
+            left: `${node.x}%`,
+            top: `${node.y}%`,
+            animationDelay: `${index * 180}ms`,
+          } satisfies CSSProperties
+
+          return (
+            <div key={node.label} className="absolute -translate-x-1/2 -translate-y-1/2" style={style}>
+              <div className="flex items-center gap-3">
+                <span
+                  className={`inline-flex ${dotClasses[node.size]} animate-[constellation-pulse_8s_ease-in-out_infinite] rounded-full border border-white/50 bg-[var(--marketing-accent)] shadow-[0_0_0_10px_rgba(204,92,44,0.08)]`}
+                />
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] backdrop-blur-sm ${toneClasses[node.tone]}`}
+                >
+                  {node.label}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="absolute bottom-4 left-4 z-10 max-w-[13rem] rounded-[1.25rem] border border-[color:var(--marketing-line)] bg-[rgba(243,235,221,0.9)] p-4 shadow-[0_18px_50px_rgba(15,23,23,0.12)] backdrop-blur-md sm:bottom-6 sm:left-6 sm:max-w-[15rem] dark:bg-[rgba(13,21,21,0.84)]">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+          Network Thesis
+        </p>
+        <p className="mt-2 text-sm leading-6 text-[var(--marketing-muted-strong)]">
+          Projects feed the loop, people deepen the signal, and value returns with more context than a single app can
+          see alone.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/marketing/network-constellation.tsx
+++ b/components/marketing/network-constellation.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, type CSSProperties, type PointerEvent } from "react"
+import { useEffect, useRef, type CSSProperties, type PointerEvent } from "react"
 
 const nodes = [
   { label: "Projects", x: 18, y: 24, size: "lg", tone: "accent" },
@@ -35,30 +35,71 @@ const dotClasses = {
 } as const
 
 export function NetworkConstellation() {
-  const [offset, setOffset] = useState({ x: 0, y: 0 })
+  const containerRef = useRef<HTMLDivElement>(null)
+  const frameRef = useRef<number | null>(null)
+  const pendingOffsetRef = useRef({ x: 0, y: 0 })
+
+  const applyOffset = () => {
+    frameRef.current = null
+
+    if (!containerRef.current) {
+      return
+    }
+
+    containerRef.current.style.setProperty("--constellation-offset-x", `${pendingOffsetRef.current.x}px`)
+    containerRef.current.style.setProperty("--constellation-offset-y", `${pendingOffsetRef.current.y}px`)
+  }
+
+  const queueOffsetUpdate = (x: number, y: number) => {
+    pendingOffsetRef.current = { x, y }
+
+    if (frameRef.current !== null) {
+      return
+    }
+
+    frameRef.current = window.requestAnimationFrame(applyOffset)
+  }
 
   const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect()
     const nextX = ((event.clientX - rect.left) / rect.width - 0.5) * 20
     const nextY = ((event.clientY - rect.top) / rect.height - 0.5) * 20
 
-    setOffset({ x: nextX, y: nextY })
+    queueOffsetUpdate(nextX, nextY)
   }
 
-  const resetOffset = () => setOffset({ x: 0, y: 0 })
+  const resetOffset = () => queueOffsetUpdate(0, 0)
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+      }
+    }
+  }, [])
 
   return (
     <div
+      ref={containerRef}
       className="relative aspect-[5/4] min-h-[22rem] overflow-hidden rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(180deg,rgba(255,248,238,0.76),rgba(248,238,223,0.48))] p-6 shadow-[0_40px_120px_rgba(15,23,23,0.12)] dark:bg-[linear-gradient(180deg,rgba(18,27,25,0.92),rgba(10,18,17,0.84))]"
       onPointerLeave={resetOffset}
       onPointerMove={handlePointerMove}
+      style={
+        {
+          "--constellation-offset-x": "0px",
+          "--constellation-offset-y": "0px",
+        } as CSSProperties
+      }
     >
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(204,92,44,0.22),transparent_30%),radial-gradient(circle_at_80%_30%,rgba(120,138,101,0.18),transparent_28%),radial-gradient(circle_at_55%_75%,rgba(255,214,144,0.18),transparent_26%)]" />
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(rgba(22,33,33,0.07)_1px,transparent_1px),linear-gradient(90deg,rgba(22,33,33,0.07)_1px,transparent_1px)] bg-[size:3.5rem_3.5rem] opacity-35 dark:opacity-20" />
 
       <div
         className="absolute inset-0 transition-transform duration-500 ease-out"
-        style={{ transform: `translate(${offset.x * 0.32}px, ${offset.y * 0.32}px)` }}
+        style={{
+          transform:
+            "translate(calc(var(--constellation-offset-x) * 0.32), calc(var(--constellation-offset-y) * 0.32))",
+        }}
       >
         <svg viewBox="0 0 100 100" className="absolute inset-0 h-full w-full">
           {links.map(([from, to]) => (
@@ -78,7 +119,10 @@ export function NetworkConstellation() {
 
       <div
         className="absolute inset-0 animate-[constellation-float_18s_ease-in-out_infinite] transition-transform duration-500 ease-out"
-        style={{ transform: `translate(${offset.x * -0.28}px, ${offset.y * -0.28}px)` }}
+        style={{
+          transform:
+            "translate(calc(var(--constellation-offset-x) * -0.28), calc(var(--constellation-offset-y) * -0.28))",
+        }}
       >
         {nodes.map((node, index) => {
           const style = {

--- a/components/marketing/open-use-cases-cta.tsx
+++ b/components/marketing/open-use-cases-cta.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { OPEN_USE_CASES_MENU_EVENT } from "@/lib/use-cases-nav"
+
+type OpenUseCasesCtaProps = {
+  children: ReactNode
+  className?: string
+}
+
+export function OpenUseCasesCta({ children, className }: OpenUseCasesCtaProps) {
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={() => window.dispatchEvent(new CustomEvent(OPEN_USE_CASES_MENU_EVENT))}
+    >
+      {children}
+    </button>
+  )
+}

--- a/components/marketing/page-chrome.tsx
+++ b/components/marketing/page-chrome.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+type MarketingPageProps = {
+  children: ReactNode
+  className?: string
+}
+
+type MarketingSectionProps = {
+  children: ReactNode
+  className?: string
+  containerClassName?: string
+  id?: string
+}
+
+export function MarketingPage({ children, className }: MarketingPageProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden bg-[var(--marketing-paper)] text-[var(--marketing-ink)] dark:bg-[var(--marketing-ink)] dark:text-[var(--marketing-paper)]",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-x-0 top-0 h-[36rem] bg-[radial-gradient(circle_at_top_left,rgba(255,214,144,0.42),transparent_34%),radial-gradient(circle_at_75%_15%,rgba(204,92,44,0.28),transparent_28%),radial-gradient(circle_at_55%_55%,rgba(99,112,86,0.14),transparent_36%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(22,33,33,0.05)_1px,transparent_1px),linear-gradient(90deg,rgba(22,33,33,0.05)_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-30 dark:opacity-15" />
+        <div className="absolute inset-0 opacity-[0.05] [background-image:radial-gradient(circle_at_1px_1px,currentColor_1px,transparent_0)] [background-size:18px_18px]" />
+      </div>
+      <div className="relative">{children}</div>
+    </div>
+  )
+}
+
+export function MarketingSection({ children, className, containerClassName, id }: MarketingSectionProps) {
+  return (
+    <section id={id} className={cn("relative py-16 sm:py-20", className)}>
+      <div className={cn("mx-auto w-full max-w-7xl px-6 sm:px-8 lg:px-12", containerClassName)}>{children}</div>
+    </section>
+  )
+}
+
+export function SectionEyebrow({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <p className={cn("text-[0.72rem] font-semibold uppercase tracking-[0.32em] text-[var(--marketing-muted)]", className)}>
+      {children}
+    </p>
+  )
+}
+
+export function SectionTitle({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <h2 className={cn("font-display text-4xl leading-none tracking-[-0.03em] sm:text-5xl lg:text-6xl", className)}>
+      {children}
+    </h2>
+  )
+}
+
+export function SectionBody({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <p className={cn("max-w-2xl text-base leading-7 text-[var(--marketing-muted-strong)] sm:text-lg", className)}>
+      {children}
+    </p>
+  )
+}

--- a/components/marketing/reveal.tsx
+++ b/components/marketing/reveal.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+type RevealProps = {
+  children: ReactNode
+  className?: string
+  delay?: number
+}
+
+export function Reveal({ children, className, delay = 0 }: RevealProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [visible, setVisible] = useState(
+    typeof window !== "undefined" && typeof window.IntersectionObserver === "undefined",
+  )
+
+  useEffect(() => {
+    const node = ref.current
+
+    if (!node) {
+      return
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.16, rootMargin: "0px 0px -10% 0px" },
+    )
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        "transition-all duration-700 ease-out motion-reduce:translate-y-0 motion-reduce:opacity-100",
+        visible ? "translate-y-0 opacity-100" : "translate-y-8 opacity-0",
+        className,
+      )}
+      style={{ transitionDelay: `${delay}ms` }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -39,7 +39,7 @@ export function MobileMenu({
         </Button>
       ) : null}
       {mobileMenuOpen && (
-        <div className="fixed inset-0 z-50 bg-[var(--marketing-paper)]/95 p-6 backdrop-blur-xl dark:bg-[var(--marketing-ink)]/95">
+        <div className="fixed inset-0 z-50 overflow-y-auto bg-[var(--marketing-paper)]/95 p-6 backdrop-blur-xl dark:bg-[var(--marketing-ink)]/95">
           <div className="mb-8 flex items-center justify-between">
             <div>
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -12,38 +12,60 @@ interface MobileMenuProps {
   mobileMenuOpen?: boolean
   navLinks?: { label: string; href: string }[]
   useCaseLinks?: { label: string; href: string }[]
+  resourceLinks?: { label: string; href: string }[]
   showTrigger?: boolean
 }
 
-export function MobileMenu({ setMobileMenuOpen, mobileMenuOpen, navLinks, useCaseLinks, showTrigger = true }: MobileMenuProps) {
+export function MobileMenu({
+  setMobileMenuOpen,
+  mobileMenuOpen,
+  navLinks,
+  useCaseLinks,
+  resourceLinks,
+  showTrigger = true,
+}: MobileMenuProps) {
   const pathname = usePathname()
 
   return (
     <>
       {showTrigger ? (
-        <Button variant="ghost" size="icon" className="md:hidden" onClick={() => setMobileMenuOpen(true)}>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-full border border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.72)] text-[var(--marketing-ink)] shadow-sm hover:bg-[rgba(255,248,238,0.92)] lg:hidden dark:bg-[rgba(13,21,21,0.72)] dark:text-[var(--marketing-paper)] dark:hover:bg-[rgba(13,21,21,0.92)]"
+          onClick={() => setMobileMenuOpen(true)}
+        >
           <Menu className="h-5 w-5" />
         </Button>
       ) : null}
       {mobileMenuOpen && (
-        <div className="fixed inset-0 z-50 bg-background p-6">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-semibold">Menu</h2>
-            <Button variant="ghost" size="icon" onClick={() => setMobileMenuOpen(false)}>
+        <div className="fixed inset-0 z-50 bg-[var(--marketing-paper)]/95 p-6 backdrop-blur-xl dark:bg-[var(--marketing-ink)]/95">
+          <div className="mb-8 flex items-center justify-between">
+            <div>
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Navigate
+              </p>
+              <h2 className="mt-2 font-display text-3xl">FundLoop</h2>
+            </div>
+            <Button variant="ghost" size="icon" className="rounded-full" onClick={() => setMobileMenuOpen(false)}>
               <X className="h-6 w-6" />
             </Button>
           </div>
-          <div className="flex flex-col space-y-4">
+          <div className="flex flex-col gap-8">
             {useCaseLinks?.length ? (
-              <div className="space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">Use Cases</p>
+              <div className="space-y-4">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                  Use Cases
+                </p>
                 <div className="flex flex-col space-y-3">
                   {useCaseLinks.map(({ href, label }) => (
                     <Link
                       key={href}
                       href={href}
                       onClick={() => setMobileMenuOpen(false)}
-                      className={`text-sm ${pathname === href ? "text-emerald-600" : "text-muted-foreground"}`}
+                      className={`font-display text-2xl ${
+                        pathname === href ? "text-[var(--marketing-accent)]" : "text-[var(--marketing-ink)] dark:text-[var(--marketing-paper)]"
+                      }`}
                     >
                       {label}
                     </Link>
@@ -51,11 +73,44 @@ export function MobileMenu({ setMobileMenuOpen, mobileMenuOpen, navLinks, useCas
                 </div>
               </div>
             ) : null}
-            {navLinks?.map(({ href, label }) => (
-              <Link key={href} href={href} onClick={() => setMobileMenuOpen(false)} className="text-md">
-                {label}
-              </Link>
-            ))}
+            {navLinks?.length ? (
+              <div className="space-y-4">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                  Explore
+                </p>
+                <div className="grid gap-3">
+                  {navLinks.map(({ href, label }) => (
+                    <Link
+                      key={href}
+                      href={href}
+                      onClick={() => setMobileMenuOpen(false)}
+                      className="border-b border-[color:var(--marketing-line)] pb-3 text-lg text-[var(--marketing-muted-strong)]"
+                    >
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+            {resourceLinks?.length ? (
+              <div className="space-y-4">
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                  Resources
+                </p>
+                <div className="grid gap-3">
+                  {resourceLinks.map(({ href, label }) => (
+                    <Link
+                      key={href}
+                      href={href}
+                      onClick={() => setMobileMenuOpen(false)}
+                      className="text-sm uppercase tracking-[0.2em] text-[var(--marketing-muted-strong)]"
+                    >
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
       )}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -130,7 +130,8 @@ export default function Navbar() {
     router.refresh()
   }
 
-  const navLinks = [...publicExploreLinks, { label: "Blog", href: "/blog", description: "Essays, explainers, and product notes from the FundLoop orbit." }]
+  const exploreLinks = publicExploreLinks
+  const topLevelLinks = [{ label: "Blog", href: "/blog" }]
   const mobileNavLinks = [...publicExploreLinks, { label: "Blog", href: "/blog" }]
 
   const desktopNavItemClass =
@@ -166,7 +167,7 @@ export default function Navbar() {
                 className="w-[30rem] max-w-[calc(100vw-2rem)] rounded-[1.5rem] border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.94)] p-3 shadow-[0_30px_90px_rgba(15,23,23,0.14)] backdrop-blur-xl dark:bg-[rgba(13,21,21,0.95)]"
               >
                 <div className="grid gap-1 sm:grid-cols-2">
-                  {navLinks.map((link) => (
+                  {exploreLinks.map((link) => (
                     <DropdownMenuItem key={link.href} asChild className="p-0">
                       <Link
                         href={link.href}
@@ -183,7 +184,7 @@ export default function Navbar() {
               </DropdownMenuContent>
             </DropdownMenu>
 
-            {navLinks.slice(4).map((link) => (
+            {topLevelLinks.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { getSupabaseBrowserClient } from "@/lib/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import {
@@ -20,7 +20,9 @@ import UseCasesDropdown from "@/components/use-cases-dropdown"
 import { CircleDollarSign, ChevronDown, User, Settings, LogOut } from "lucide-react"
 import { MobileMenu } from "@/components/mobile-menu"
 import { useCaseLinks } from "@/lib/use-cases"
+import { OPEN_USE_CASES_MENU_EVENT } from "@/lib/use-cases-nav"
 import { cn } from "@/lib/utils"
+import { publicExploreLinks, resourceLinks } from "@/lib/public-site"
 
 export default function Navbar() {
   const [session, setSession] = useState<any>(null)
@@ -30,9 +32,11 @@ export default function Navbar() {
   const [loading, setLoading] = useState(true)
   const [showAuthModal, setShowAuthModal] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [useCasesOpen, setUseCasesOpen] = useState(false)
 
   const pathname = usePathname()
   const router = useRouter()
+  const supabaseConfigured = isSupabaseConfigured()
 
   const openOnboarding = () => {
     const params = new URLSearchParams(window.location.search)
@@ -42,6 +46,13 @@ export default function Navbar() {
   }
 
   useEffect(() => {
+    if (!supabaseConfigured) {
+      setLoading(false)
+      setSession(null)
+      setUser(null)
+      return
+    }
+
     const fetchUser = async () => {
       const supabase = getSupabaseBrowserClient()
       const { data } = await supabase.auth.getSession()
@@ -88,9 +99,30 @@ export default function Navbar() {
     })
 
     return () => subscription.unsubscribe()
-  }, [router])
+  }, [router, supabaseConfigured])
+
+  useEffect(() => {
+    const openUseCasesMenu = () => {
+      if (window.matchMedia("(min-width: 1024px)").matches) {
+        setMobileMenuOpen(false)
+        setUseCasesOpen(true)
+        return
+      }
+
+      setUseCasesOpen(false)
+      setMobileMenuOpen(true)
+    }
+
+    window.addEventListener(OPEN_USE_CASES_MENU_EVENT, openUseCasesMenu)
+
+    return () => window.removeEventListener(OPEN_USE_CASES_MENU_EVENT, openUseCasesMenu)
+  }, [])
 
   const handleSignOut = async () => {
+    if (!supabaseConfigured) {
+      return
+    }
+
     const supabase = getSupabaseBrowserClient()
     await supabase.auth.signOut()
     setSession(null)
@@ -98,55 +130,30 @@ export default function Navbar() {
     router.refresh()
   }
 
-  const navLinks = [
-    { label: "Projects", href: "/projects" },
-    { label: "Users", href: "/users" },
-    { label: "Analytics", href: "/analytics" },
-    { label: "Blog", href: "/blog" },
-  ]
-
-  const mobileNavLinks = [...navLinks, { label: "About FundLoop", href: "/about" }]
-
-  const exploreLinks = [
-    {
-      label: "Projects",
-      href: "/projects",
-      description: "Browse aligned projects participating in the FundLoop ecosystem.",
-    },
-    {
-      label: "Users",
-      href: "/users",
-      description: "See the people shaping the network and participating across projects.",
-    },
-    {
-      label: "Analytics",
-      href: "/analytics",
-      description: "Understand how contributions, activity, and citizen salary flow through the system.",
-    },
-    {
-      label: "About FundLoop",
-      href: "/about",
-      description: "Learn the mission, model, and long-term vision behind FundLoop.",
-    },
-  ]
+  const navLinks = [...publicExploreLinks, { label: "Blog", href: "/blog", description: "Essays, explainers, and product notes from the FundLoop orbit." }]
+  const mobileNavLinks = [...publicExploreLinks, { label: "Blog", href: "/blog" }]
 
   const desktopNavItemClass =
-    "h-9 rounded-full px-4 text-sm font-medium transition-colors data-[state=open]:bg-emerald-50 data-[state=open]:text-emerald-700 dark:data-[state=open]:bg-emerald-950/40 dark:data-[state=open]:text-emerald-300"
+    "h-10 rounded-full px-4 text-sm font-medium text-[var(--marketing-muted-strong)] transition-colors data-[state=open]:bg-black/[0.04] data-[state=open]:text-[var(--marketing-ink)] dark:data-[state=open]:bg-white/[0.06] dark:data-[state=open]:text-[var(--marketing-paper)]"
 
   return (
     <>
-      <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur">
-        <div className="container flex h-16 items-center justify-between px-4">
-          <Link href="/" className="flex items-center gap-2">
-            <CircleDollarSign className="h-6 w-6 text-emerald-600" />
-            <span className="font-bold text-xl hidden sm:inline">FundLoop</span>
-            <span className="relative left-1 top-1 hidden text-[0.7rem] font-medium italic tracking-[0.08em] text-[#5a1f1f] sm:inline dark:text-[#d6a3a3]">
-              Coming Soon
+      <header className="sticky top-0 z-50 w-full px-3 py-3 sm:px-4">
+        <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between rounded-full border border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.74)] px-3 shadow-[0_12px_40px_rgba(15,23,23,0.08)] backdrop-blur-xl dark:bg-[rgba(13,21,21,0.74)]">
+          <Link href="/" className="flex items-center gap-3 rounded-full px-2 py-1">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-[rgba(204,92,44,0.14)] text-[var(--marketing-accent)]">
+              <CircleDollarSign className="h-5 w-5" />
             </span>
+            <div className="hidden sm:block">
+              <p className="font-display text-2xl leading-none tracking-[-0.04em]">FundLoop</p>
+              <p className="mt-1 text-[0.6rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
+                Networked mutual prosperity
+              </p>
+            </div>
           </Link>
 
-          <div className="hidden md:flex items-center rounded-full border border-slate-200/80 bg-white/80 px-2 py-1 shadow-sm dark:border-slate-800 dark:bg-slate-950/70">
-            <UseCasesDropdown triggerClassName={desktopNavItemClass} />
+          <div className="hidden lg:flex items-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 px-2 py-1 dark:bg-white/[0.03]">
+            <UseCasesDropdown open={useCasesOpen} onOpenChange={setUseCasesOpen} triggerClassName={desktopNavItemClass} />
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -154,34 +161,37 @@ export default function Navbar() {
                   Explore <ChevronDown className="h-4 w-4 ml-1" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="w-[30rem] max-w-[calc(100vw-2rem)] p-2">
+              <DropdownMenuContent
+                align="start"
+                className="w-[30rem] max-w-[calc(100vw-2rem)] rounded-[1.5rem] border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.94)] p-3 shadow-[0_30px_90px_rgba(15,23,23,0.14)] backdrop-blur-xl dark:bg-[rgba(13,21,21,0.95)]"
+              >
                 <div className="grid gap-1 sm:grid-cols-2">
-                {exploreLinks.map((link) => (
-                  <DropdownMenuItem key={link.href} asChild className="p-0">
-                    <Link
-                      href={link.href}
-                      className={`flex min-h-24 flex-col items-start rounded-sm px-3 py-3 outline-none transition-colors hover:bg-accent ${
-                        pathname === link.href ? "text-emerald-600" : ""
-                      }`}
-                    >
-                      <span className="text-sm font-semibold">{link.label}</span>
-                      <span className="mt-1 text-xs leading-5 text-muted-foreground">{link.description}</span>
-                    </Link>
-                  </DropdownMenuItem>
-                ))}
+                  {navLinks.map((link) => (
+                    <DropdownMenuItem key={link.href} asChild className="p-0">
+                      <Link
+                        href={link.href}
+                        className={`flex min-h-24 flex-col items-start rounded-2xl px-4 py-4 outline-none transition-transform duration-200 hover:-translate-y-0.5 hover:bg-black/[0.03] ${
+                          pathname === link.href ? "text-[var(--marketing-accent)]" : ""
+                        }`}
+                      >
+                        <span className="text-sm font-semibold uppercase tracking-[0.18em]">{link.label}</span>
+                        <span className="mt-2 text-xs leading-5 text-[var(--marketing-muted-strong)]">{link.description}</span>
+                      </Link>
+                    </DropdownMenuItem>
+                  ))}
                 </div>
               </DropdownMenuContent>
             </DropdownMenu>
 
-            {navLinks.slice(3).map((link) => (
+            {navLinks.slice(4).map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
                 className={cn(
                   "inline-flex h-9 items-center rounded-full px-4 text-sm font-medium transition-colors",
                   pathname === link.href
-                    ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300"
-                    : "text-muted-foreground hover:bg-slate-100 hover:text-foreground dark:hover:bg-slate-900",
+                    ? "bg-black/[0.04] text-[var(--marketing-accent)] dark:bg-white/[0.06]"
+                    : "text-[var(--marketing-muted-strong)] hover:bg-black/[0.04] hover:text-[var(--marketing-ink)] dark:hover:bg-white/[0.06] dark:hover:text-[var(--marketing-paper)]",
                 )}
               >
                 {link.label}
@@ -195,12 +205,19 @@ export default function Navbar() {
             <ThemeToggle />
 
             {!session ? (
-              <Button className="bg-emerald-600 text-white hover:bg-emerald-700" onClick={() => setShowAuthModal(true)}>
-                Authenticate
+              <Button
+                className="rounded-full border border-transparent bg-[var(--marketing-accent)] px-5 text-white hover:bg-[color:var(--marketing-accent)]/90"
+                disabled={!supabaseConfigured || loading}
+                onClick={() => setShowAuthModal(true)}
+              >
+                {supabaseConfigured ? "Authenticate" : "Auth unavailable locally"}
               </Button>
             ) : user?.status !== "active" ? (
               <div className="flex items-center gap-2">
-                <Button className="bg-emerald-600 text-white hover:bg-emerald-700" onClick={openOnboarding}>
+                <Button
+                  className="rounded-full border border-transparent bg-[var(--marketing-accent)] px-5 text-white hover:bg-[color:var(--marketing-accent)]/90"
+                  onClick={openOnboarding}
+                >
                   Continue onboarding
                 </Button>
                 <Button variant="ghost" size="icon" onClick={() => void handleSignOut()}>
@@ -256,6 +273,7 @@ export default function Navbar() {
         mobileMenuOpen={mobileMenuOpen}
         setMobileMenuOpen={setMobileMenuOpen}
         navLinks={mobileNavLinks}
+        resourceLinks={resourceLinks.map(({ href, label }) => ({ href, label }))}
         useCaseLinks={useCaseLinks.map(({ href, shortLabel }) => ({ href, label: shortLabel }))}
         showTrigger={false}
       />

--- a/components/onboarding-modal-manager.tsx
+++ b/components/onboarding-modal-manager.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useMemo, useState } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { getSupabaseBrowserClient } from "@/lib/supabase"
+import { getSupabaseBrowserClient, isSupabaseConfigured } from "@/lib/supabase"
 import { Modal } from "@/components/modal"
+import { Button } from "@/components/ui/button"
 import UserSignupFlow from "@/components/user-signup-flow"
 import ProjectSignupFlow from "@/components/project-signup-flow"
 import { buildUrl } from "@/lib/url"
@@ -14,6 +15,7 @@ export function OnboardingModalManager() {
   const searchParams = useSearchParams()
   const onboardingFlow = searchParams.get("onboarding")
   const inviteCode = searchParams.get("invite") ?? ""
+  const supabaseConfigured = isSupabaseConfigured()
 
   const [authUserId, setAuthUserId] = useState<string | null>(null)
   const [profileStatus, setProfileStatus] = useState<string | null>(null)
@@ -21,6 +23,10 @@ export function OnboardingModalManager() {
   const dismissalKey = authUserId ? `fundloop-onboarding-dismissed:${authUserId}` : null
 
   useEffect(() => {
+    if (!supabaseConfigured) {
+      return
+    }
+
     const supabase = getSupabaseBrowserClient()
 
     const loadSession = async () => {
@@ -39,9 +45,13 @@ export function OnboardingModalManager() {
     })
 
     return () => subscription.unsubscribe()
-  }, [])
+  }, [supabaseConfigured])
 
   useEffect(() => {
+    if (!supabaseConfigured) {
+      return
+    }
+
     const fetchStatus = async () => {
       if (!authUserId) {
         setProfileStatus(null)
@@ -54,7 +64,7 @@ export function OnboardingModalManager() {
     }
 
     void fetchStatus()
-  }, [authUserId])
+  }, [authUserId, supabaseConfigured])
 
   useEffect(() => {
     if (!authUserId || profileStatus !== "inactive" || onboardingFlow) {
@@ -106,6 +116,40 @@ export function OnboardingModalManager() {
 
   if (!effectiveFlow) {
     return null
+  }
+
+  if (!supabaseConfigured) {
+    return (
+      <Modal
+        title="FundLoop onboarding"
+        description="Open onboarding links are working, but this local environment is missing the backend configuration needed to continue."
+        isOpen
+        onClose={closeModal}
+        size="lg"
+        contentClassName="bg-slate-50 p-0"
+      >
+        <div className="space-y-5 p-4 sm:p-6">
+          <div className="rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-8">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-600">
+              {onboardingFlow === "project" ? "Project onboarding" : "User onboarding"}
+            </p>
+            <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+              Backend setup is required to continue this flow locally.
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              FundLoop needs Supabase environment variables before authentication, draft saving, and onboarding state can
+              work. The query param is being handled correctly; the local checkout just cannot continue the flow yet.
+            </p>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Button onClick={closeModal}>Close</Button>
+              <Button variant="outline" onClick={() => requestFlowChange(onboardingFlow === "project" ? "user" : "project")}>
+                Switch to {onboardingFlow === "project" ? "user" : "project"} flow
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Modal>
+    )
   }
 
   return (

--- a/components/resources-dropdown.tsx
+++ b/components/resources-dropdown.tsx
@@ -7,6 +7,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Button } from "@/components/ui/button"
 import { ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { resourceLinks } from "@/lib/public-site"
 
 type ResourcesDropdownProps = {
   triggerClassName?: string
@@ -16,35 +17,7 @@ export default function ResourcesDropdown({ triggerClassName }: ResourcesDropdow
   const [open, setOpen] = useState(false)
   const pathname = usePathname()
 
-  const resources = [
-    {
-      href: "/pricing",
-      label: "Pricing",
-      description: "How FundLoop stays free for users and how projects are asked to support the ecosystem.",
-    },
-    {
-      href: "/documentation",
-      label: "Documentation",
-      description: "Implementation guides, setup details, and reference material for the platform.",
-    },
-    {
-      href: "/faq",
-      label: "FAQ",
-      description: "Straight answers to common questions from projects, users, and contributors.",
-    },
-    {
-      href: "/support",
-      label: "Support",
-      description: "Get help when you are stuck or need a path through onboarding and platform flows.",
-    },
-    {
-      href: "/api",
-      label: "API",
-      description: "Developer-facing endpoints and integration details for product and data workflows.",
-    },
-  ]
-
-  const isActive = resources.some((resource) => pathname === resource.href)
+  const isActive = resourceLinks.some((resource) => pathname === resource.href)
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -53,7 +26,9 @@ export default function ResourcesDropdown({ triggerClassName }: ResourcesDropdow
           variant="ghost"
           className={cn(
             "text-sm font-medium",
-            isActive ? "text-emerald-600 dark:text-emerald-400" : "text-muted-foreground hover:text-foreground",
+            isActive
+              ? "text-[var(--marketing-accent)]"
+              : "text-[var(--marketing-muted-strong)] hover:text-[var(--marketing-ink)] dark:hover:text-[var(--marketing-paper)]",
             triggerClassName,
           )}
         >
@@ -61,22 +36,25 @@ export default function ResourcesDropdown({ triggerClassName }: ResourcesDropdow
           <ChevronDown className="ml-1 h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-[30rem] max-w-[calc(100vw-2rem)] p-2">
+      <DropdownMenuContent
+        align="end"
+        className="w-[30rem] max-w-[calc(100vw-2rem)] rounded-[1.5rem] border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.94)] p-3 shadow-[0_30px_90px_rgba(15,23,23,0.14)] backdrop-blur-xl dark:bg-[rgba(13,21,21,0.95)]"
+      >
         <div className="grid gap-1 sm:grid-cols-2">
-        {resources.map((resource) => (
-          <DropdownMenuItem key={resource.href} asChild className="p-0">
-            <Link
-              href={resource.href}
-              className={`flex min-h-24 flex-col items-start rounded-sm px-3 py-3 outline-none transition-colors hover:bg-accent ${
-                pathname === resource.href ? "text-emerald-600 dark:text-emerald-400" : ""
-              }`}
-              onClick={() => setOpen(false)}
-            >
-              <span className="text-sm font-semibold">{resource.label}</span>
-              <span className="mt-1 text-xs leading-5 text-muted-foreground">{resource.description}</span>
-            </Link>
-          </DropdownMenuItem>
-        ))}
+          {resourceLinks.map((resource) => (
+            <DropdownMenuItem key={resource.href} asChild className="p-0">
+              <Link
+                href={resource.href}
+                className={`flex min-h-24 flex-col items-start rounded-2xl px-4 py-4 outline-none transition-transform duration-200 hover:-translate-y-0.5 hover:bg-black/[0.03] ${
+                  pathname === resource.href ? "text-[var(--marketing-accent)]" : ""
+                }`}
+                onClick={() => setOpen(false)}
+              >
+                <span className="text-sm font-semibold uppercase tracking-[0.18em]">{resource.label}</span>
+                <span className="mt-2 text-xs leading-5 text-[var(--marketing-muted-strong)]">{resource.description}</span>
+              </Link>
+            </DropdownMenuItem>
+          ))}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/components/use-cases-dropdown.tsx
+++ b/components/use-cases-dropdown.tsx
@@ -11,21 +11,34 @@ import { cn } from "@/lib/utils"
 
 type UseCasesDropdownProps = {
   triggerClassName?: string
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
-export default function UseCasesDropdown({ triggerClassName }: UseCasesDropdownProps) {
-  const [open, setOpen] = useState(false)
+export default function UseCasesDropdown({ triggerClassName, open: controlledOpen, onOpenChange }: UseCasesDropdownProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
   const pathname = usePathname()
   const isActive = pathname.startsWith("/use-cases")
+  const open = controlledOpen ?? internalOpen
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange?.(nextOpen)
+
+    if (controlledOpen === undefined) {
+      setInternalOpen(nextOpen)
+    }
+  }
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
           className={cn(
             "text-sm font-medium",
-            isActive ? "text-emerald-600" : "text-muted-foreground hover:text-foreground",
+            isActive
+              ? "text-[var(--marketing-accent)]"
+              : "text-[var(--marketing-muted-strong)] hover:text-[var(--marketing-ink)] dark:hover:text-[var(--marketing-paper)]",
             triggerClassName,
           )}
         >
@@ -33,17 +46,20 @@ export default function UseCasesDropdown({ triggerClassName }: UseCasesDropdownP
           <ChevronDown className="ml-1 h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-[36rem] max-w-[calc(100vw-2rem)] p-2">
+      <DropdownMenuContent
+        align="start"
+        className="w-[36rem] max-w-[calc(100vw-2rem)] rounded-[1.5rem] border-[color:var(--marketing-line)] bg-[rgba(255,248,238,0.94)] p-3 shadow-[0_30px_90px_rgba(15,23,23,0.14)] backdrop-blur-xl dark:bg-[rgba(13,21,21,0.95)]"
+      >
         <div className="grid gap-1 sm:grid-cols-2">
           {useCaseLinks.map((useCase) => (
             <DropdownMenuItem key={useCase.slug} asChild className="p-0">
               <Link
                 href={useCase.href}
-                onClick={() => setOpen(false)}
-                className="flex min-h-24 flex-col items-start rounded-sm px-3 py-3 outline-none transition-colors hover:bg-accent"
+                onClick={() => handleOpenChange(false)}
+                className="flex min-h-24 flex-col items-start rounded-2xl px-4 py-4 outline-none transition-transform duration-200 hover:-translate-y-0.5 hover:bg-black/[0.03]"
               >
-                <span className="text-sm font-semibold">{useCase.label}</span>
-                <span className="mt-1 text-xs leading-5 text-muted-foreground">{useCase.description}</span>
+                <span className="text-sm font-semibold uppercase tracking-[0.18em]">{useCase.label}</span>
+                <span className="mt-2 text-xs leading-5 text-[var(--marketing-muted-strong)]">{useCase.description}</span>
               </Link>
             </DropdownMenuItem>
           ))}

--- a/components/web3-provider.tsx
+++ b/components/web3-provider.tsx
@@ -41,13 +41,20 @@ function ensureAppKit() {
 }
 
 export function openFundLoopWalletModal() {
+  if (!hasReownProjectId) {
+    return Promise.resolve()
+  }
+
   ensureAppKit()
   return import("@reown/appkit/react").then(({ modal }) => modal?.open())
 }
 
 export function Web3Provider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
-  ensureAppKit()
+
+  if (hasReownProjectId) {
+    ensureAppKit()
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/components/web3-provider.tsx
+++ b/components/web3-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { type ReactNode, useState } from "react"
+import { type ReactNode, useEffect, useState } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createAppKit } from "@reown/appkit/react"
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi"
@@ -52,9 +52,13 @@ export function openFundLoopWalletModal() {
 export function Web3Provider({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient())
 
-  if (hasReownProjectId) {
+  useEffect(() => {
+    if (!hasReownProjectId) {
+      return
+    }
+
     ensureAppKit()
-  }
+  }, [])
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/lib/public-site.ts
+++ b/lib/public-site.ts
@@ -1,0 +1,148 @@
+export const publicExploreLinks = [
+  {
+    label: "Projects",
+    href: "/projects",
+    description: "Browse aligned projects already participating in the FundLoop network.",
+  },
+  {
+    label: "Users",
+    href: "/users",
+    description: "Meet the people shaping the ecosystem through real participation.",
+  },
+  {
+    label: "Analytics",
+    href: "/analytics",
+    description: "See how contribution, activity, and value circulation show up across the network.",
+  },
+  {
+    label: "About FundLoop",
+    href: "/about",
+    description: "Understand the mission, the 1% pledge, and the long-term economic thesis.",
+  },
+] as const
+
+export const resourceLinks = [
+  {
+    href: "/participation",
+    label: "Participation",
+    description: "How people join projects, build signal, manage proof, and receive rewards through FundLoop.",
+  },
+  {
+    href: "/pricing",
+    label: "Pricing",
+    description: "How FundLoop stays free for users and how projects are asked to support the loop.",
+  },
+  {
+    href: "/documentation",
+    label: "Documentation",
+    description: "Guides, implementation notes, and support articles for using the platform.",
+  },
+  {
+    href: "/faq",
+    label: "FAQ",
+    description: "Clear answers for founders, community members, and honest bots.",
+  },
+  {
+    href: "/support",
+    label: "Support",
+    description: "Get help when onboarding, profiles, payments, or project setup need a hand.",
+  },
+  {
+    href: "/api",
+    label: "API",
+    description: "A developer-facing preview of the integration surface FundLoop is growing toward.",
+  },
+] as const
+
+export const ecosystemSites = [
+  {
+    name: "ChainCrew",
+    url: "https://chaincrew.xyz",
+    desc: "Team up in Crews to manage memberships, events, and community treasuries.",
+  },
+  {
+    name: "ClearPass",
+    url: "https://clearpass.app",
+    desc: "KYC verification with NFC-enabled passports and driver's licenses.",
+  },
+  {
+    name: "Cubid",
+    url: "https://cubid.me",
+    desc: "Privacy-preserving identity infrastructure with proofs and stamps.",
+  },
+  {
+    name: "EquityFlow",
+    url: "https://equityflow.xyz",
+    desc: "Tools for equity and commitment-sharing among founders and teams.",
+  },
+  {
+    name: "Firebelly",
+    url: "https://firebelly.xyz",
+    desc: "Innovation studio supporting regenerative and Web3 ventures.",
+  },
+  {
+    name: "FundLoop",
+    url: "https://fundloop.org",
+    desc: "Collaborative incubator and funding network for early-stage projects.",
+  },
+  {
+    name: "FreeForm",
+    url: "https://usefreeform.com",
+    desc: "A next-gen form builder with voting, branching, and identity options.",
+  },
+  {
+    name: "GreenPill Canada",
+    url: "https://greenpill.ca",
+    desc: "Building local regenerative economies across Canada.",
+  },
+  {
+    name: "GreenPill Toronto",
+    url: "https://greenpill.to",
+    desc: "Toronto's node of the global GreenPill network.",
+  },
+  {
+    name: "I Am Human",
+    url: "https://www.i-am-human.app/",
+    desc: "Developer infrastructure for sybil resistance.",
+  },
+  {
+    name: "Procent Foundation",
+    url: "https://procentfoundation.com",
+    desc: "A nonprofit supporting public goods and open innovation.",
+  },
+  {
+    name: "Safe2Meet",
+    url: "https://safe2meet.me",
+    desc: "Safer in-person meetups for real estate, classifieds, and dating.",
+  },
+  {
+    name: "Solar Village",
+    url: "https://solarvillage.xyz",
+    desc: "Carbon credits for off-grid solar projects in Africa.",
+  },
+  {
+    name: "SmarTrust",
+    url: "https://smartrust.me",
+    desc: "AI-powered escrow and arbitration for freelancers, agencies, and B2B work.",
+  },
+  {
+    name: "SnapVote",
+    url: "https://snapvote.org",
+    desc: "Fast, trustworthy decision-making and polls for communities.",
+  },
+  {
+    name: "SpareChange",
+    url: "https://sparechange.tips",
+    desc: "Tip anyone with QR codes and digital micro-payments.",
+  },
+  {
+    name: "TCOIN",
+    url: "https://tcoin.me",
+    desc: "Toronto's local community currency pegged to transit tokens.",
+  },
+  {
+    name: "UBI Finder",
+    url: "https://ubifinder.org",
+    desc: "A global directory of Universal Basic Income projects.",
+  },
+] as const

--- a/lib/use-cases-nav.ts
+++ b/lib/use-cases-nav.ts
@@ -1,0 +1,1 @@
+export const OPEN_USE_CASES_MENU_EVENT = "fundloop:open-use-cases-menu"


### PR DESCRIPTION
## Summary
- refresh the public marketing surface with a shared editorial layout system, stronger homepage hero, and updated secondary pages
- add a dedicated `/participation` explainer so participant-facing copy has a real destination instead of pointing at pricing
- tighten public navigation behavior across desktop and mobile, including the homepage use-case CTA and resource menus
- harden local-env fallbacks so public pages and onboarding query params still behave predictably without Supabase or wallet config
- curate the homepage ecosystem preview and update the ecosystem directory with the requested partner entries

## Objective
FundLoop's public-facing pages had drifted into a mix of older layouts, incomplete participant guidance, and a few marketing-flow regressions. This PR turns the public site into a coherent landing experience for founders and participants, fixes the most visible navigation/onboarding issues, and adds the missing participant journey page that the homepage now points to.

## Changes
- introduced shared marketing primitives under `components/marketing/` and rewrote the homepage, about, pricing, FAQ, ecosystem, API, documentation, support, join, and use-case pages to use that system
- rebuilt the homepage hero and section flow, including the network constellation visual, curated ecosystem preview, and a CTA that opens the use-case chooser from the header
- added `/participation` for the participant journey, covering multi-project participation, monthly reward review, humanity proof, Cubid Passport controls, withdrawals, and payout preferences
- updated shared navigation, footer, use-case/resources dropdowns, and mobile menu so the new pages are discoverable and responsive across breakpoints
- fixed local-env public-flow regressions so `?onboarding=user` and `?onboarding=project` still open a visible modal when backend config is missing instead of failing silently
- added `I Am Human` to the ecosystem directory and changed the homepage ecosystem preview to feature `SmarTrust`, `TCOIN`, and `Solar Village`

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm --dir contracts test`
- Playwright/manual browser smoke checks on `/`, `/about`, `/pricing`, `/faq`, `/ecosystem`, `/support`, `/api`, `/documentation`, `/use-cases/fairdrops`, and `/participation`
- verified responsive behavior on small/mobile, tablet, and desktop widths for the refreshed public pages

## Reviewer Notes
- review the shared marketing primitives and homepage first, then scan the secondary public pages for copy/layout consistency
- the local-env fallback changes in `components/onboarding-modal-manager.tsx`, `components/web3-provider.tsx`, and `components/navbar.tsx` are important because they change failure behavior from silent/no-op to visible guidance
- the existing non-failing Recharts width/height warning during static generation on analytics-related pages is still present in `pnpm build`; this PR does not attempt to change that unrelated behavior

## Follow-ups
- this PR does not redesign the non-marketing app surfaces such as `/blog`, `/projects`, or `/users`
- this PR does not add new backend payout logic, identity integrations, or broader authenticated end-to-end coverage beyond the public/onboarding smoke checks
