### PR TITLE
[codex] Address wallet stack review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See [Local Seed Fixtures](/Users/botmaster/src/fundloop/docs/engineering/local-s
 
 Wallet execution uses a hybrid model:
 
-- tracked manifests under [`lib/onchain/deployments/`](/Users/botmaster/src/fundloop/lib/onchain/deployments) are the source of truth for deployed intake contract and treasury addresses
+- tracked manifests under [`lib/onchain/deployments/`](lib/onchain/deployments/) are the source of truth for deployed intake contract and treasury addresses
 - Supabase `chain_intake_contracts` rows remain the runtime source used by project payment routes
 - the sync script applies manifest changes into Supabase explicitly instead of mutating the database at app startup
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After a local reset, these stable public smoke targets should exist:
 - `/en/projects/open-transit-ledger`
 - `/en/users/00000000-0000-4000-8000-000000000101`
 
-See [Local Seed Fixtures](/Users/botmaster/src/fundloop/docs/engineering/local-seed.md) for the full deterministic fixture set.
+See [Local Seed Fixtures](docs/engineering/local-seed.md) for the full deterministic fixture set.
 
 ## Wallet Deployment Workflow
 

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -6,22 +6,22 @@ Keep this folder small and current. It should hold the working context agents ne
 
 ## Live Agent Context
 
-- [Backgrounder for Agents](/Users/botmaster/src/fundloop/agent-context/backgrounder-for-agents.md)
+- [Backgrounder for Agents](./backgrounder-for-agents.md)
   Product intent, users, and decision-making context.
-- [Current-State Architecture](/Users/botmaster/src/fundloop/agent-context/current-state-architecture.md)
+- [Current-State Architecture](./current-state-architecture.md)
   Repo-grounded summary of how the app is structured today.
-- [Target-State Architecture](/Users/botmaster/src/fundloop/agent-context/target-state-architecture.md)
+- [Target-State Architecture](./target-state-architecture.md)
   Intended operating model for the production FundLoop system.
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [TODO Roadmap](./todo.md)
   Sequenced execution backlog, one agentic coding session per item.
-- [Session Log](/Users/botmaster/src/fundloop/agent-context/session-log.md)
+- [Session Log](./session-log.md)
   Commit-by-commit record of completed work, validation, and next steps.
 
 ## Long-Lived Engineering Docs
 
-- [Engineering Docs Index](/Users/botmaster/src/fundloop/docs/engineering/README.md)
-- [Information Architecture](/Users/botmaster/src/fundloop/docs/engineering/information-architecture.md)
-- [Route Inventory](/Users/botmaster/src/fundloop/docs/engineering/route-inventory.md)
+- [Engineering Docs Index](../docs/engineering/README.md)
+- [Information Architecture](../docs/engineering/information-architecture.md)
+- [Route Inventory](../docs/engineering/route-inventory.md)
 
 ## How To Use This Folder
 

--- a/agent-context/backgrounder-for-agents.md
+++ b/agent-context/backgrounder-for-agents.md
@@ -1,10 +1,10 @@
 # backgrounder-for-agents.md
 
 Related planning docs:
-- [Agent Context Index](/Users/botmaster/src/fundloop/agent-context/README.md)
-- [Current-State Architecture](/Users/botmaster/src/fundloop/agent-context/current-state-architecture.md)
-- [Target-State Architecture](/Users/botmaster/src/fundloop/agent-context/target-state-architecture.md)
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [Agent Context Index](./README.md)
+- [Current-State Architecture](./current-state-architecture.md)
+- [Target-State Architecture](./target-state-architecture.md)
+- [TODO Roadmap](./todo.md)
 
 ## Purpose of this Document
 

--- a/agent-context/current-state-architecture.md
+++ b/agent-context/current-state-architecture.md
@@ -3,10 +3,10 @@
 Last reviewed: 2026-04-14
 
 Related planning docs:
-- [Agent Context Index](/Users/botmaster/src/fundloop/agent-context/README.md)
-- [Backgrounder for Agents](/Users/botmaster/src/fundloop/agent-context/backgrounder-for-agents.md)
-- [Target-State Architecture](/Users/botmaster/src/fundloop/agent-context/target-state-architecture.md)
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [Agent Context Index](./README.md)
+- [Backgrounder for Agents](./backgrounder-for-agents.md)
+- [Target-State Architecture](./target-state-architecture.md)
+- [TODO Roadmap](./todo.md)
 
 ## 1. What This Repo Is Today
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2,7 +2,7 @@
 - timestamp: 2026-04-19T21:54:03-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/address-wallet-review-comments**
-- head: TBD
+- head: 8797552
 
 #### Objective
 Address the first review pass on PR #22 after the cleanup branch was opened against `dev`, focusing on the reconciliation finalizer RPC security and session-log metadata.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,5 +1,37 @@
 ---
 
+### session v54: Address PR 18 payment and onchain reconciliation review comments
+- timestamp: 2026-04-17T20:08:59-0400
+- agent: **Codex (GPT-5)**
+- branch: **codex/address-wallet-review-comments**
+- head: TBD
+
+#### Objective
+Address the outstanding review threads from PR #18 after the wallet payments and Edge Function groundwork was approved and merged, without reopening the original stacked branch.
+
+#### Actions Taken
+- Converted the PR #18 doc links called out in review from machine-local `/Users/...` targets to repo-relative links in:
+  - `docs/engineering/README.md`
+  - `README.md`
+- Added runtime validation and string-to-number coercion for the internal onchain reconciliation route body in `app/api/internal/payments/reconcile-onchain/route.ts`.
+- Added route coverage proving valid numeric strings are accepted and invalid numeric filters return `400` before reaching reconciliation.
+- Hardened `recordOnchainPaymentSubmission(...)` so the submitted onchain decimal amount must match the canonical `payments.payment_amount` before a submission is stored.
+- Added the forward-only migration `supabase/migrations/20260417193000_onchain_reconciliation_atomic_update.sql` with `public.finalize_onchain_payment_reconciliation(...)`.
+- Switched reconciliation finalization in `lib/onchain/payment-reconciliation.ts` to call the new RPC so terminal submission state and linked payment state update inside one database transaction.
+- Updated `types/supabase.ts` with the new RPC signature.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/onchain-reconciliation-route.test.ts tests/payment-reconciliation.test.ts tests/project-payment-observability-actions.test.ts` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed
+
+#### Reflections
+- The two P1 review comments were tightly coupled: canonical amount validation prevents underpayment snapshots from entering the reconciliation queue, and atomic finalization prevents payment/submission status drift once reconciliation starts.
+- The RPC keeps the application-level logic readable while giving Postgres ownership of the transactional boundary.
+
+#### Suggested Next Steps
+- Reply to and resolve the five PR #18 review threads with this commit reference.
+- Continue the same review-fix-resolve loop with the outstanding PR #19 comments.
+
 ### session v53: Remove duplicate bootstrap from the founder CUBID project gate
 - timestamp: 2026-04-17T19:37:49-0400
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,10 +1,40 @@
 ---
 
+### session v55: Address PR 19 shell and planning-doc review comments
+- timestamp: 2026-04-17T20:19:02-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/address-wallet-review-comments**
+- head: TBD
+
+#### Objective
+Address the outstanding review threads from PR #19 after the app-shell and locale-routing work merged, keeping the fixes focused on review cleanup rather than additional shell refactors.
+
+#### Actions Taken
+- Converted the active planning, engineering, README, and local-seed documentation links from machine-local `/Users/...` targets to repo-relative links.
+- Left historical session-log command paths intact because those entries describe prior local validation commands rather than navigable documentation.
+- Updated `docs/engineering/i18n.md` to record that FundLoop is on Next.js 16 and intentionally uses the active `proxy.ts` convention rather than adding deprecated `middleware.ts`.
+- Hardened `lib/navigation-context.ts` so Supabase read errors are no longer silently ignored.
+- Added explicit navigation-context logging for auth, profile, CUBID snapshot, participant, organization, project, interest, occupation, and location reads.
+- Kept navigation fallbacks conservative when reads fail so the app shell can still render while avoiding inflated founder/admin/project access from partial data.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed
+- `rg -n '/Users/botmaster/src/fundloop|/Users/' README.md agent-context docs i18n proxy.ts lib/navigation-context.ts` now only reports historical session-log entries.
+
+#### Reflections
+- The middleware review note was correct for older Next.js versions but stale for this repo’s Next.js 16 baseline. Documenting the convention is safer than adding a conflicting `middleware.ts`.
+- Navigation context should stay resilient, but explicit logging gives future agents and operators a trail when role-aware shell state falls back because a read failed.
+
+#### Suggested Next Steps
+- Reply to and resolve the eight PR #19 review threads with this commit reference.
+- Continue the same review-fix-resolve loop with the outstanding PR #20 comments.
+
 ### session v54: Address PR 18 payment and onchain reconciliation review comments
 - timestamp: 2026-04-17T20:08:59-0400
 - agent: **Codex (GPT-5)**
 - branch: **codex/address-wallet-review-comments**
-- head: TBD
+- head: 36cfd26
 
 #### Objective
 Address the outstanding review threads from PR #18 after the wallet payments and Edge Function groundwork was approved and merged, without reopening the original stacked branch.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,8 +1,39 @@
+### session v57: Address PR 21 CUBID onboarding review comments
+- timestamp: 2026-04-17T20:25:13-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/address-wallet-review-comments**
+- head: TBD
+
+#### Objective
+Address the outstanding review threads from PR #21 after the CUBID onboarding work merged, focusing on trust-boundary fixes and reproducible dependency cleanup.
+
+#### Actions Taken
+- Removed internal session-planning wording from the CUBID browser bridge unsupported-operation error.
+- Verified the outdated package and lockfile comments were already addressed on the merged tip by switching `@cubid/*` dependencies to repo-vendored tarballs under `vendor/cubid/`.
+- Extended the shared Edge Function command runtime to return the authenticated Supabase client alongside the service-role client.
+- Changed `project-onboarding-publish` so the project publish RPC runs through the authenticated client while privileged reads/writes remain on the admin client.
+- Added an optional `rpcSupabase` command input for `executeProjectOnboardingPublishCommand(...)` and covered that handoff in command tests.
+- Preserved existing `users.invited_by_code` during user publish when the draft does not provide a new invite code.
+- Enforced signed-in email matching in the CUBID resolve and sync Edge Functions so client-provided email overrides cannot link or sync another email identity.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/project-onboarding-commands.test.ts tests/user-onboarding-commands.test.ts tests/onboarding-edge-adapters.test.ts tests/cubid-resolve-email-command.test.ts tests/cubid-read-model.test.ts` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed
+
+#### Reflections
+- The project publish path now preserves the intended split: service role for privileged server-owned data access, user JWT for the RPC that depends on `auth.uid()`.
+- The CUBID email guard is deliberately duplicated across resolve and sync because both are user-facing identity writes and should share the same trust boundary.
+
+#### Suggested Next Steps
+- Reply to and resolve the seven PR #21 review threads with the relevant commit references.
+- Open a fresh cleanup PR from `codex/address-wallet-review-comments` into `dev` after all review threads are closed.
+
 ### session v56: Address PR 20 public discovery review comments
 - timestamp: 2026-04-17T20:22:03-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/address-wallet-review-comments**
-- head: TBD
+- head: f4ce96d
 
 #### Objective
 Address the outstanding review threads from PR #20 after the public funnel and discovery work merged, focusing on truthful public rendering and consistent discovery semantics.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,10 +1,38 @@
----
+### session v56: Address PR 20 public discovery review comments
+- timestamp: 2026-04-17T20:22:03-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/address-wallet-review-comments**
+- head: TBD
+
+#### Objective
+Address the outstanding review threads from PR #20 after the public funnel and discovery work merged, focusing on truthful public rendering and consistent discovery semantics.
+
+#### Actions Taken
+- Removed the stray opening YAML frontmatter delimiter from `agent-context/session-log.md` so the log renders as normal Markdown.
+- Updated public project participant totals to count only active users, matching project detail visibility.
+- Reworked public user-directory project slug derivation to use a precomputed `projectId -> slug` map instead of filtering all projects for every user.
+- Added an all-project membership guard so the users directory only includes active public users who participate in at least one public project.
+- Changed the FAQ closing CTA eyebrow to a dedicated localized CTA label instead of reusing the hero eyebrow.
+- Changed blog-post rendering so missing publish/create timestamps show an explicit pending publication label rather than pretending the post was published today.
+- Noted that the PR #20 doc-link comments were already fixed by the preceding PR #19 cleanup commit, `7a53688`.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed
+
+#### Reflections
+- The directory count and membership fixes keep list and detail pages aligned around the same public/active participation rules.
+- The blog timestamp fallback was a small but important honesty fix: no fabricated dates, even for edge-case content.
+
+#### Suggested Next Steps
+- Reply to and resolve the nine PR #20 review threads with the relevant commit references.
+- Continue the same review-fix-resolve loop with the outstanding PR #21 comments.
 
 ### session v55: Address PR 19 shell and planning-doc review comments
 - timestamp: 2026-04-17T20:19:02-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/address-wallet-review-comments**
-- head: TBD
+- head: 7a53688
 
 #### Objective
 Address the outstanding review threads from PR #19 after the app-shell and locale-routing work merged, keeping the fixes focused on review cleanup rather than additional shell refactors.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,8 +1,37 @@
+### session v58: Address PR 22 reconciliation RPC review comments
+- timestamp: 2026-04-19T21:54:03-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/address-wallet-review-comments**
+- head: TBD
+
+#### Objective
+Address the first review pass on PR #22 after the cleanup branch was opened against `dev`, focusing on the reconciliation finalizer RPC security and session-log metadata.
+
+#### Actions Taken
+- Changed `public.finalize_onchain_payment_reconciliation(...)` from `SECURITY DEFINER` to `SECURITY INVOKER`.
+- Added an explicit `auth.role() = 'service_role'` guard so broad function execution grants cannot mutate payment or submission state.
+- Added function-level grants that revoke execution from broad roles and grant execution only to `service_role`.
+- Matched `p_payment_status_id` to the schema `integer` type used by `payments.status_id`.
+- Tightened the submission update so the target submission must be linked to the provided payment id before either terminal update proceeds.
+- Replaced the stale `head: TBD` in the prior session-log entry with the actual `07d8bf8` commit hash.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/onchain-reconciliation-route.test.ts tests/payment-reconciliation.test.ts tests/project-payment-observability-actions.test.ts` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed
+
+#### Reflections
+- The RPC is still the right transaction boundary, but the privilege model needed to be explicit because SQL functions can outlive the assumptions of their initial app caller.
+
+#### Suggested Next Steps
+- Reply to and resolve the PR #22 Copilot/Codex review threads with this commit reference.
+- Request a fresh `@Codex review` after the current review threads are closed and CI is green.
+
 ### session v57: Address PR 21 CUBID onboarding review comments
 - timestamp: 2026-04-17T20:25:13-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/address-wallet-review-comments**
-- head: TBD
+- head: 07d8bf8
 
 #### Objective
 Address the outstanding review threads from PR #21 after the CUBID onboarding work merged, focusing on trust-boundary fixes and reproducible dependency cleanup.

--- a/agent-context/target-state-architecture.md
+++ b/agent-context/target-state-architecture.md
@@ -3,10 +3,10 @@
 Last drafted: 2026-04-14
 
 Related planning docs:
-- [Agent Context Index](/Users/botmaster/src/fundloop/agent-context/README.md)
-- [Backgrounder for Agents](/Users/botmaster/src/fundloop/agent-context/backgrounder-for-agents.md)
-- [Current-State Architecture](/Users/botmaster/src/fundloop/agent-context/current-state-architecture.md)
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [Agent Context Index](./README.md)
+- [Backgrounder for Agents](./backgrounder-for-agents.md)
+- [Current-State Architecture](./current-state-architecture.md)
+- [TODO Roadmap](./todo.md)
 
 ## 1. North Star
 

--- a/app/[locale]/(public)/blog/[slug]/page.tsx
+++ b/app/[locale]/(public)/blog/[slug]/page.tsx
@@ -56,6 +56,7 @@ export default async function BlogPostPage({ params, searchParams }: PageProps) 
 
   const backHref = origin === "benefits" ? "/" : "/blog"
   const backText = origin === "benefits" ? t("backToHome") : t("backToBlog")
+  const publishedDate = post.publishedAt ?? post.createdAt
 
   return (
     <MarketingPage>
@@ -77,7 +78,7 @@ export default async function BlogPostPage({ params, searchParams }: PageProps) 
       <MarketingSection className="pt-0">
         <div className="mx-auto max-w-4xl">
           <Reveal>
-            <SectionEyebrow>{t("publishedLabel", { date: formatDate(locale, post.publishedAt ?? post.createdAt ?? new Date().toISOString()) })}</SectionEyebrow>
+            <SectionEyebrow>{publishedDate ? t("publishedLabel", { date: formatDate(locale, publishedDate) }) : t("unpublishedLabel")}</SectionEyebrow>
             <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl lg:text-7xl">{post.title}</SectionTitle>
             {post.subtitle ? <SectionBody className="mt-6 max-w-3xl">{post.subtitle}</SectionBody> : null}
           </Reveal>

--- a/app/[locale]/(public)/faq/page.tsx
+++ b/app/[locale]/(public)/faq/page.tsx
@@ -130,7 +130,7 @@ export default async function FAQPage({ params }: PageProps) {
       <MarketingSection className="pb-24 pt-14">
         <Reveal>
           <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
-            <SectionEyebrow>{t("hero.eyebrow")}</SectionEyebrow>
+            <SectionEyebrow>{t("cta.eyebrow")}</SectionEyebrow>
             <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl">{t("cta.title")}</SectionTitle>
             <SectionBody className="mt-5 max-w-3xl">{t("cta.body")}</SectionBody>
             <div className="mt-8 flex flex-col gap-4 sm:flex-row">

--- a/app/actions/project-payment-actions.ts
+++ b/app/actions/project-payment-actions.ts
@@ -1080,7 +1080,7 @@ export async function recordOnchainPaymentSubmission(
 
   const [{ data: payment }, { data: paymentMethod }, { data: awaitingStatus }, { data: unresolvedSubmission }] =
     await Promise.all([
-      supabase.from("payments").select("id, project_id, notes").eq("id", input.paymentId).single(),
+      supabase.from("payments").select("id, project_id, payment_amount, notes").eq("id", input.paymentId).single(),
       supabase
         .from("payment_methods")
         .select(`
@@ -1232,6 +1232,47 @@ export async function recordOnchainPaymentSubmission(
       error: "Payment amount is invalid",
     })
     return { ok: false, error: "Payment amount is invalid" }
+  }
+
+  const expectedAmount = Number(payment.payment_amount)
+  if (!Number.isFinite(expectedAmount) || expectedAmount <= 0) {
+    await recordActionObservabilityEvent({
+      flow: "receipt_recording",
+      stage: "submission_record",
+      outcome: "failure",
+      attemptId,
+      actorUserId: context.data.userId,
+      actorRole: "project_admin",
+      projectId: context.data.project.id,
+      paymentId: input.paymentId,
+      paymentMethodId: input.paymentMethodId,
+      txHash: input.txHash,
+      walletAddress: input.walletAddress,
+      error: "Canonical payment amount is invalid",
+    })
+    return { ok: false, error: "Canonical payment amount is invalid" }
+  }
+
+  if (Math.abs(amountDecimal - expectedAmount) > 0.000001) {
+    await recordActionObservabilityEvent({
+      flow: "receipt_recording",
+      stage: "submission_record",
+      outcome: "failure",
+      attemptId,
+      actorUserId: context.data.userId,
+      actorRole: "project_admin",
+      projectId: context.data.project.id,
+      paymentId: input.paymentId,
+      paymentMethodId: input.paymentMethodId,
+      txHash: input.txHash,
+      walletAddress: input.walletAddress,
+      error: "Submitted onchain amount does not match the payment amount",
+      metadata: {
+        expectedAmount,
+        submittedAmount: amountDecimal,
+      },
+    })
+    return { ok: false, error: "Submitted onchain amount does not match the payment amount" }
   }
 
   if (!Number.isInteger(input.periodId) || input.periodId < 0 || input.periodId > 12) {

--- a/app/api/internal/payments/reconcile-onchain/route.ts
+++ b/app/api/internal/payments/reconcile-onchain/route.ts
@@ -10,6 +10,66 @@ function getRequestSecret(request: Request) {
   return request.headers.get("x-fundloop-cron-secret")?.trim() ?? null
 }
 
+type ReconciliationRequestBody = {
+  limit?: number
+  paymentId?: number
+  submissionId?: number
+}
+
+function parseOptionalPositiveInteger(value: unknown, field: string) {
+  if (value === undefined || value === null || value === "") {
+    return { ok: true as const, value: undefined }
+  }
+
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : Number.NaN
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return {
+      ok: false as const,
+      error: `${field} must be a positive integer.`,
+    }
+  }
+
+  return { ok: true as const, value: parsed }
+}
+
+function parseRequestBody(value: unknown) {
+  if (value === undefined || value === null) {
+    return { ok: true as const, value: {} satisfies ReconciliationRequestBody }
+  }
+
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return {
+      ok: false as const,
+      error: "Request body must be a JSON object.",
+    }
+  }
+
+  const body = value as Record<string, unknown>
+  const limit = parseOptionalPositiveInteger(body.limit, "limit")
+  if (!limit.ok) {
+    return limit
+  }
+
+  const paymentId = parseOptionalPositiveInteger(body.paymentId, "paymentId")
+  if (!paymentId.ok) {
+    return paymentId
+  }
+
+  const submissionId = parseOptionalPositiveInteger(body.submissionId, "submissionId")
+  if (!submissionId.ok) {
+    return submissionId
+  }
+
+  return {
+    ok: true as const,
+    value: {
+      limit: limit.value,
+      paymentId: paymentId.value,
+      submissionId: submissionId.value,
+    } satisfies ReconciliationRequestBody,
+  }
+}
+
 export async function POST(request: Request) {
   const configuredSecret = process.env.FUNDLOOP_PAYMENTS_CRON_SECRET?.trim()
   if (!configuredSecret) {
@@ -33,19 +93,30 @@ export async function POST(request: Request) {
     )
   }
 
-  let body: { limit?: number; paymentId?: number; submissionId?: number } = {}
+  let rawBody: unknown = undefined
   try {
-    body = (await request.json()) as typeof body
+    rawBody = await request.json()
   } catch {
-    body = {}
+    rawBody = undefined
+  }
+
+  const body = parseRequestBody(rawBody)
+  if (!body.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: body.error,
+      },
+      { status: 400 },
+    )
   }
 
   try {
     const summary = await runOnchainPaymentReconciliation({
       source: "cron",
-      limit: body.limit,
-      paymentId: body.paymentId,
-      submissionId: body.submissionId,
+      limit: body.value.limit,
+      paymentId: body.value.paymentId,
+      submissionId: body.value.submissionId,
     })
 
     return NextResponse.json({

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -11,13 +11,13 @@ Use this directory for material that should outlive a single agent session, incl
 
 Current high-signal docs:
 
-- [CUBID Identity and Snapshot Model](/Users/botmaster/src/fundloop/docs/engineering/cubid-identity.md)
-- [Design Tokens](/Users/botmaster/src/fundloop/docs/engineering/design-tokens.md)
+- [CUBID Identity and Snapshot Model](./cubid-identity.md)
+- [Design Tokens](./design-tokens.md)
 - [Edge Function Contract Pattern](./edge-functions.md)
-- [Information Architecture](/Users/botmaster/src/fundloop/docs/engineering/information-architecture.md)
-- [Internationalization](/Users/botmaster/src/fundloop/docs/engineering/i18n.md)
-- [Local Seed Fixtures](/Users/botmaster/src/fundloop/docs/engineering/local-seed.md)
-- [Navigation and Shell Architecture](/Users/botmaster/src/fundloop/docs/engineering/navigation-shell.md)
-- [Route Inventory](/Users/botmaster/src/fundloop/docs/engineering/route-inventory.md)
+- [Information Architecture](./information-architecture.md)
+- [Internationalization](./i18n.md)
+- [Local Seed Fixtures](./local-seed.md)
+- [Navigation and Shell Architecture](./navigation-shell.md)
+- [Route Inventory](./route-inventory.md)
 
-Agent-only live context still belongs in [agent-context](/Users/botmaster/src/fundloop/agent-context/README.md).
+Agent-only live context still belongs in [agent-context](../../agent-context/README.md).

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -13,7 +13,7 @@ Current high-signal docs:
 
 - [CUBID Identity and Snapshot Model](/Users/botmaster/src/fundloop/docs/engineering/cubid-identity.md)
 - [Design Tokens](/Users/botmaster/src/fundloop/docs/engineering/design-tokens.md)
-- [Edge Function Contract Pattern](/Users/botmaster/src/fundloop/docs/engineering/edge-functions.md)
+- [Edge Function Contract Pattern](./edge-functions.md)
 - [Information Architecture](/Users/botmaster/src/fundloop/docs/engineering/information-architecture.md)
 - [Internationalization](/Users/botmaster/src/fundloop/docs/engineering/i18n.md)
 - [Local Seed Fixtures](/Users/botmaster/src/fundloop/docs/engineering/local-seed.md)

--- a/docs/engineering/design-tokens.md
+++ b/docs/engineering/design-tokens.md
@@ -10,7 +10,7 @@ Session 07 establishes the shared token model for FundLoop’s light and dark th
 
 ## Token families
 
-Primary token definitions live in [app/globals.css](/Users/botmaster/src/fundloop/app/globals.css).
+Primary token definitions live in [app/globals.css](../../app/globals.css).
 
 ### Core shadcn-compatible tokens
 
@@ -77,16 +77,16 @@ Use these for shared marketing/layout primitives so spacing and typography stay 
 
 Shared primitives that should consume the token system first:
 
-- [components/ui/button.tsx](/Users/botmaster/src/fundloop/components/ui/button.tsx)
-- [components/ui/card.tsx](/Users/botmaster/src/fundloop/components/ui/card.tsx)
-- [components/ui/input.tsx](/Users/botmaster/src/fundloop/components/ui/input.tsx)
-- [components/ui/textarea.tsx](/Users/botmaster/src/fundloop/components/ui/textarea.tsx)
-- [components/ui/select.tsx](/Users/botmaster/src/fundloop/components/ui/select.tsx)
-- [components/marketing/page-chrome.tsx](/Users/botmaster/src/fundloop/components/marketing/page-chrome.tsx)
+- [components/ui/button.tsx](../../components/ui/button.tsx)
+- [components/ui/card.tsx](../../components/ui/card.tsx)
+- [components/ui/input.tsx](../../components/ui/input.tsx)
+- [components/ui/textarea.tsx](../../components/ui/textarea.tsx)
+- [components/ui/select.tsx](../../components/ui/select.tsx)
+- [components/marketing/page-chrome.tsx](../../components/marketing/page-chrome.tsx)
 
 ## Practical rules
 
 - Prefer semantic token variables over raw palette classes for shared UI.
 - Keep page-level exceptions localized; if the same styling appears more than twice, promote it into the shared token system or primitive layer.
 - Preserve strong contrast in both themes before introducing additional accent colors or decorative surfaces.
-- When architecture or theming assumptions change, update this doc and [docs/engineering/README.md](/Users/botmaster/src/fundloop/docs/engineering/README.md) before closing the task.
+- When architecture or theming assumptions change, update this doc and [docs/engineering/README.md](./README.md) before closing the task.

--- a/docs/engineering/i18n.md
+++ b/docs/engineering/i18n.md
@@ -14,16 +14,18 @@ FundLoop now uses `next-intl` as the standard localization layer for the Next.js
 
 ## Routing and middleware
 
-- locale routing is defined in [i18n/routing.ts](/Users/botmaster/src/fundloop/i18n/routing.ts)
-- locale-aware navigation helpers live in [i18n/navigation.ts](/Users/botmaster/src/fundloop/i18n/navigation.ts)
-- request-time message loading lives in [i18n/request.ts](/Users/botmaster/src/fundloop/i18n/request.ts)
-- root redirect and locale-prefix enforcement live in [proxy.ts](/Users/botmaster/src/fundloop/proxy.ts)
+- locale routing is defined in [i18n/routing.ts](../../i18n/routing.ts)
+- locale-aware navigation helpers live in [i18n/navigation.ts](../../i18n/navigation.ts)
+- request-time message loading lives in [i18n/request.ts](../../i18n/request.ts)
+- root redirect and locale-prefix enforcement live in [proxy.ts](../../proxy.ts)
+
+FundLoop is on Next.js 16, where `proxy.ts` is the active root request-interception convention and `middleware.ts` is deprecated. Do not add a parallel `middleware.ts`; Next rejects projects that define both conventions.
 
 Use the locale-aware `Link`, `useRouter`, and `usePathname` exports from `@/i18n/navigation` for internal navigation. Do not add new internal links with plain `next/link` unless the destination is intentionally external to locale routing.
 
 ## Dictionary layout and fallback
 
-Messages live under [i18n/messages](/Users/botmaster/src/fundloop/i18n/messages).
+Messages live under [i18n/messages](../../i18n/messages).
 
 Current domains:
 

--- a/docs/engineering/information-architecture.md
+++ b/docs/engineering/information-architecture.md
@@ -3,13 +3,13 @@
 Last reviewed: 2026-04-14
 
 Related planning docs:
-- [Engineering Docs Index](/Users/botmaster/src/fundloop/docs/engineering/README.md)
-- [Agent Context Index](/Users/botmaster/src/fundloop/agent-context/README.md)
-- [Backgrounder for Agents](/Users/botmaster/src/fundloop/agent-context/backgrounder-for-agents.md)
-- [Current-State Architecture](/Users/botmaster/src/fundloop/agent-context/current-state-architecture.md)
-- [Target-State Architecture](/Users/botmaster/src/fundloop/agent-context/target-state-architecture.md)
-- [Route Inventory](/Users/botmaster/src/fundloop/docs/engineering/route-inventory.md)
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [Engineering Docs Index](./README.md)
+- [Agent Context Index](../../agent-context/README.md)
+- [Backgrounder for Agents](../../agent-context/backgrounder-for-agents.md)
+- [Current-State Architecture](../../agent-context/current-state-architecture.md)
+- [Target-State Architecture](../../agent-context/target-state-architecture.md)
+- [Route Inventory](./route-inventory.md)
+- [TODO Roadmap](../../agent-context/todo.md)
 
 This document locks the target route model for FundLoop. It does not move routes yet. It defines which surfaces stay public, which authenticated surfaces converge into role-based workspaces, and where transitional current routes should land.
 

--- a/docs/engineering/local-seed.md
+++ b/docs/engineering/local-seed.md
@@ -1,6 +1,6 @@
 # Local Seed Fixtures
 
-FundLoop's tracked [`supabase/seed.sql`](/Users/botmaster/src/fundloop/supabase/seed.sql) remains the canonical local data seed, but it now includes a small deterministic public-discovery fixture set specifically for browser smoke tests and local UX validation.
+FundLoop's tracked [`supabase/seed.sql`](../../supabase/seed.sql) remains the canonical local data seed, but it now includes a small deterministic public-discovery fixture set specifically for browser smoke tests and local UX validation.
 
 Use these fixtures after `supabase db reset` when you want predictable public pages:
 

--- a/docs/engineering/route-inventory.md
+++ b/docs/engineering/route-inventory.md
@@ -3,12 +3,12 @@
 Last reviewed: 2026-04-15
 
 Related planning docs:
-- [Engineering Docs Index](/Users/botmaster/src/fundloop/docs/engineering/README.md)
-- [Agent Context Index](/Users/botmaster/src/fundloop/agent-context/README.md)
-- [Current-State Architecture](/Users/botmaster/src/fundloop/agent-context/current-state-architecture.md)
-- [Target-State Architecture](/Users/botmaster/src/fundloop/agent-context/target-state-architecture.md)
-- [Information Architecture](/Users/botmaster/src/fundloop/docs/engineering/information-architecture.md)
-- [TODO Roadmap](/Users/botmaster/src/fundloop/agent-context/todo.md)
+- [Engineering Docs Index](./README.md)
+- [Agent Context Index](../../agent-context/README.md)
+- [Current-State Architecture](../../agent-context/current-state-architecture.md)
+- [Target-State Architecture](../../agent-context/target-state-architecture.md)
+- [Information Architecture](./information-architecture.md)
+- [TODO Roadmap](../../agent-context/todo.md)
 
 This inventory covers every current `page.tsx` and `route.ts` surface under `app/`. Each entry records who the surface is for, its current state, the evidence that matters for planning, the intended disposition, the canonical future destination, and the roadmap session that should absorb the work.
 

--- a/i18n/messages/en.ts
+++ b/i18n/messages/en.ts
@@ -1221,6 +1221,7 @@ export const enMessages = {
     missingTitle: "Article not found",
     missingBody: "The blog post you requested does not exist or is no longer published.",
     publishedLabel: "Published {date}",
+    unpublishedLabel: "Publication date pending",
   },
   ecosystemPage: {
     backToHome: "Back to home",
@@ -1333,6 +1334,7 @@ export const enMessages = {
       },
     },
     cta: {
+      eyebrow: "Next steps",
       title: "Still need help?",
       body: "The next best stop is participation, the founder path, or support, depending on what you are trying to resolve.",
       participation: "View participation",

--- a/i18n/messages/es.ts
+++ b/i18n/messages/es.ts
@@ -1083,6 +1083,7 @@ export const esMessages = {
     missingTitle: "Artículo no encontrado",
     missingBody: "El artículo solicitado no existe o ya no está publicado.",
     publishedLabel: "Publicado el {date}",
+    unpublishedLabel: "Fecha de publicación pendiente",
   },
   ecosystemPage: {
     backToHome: "Volver al inicio",
@@ -1103,6 +1104,7 @@ export const esMessages = {
         "La versión corta sigue siendo simple: los usuarios no pagan por unirse, los proyectos alineados sostienen el loop cuando existe valor para compartir, y FundLoop está construyendo infraestructura de producto para una participación más justa.",
     },
     cta: {
+      eyebrow: "Próximos pasos",
       title: "¿Todavía necesitas ayuda?",
       body: "La siguiente mejor parada depende del tema: participación, ruta de fundadores o soporte.",
       participation: "Ver participación",

--- a/i18n/messages/fr.ts
+++ b/i18n/messages/fr.ts
@@ -1083,6 +1083,7 @@ export const frMessages = {
     missingTitle: "Article introuvable",
     missingBody: "L’article demandé n’existe pas ou n’est plus publié.",
     publishedLabel: "Publié le {date}",
+    unpublishedLabel: "Date de publication en attente",
   },
   ecosystemPage: {
     backToHome: "Retour à l’accueil",
@@ -1103,6 +1104,7 @@ export const frMessages = {
         "La version courte reste simple : les utilisateurs ne paient pas pour rejoindre, les projets alignés soutiennent la boucle lorsque la valeur existe, et FundLoop construit une infrastructure produit pour une participation plus juste.",
     },
     cta: {
+      eyebrow: "Prochaines étapes",
       title: "Vous avez encore besoin d’aide ?",
       body: "La prochaine meilleure étape dépend du sujet : participation, parcours fondateur ou support.",
       participation: "Voir la participation",

--- a/lib/cubid/browser-web2-client.ts
+++ b/lib/cubid/browser-web2-client.ts
@@ -15,7 +15,7 @@ import type {
 
 function unsupportedPromise<T>() {
   return Promise.reject<T>(
-    new Error("This CUBID browser bridge only supports phone OTP and stamp persistence in Session 14."),
+    new Error("This CUBID browser bridge only supports phone OTP and stamp persistence."),
   )
 }
 

--- a/lib/navigation-context.ts
+++ b/lib/navigation-context.ts
@@ -105,6 +105,13 @@ type UserProfileRow = {
   cubid_score: number | null
 }
 
+type NavigationQueryError = {
+  message?: string
+  code?: string
+  details?: string
+  hint?: string
+}
+
 function emptyNavigationContext(): NavigationContext {
   return {
     user: null,
@@ -118,11 +125,28 @@ function emptyNavigationContext(): NavigationContext {
   }
 }
 
+function logNavigationContextError(label: string, error: NavigationQueryError | null | undefined) {
+  if (!error) {
+    return
+  }
+
+  console.warn("[navigation-context] Supabase read failed", {
+    label,
+    message: error.message,
+    code: error.code,
+    details: error.details,
+    hint: error.hint,
+  })
+}
+
 export const getNavigationContext = cache(async (): Promise<NavigationContext> => {
   const supabase = await createServerSupabaseClient()
   const {
     data: { user: authUser },
+    error: authError,
   } = await supabase.auth.getUser()
+
+  logNavigationContextError("auth.getUser", authError)
 
   if (!authUser) {
     return emptyNavigationContext()
@@ -138,8 +162,7 @@ export const getNavigationContext = cache(async (): Promise<NavigationContext> =
     }
   })()
 
-  const [{ data: profile }, { data: cubidSnapshot }, { count: interestCount }, { data: participantRows }, { data: founderRoles }] =
-    await Promise.all([
+  const [profileResult, cubidSnapshotResult, interestCountResult, participantRowsResult, founderRolesResult] = await Promise.all([
     roleAwareSupabase
       .from("users")
       .select(
@@ -153,10 +176,21 @@ export const getNavigationContext = cache(async (): Promise<NavigationContext> =
     roleAwareSupabase.from("ref_roles").select("id").in("name", ["Founder", "Admin"]),
   ])
 
+  logNavigationContextError("users.profile", profileResult.error)
+  logNavigationContextError("cubid_identity_snapshots", cubidSnapshotResult.error)
+  logNavigationContextError("user_interests.count", interestCountResult.error)
+  logNavigationContextError("participants.admin_projects", participantRowsResult.error)
+  logNavigationContextError("ref_roles.founder_admin", founderRolesResult.error)
+
+  const profile = profileResult.data ?? null
+  const cubidSnapshot = cubidSnapshotResult.data ?? null
+  const interestCount = interestCountResult.count ?? 0
+  const participantRows = participantRowsResult.error ? [] : (participantRowsResult.data ?? [])
+  const founderRoles = founderRolesResult.error ? [] : (founderRolesResult.data ?? [])
   const participantProjectIds = Array.from(new Set((participantRows ?? []).map((row) => row.project_id)))
   const founderRoleIds = ((founderRoles as RoleRow[] | null) ?? []).map((role) => role.id)
 
-  const { data: organizationMemberships } =
+  const organizationMembershipsResult =
     founderRoleIds.length > 0
       ? await roleAwareSupabase
           .from("organization_members")
@@ -164,21 +198,28 @@ export const getNavigationContext = cache(async (): Promise<NavigationContext> =
           .eq("user_id", authUser.id)
           .eq("status", "active")
           .in("role_id", founderRoleIds)
-      : { data: [] as { organization_id: number }[] }
+      : { data: [] as { organization_id: number }[], error: null }
+  logNavigationContextError("organization_members.founder_roles", organizationMembershipsResult.error)
+  const organizationMemberships = organizationMembershipsResult.error ? [] : (organizationMembershipsResult.data ?? [])
 
   const organizationIds = Array.from(new Set((organizationMemberships ?? []).map((row) => row.organization_id)))
 
   const [participantProjectsResult, organizationProjectsResult] = await Promise.all([
     participantProjectIds.length > 0
       ? roleAwareSupabase.from("projects").select("id, slug, name, organization_id").in("id", participantProjectIds)
-      : Promise.resolve({ data: [] as ProjectRow[] }),
+      : Promise.resolve({ data: [] as ProjectRow[], error: null }),
     organizationIds.length > 0
       ? roleAwareSupabase.from("projects").select("id, slug, name, organization_id").in("organization_id", organizationIds)
-      : Promise.resolve({ data: [] as ProjectRow[] }),
+      : Promise.resolve({ data: [] as ProjectRow[], error: null }),
   ])
+  logNavigationContextError("projects.participant_managed", participantProjectsResult.error)
+  logNavigationContextError("projects.organization_managed", organizationProjectsResult.error)
 
   const managedProjectsMap = new Map<number, ManagedProjectSummary>()
-  for (const project of [...(participantProjectsResult.data ?? []), ...(organizationProjectsResult.data ?? [])]) {
+  for (const project of [
+    ...(participantProjectsResult.error ? [] : (participantProjectsResult.data ?? [])),
+    ...(organizationProjectsResult.error ? [] : (organizationProjectsResult.data ?? [])),
+  ]) {
     managedProjectsMap.set(project.id, {
       id: project.id,
       slug: project.slug,
@@ -192,24 +233,32 @@ export const getNavigationContext = cache(async (): Promise<NavigationContext> =
   const locationRowPromise =
     profile?.location_id !== null && profile?.location_id !== undefined
       ? roleAwareSupabase.from("ref_locations").select("name").eq("id", profile.location_id).maybeSingle<{ name: string }>()
-      : Promise.resolve({ data: null as { name: string } | null })
+      : Promise.resolve({ data: null as { name: string } | null, error: null })
   const occupationRowPromise =
     profile?.occupation_id !== null && profile?.occupation_id !== undefined
       ? roleAwareSupabase.from("ref_occupations").select("name").eq("id", profile.occupation_id).maybeSingle<{ name: string }>()
-      : Promise.resolve({ data: null as { name: string } | null })
+      : Promise.resolve({ data: null as { name: string } | null, error: null })
 
-  const [{ data: interestRows }, { data: locationRow }, { data: occupationRow }] = await Promise.all([
+  const [interestRowsResult, locationRowResult, occupationRowResult] = await Promise.all([
     interestRowsPromise,
     locationRowPromise,
     occupationRowPromise,
   ])
+  logNavigationContextError("user_interests.rows", interestRowsResult.error)
+  logNavigationContextError("ref_locations.profile_location", locationRowResult.error)
+  logNavigationContextError("ref_occupations.profile_occupation", occupationRowResult.error)
 
-  const interestIds = (interestRows ?? []).map((row) => row.interest_id)
-  const { data: interestRefRows } =
+  const interestRows = interestRowsResult.error ? [] : (interestRowsResult.data ?? [])
+  const locationRow = locationRowResult.error ? null : locationRowResult.data
+  const occupationRow = occupationRowResult.error ? null : occupationRowResult.data
+  const interestIds = interestRows.map((row) => row.interest_id)
+  const interestRefRowsResult =
     interestIds.length > 0
       ? await roleAwareSupabase.from("ref_interests").select("id, name").in("id", interestIds)
-      : { data: [] as { id: number; name: string }[] }
-  const interestNameMap = new Map((interestRefRows ?? []).map((row) => [row.id, row.name]))
+      : { data: [] as { id: number; name: string }[], error: null }
+  logNavigationContextError("ref_interests.profile_interests", interestRefRowsResult.error)
+  const interestRefRows = interestRefRowsResult.error ? [] : (interestRefRowsResult.data ?? [])
+  const interestNameMap = new Map(interestRefRows.map((row) => [row.id, row.name]))
   const interestNames = interestIds.map((interestId) => interestNameMap.get(interestId)).filter((value): value is string => Boolean(value))
 
   const cubidReadModel = buildCubidIdentityReadModel(

--- a/lib/onboarding/project-onboarding-commands.ts
+++ b/lib/onboarding/project-onboarding-commands.ts
@@ -34,6 +34,7 @@ type ProjectDraftClearInput = {
 
 type ProjectPublishInput = {
   actorUserId: string
+  rpcSupabase?: OnboardingCommandClient
 }
 
 type ProjectCommandFailure<TCode extends string> = {
@@ -192,7 +193,8 @@ export async function executeProjectOnboardingPublishCommand(
     }
   }
 
-  const { data: publishedProject, error: publishError } = await supabase
+  const rpcSupabase = input.rpcSupabase ?? supabase
+  const { data: publishedProject, error: publishError } = await rpcSupabase
     .rpc("publish_project_onboarding_draft_atomic", {
       p_name: payload.name.trim(),
       p_slug: payload.slug.trim(),

--- a/lib/onboarding/user-onboarding-commands.ts
+++ b/lib/onboarding/user-onboarding-commands.ts
@@ -148,6 +148,9 @@ export async function executeUserOnboardingPublishCommand(
     )
   }
 
+  const inviteCode = payload.inviteCode.trim()
+  const invitedByCode = existingProfile.invited_by_code ?? (inviteCode || null)
+
   const { error: updateError } = await supabase
     .from("users")
     .update({
@@ -160,7 +163,7 @@ export async function executeUserOnboardingPublishCommand(
       gender_id: genderId,
       profile_headline: payload.profileHeadline.trim() || null,
       email: input.actorEmail ?? null,
-      invited_by_code: payload.inviteCode.trim() || null,
+      invited_by_code: invitedByCode,
       is_public: payload.visibility.isPublic,
       is_name_public: payload.visibility.isNamePublic,
       is_pfp_public: payload.visibility.isPfpPublic,
@@ -199,18 +202,18 @@ export async function executeUserOnboardingPublishCommand(
     }
   }
 
-  if (payload.inviteCode.trim() && !existingProfile?.invited_by_code) {
+  if (inviteCode && !existingProfile?.invited_by_code) {
     const { data: inviteRow } = await supabase
       .from("invitation_codes")
       .select("usage_count")
-      .eq("code", payload.inviteCode.trim())
+      .eq("code", inviteCode)
       .single()
 
     if (inviteRow) {
       await supabase
         .from("invitation_codes")
         .update({ usage_count: inviteRow.usage_count + 1 })
-        .eq("code", payload.inviteCode.trim())
+        .eq("code", inviteCode)
     }
   }
 

--- a/lib/onchain/payment-reconciliation.ts
+++ b/lib/onchain/payment-reconciliation.ts
@@ -12,7 +12,7 @@ import {
   type OnchainSubmissionSummary,
 } from "@/lib/onchain/payment-submissions"
 import { getAdminSupabaseClient } from "@/lib/supabase-admin"
-import type { Tables, TablesUpdate } from "@/types/supabase"
+import type { Tables } from "@/types/supabase"
 
 export type ReconciliationRunSource = "cron" | "admin_manual"
 
@@ -426,79 +426,44 @@ async function updateSubmissionAndPayment(
     } satisfies ReconciliationOutcome
   }
 
-  const submissionUpdate: TablesUpdate<"onchain_payment_submissions"> = {
-    status: evaluation.status,
-    last_checked_at: checkedAt,
-    confirmation_count: evaluation.confirmationCount,
-    matched_log_index: evaluation.matchedLogIndex,
-    failure_code: evaluation.failureCode,
-    failure_reason: evaluation.failureReason,
-  }
+  const submissionConfirmedAt = evaluation.status === "confirmed" ? checkedAt : null
+  const submissionReconciledAt = evaluation.status === "confirmed" || evaluation.status === "failed" ? checkedAt : null
+  const paymentStatusId =
+    row.payment_id === null
+      ? null
+      : evaluation.status === "confirmed"
+        ? paymentStatusIds.confirmed
+        : evaluation.status === "failed"
+          ? paymentStatusIds.failed
+          : paymentStatusIds.awaitingConfirmation
+  const paymentConfirmedAt = evaluation.status === "confirmed" ? checkedAt : null
+  const paymentNote =
+    evaluation.status === "failed"
+      ? appendPaymentNote(
+          row.payments?.notes,
+          `Onchain reconciliation failed: ${formatFailureMessage(evaluation.failureCode, evaluation.failureReason)}`,
+        )
+      : null
 
-  if (evaluation.status === "confirmed") {
-    submissionUpdate.confirmed_at = checkedAt
-    submissionUpdate.reconciled_at = checkedAt
-  }
+  const { error: finalizeError } = await supabase.rpc("finalize_onchain_payment_reconciliation", {
+    p_submission_id: row.id,
+    p_payment_id: row.payment_id,
+    p_submission_status: evaluation.status,
+    p_last_checked_at: checkedAt,
+    p_confirmation_count: evaluation.confirmationCount,
+    p_matched_log_index: evaluation.matchedLogIndex,
+    p_failure_code: evaluation.failureCode,
+    p_failure_reason: evaluation.failureReason,
+    p_submission_confirmed_at: submissionConfirmedAt,
+    p_submission_reconciled_at: submissionReconciledAt,
+    p_payment_status_id: paymentStatusId,
+    p_payment_confirmed_at: paymentConfirmedAt,
+    p_payment_note: paymentNote,
+    p_payment_updated_at: checkedAt,
+  })
 
-  if (evaluation.status === "failed") {
-    submissionUpdate.reconciled_at = checkedAt
-  }
-
-  const { error: submissionError } = await supabase
-    .from("onchain_payment_submissions")
-    .update(submissionUpdate)
-    .eq("id", row.id)
-
-  if (submissionError) {
-    throw new Error(submissionError.message)
-  }
-
-  if (row.payment_id !== null) {
-    if (evaluation.status === "confirmed") {
-      const { error: paymentError } = await supabase
-        .from("payments")
-        .update({
-          status_id: paymentStatusIds.confirmed,
-          confirmed_at: checkedAt,
-          updated_at: checkedAt,
-        })
-        .eq("id", row.payment_id)
-
-      if (paymentError) {
-        throw new Error(paymentError.message)
-      }
-    }
-
-    if (evaluation.status === "failed") {
-      const failureNote = formatFailureMessage(evaluation.failureCode, evaluation.failureReason)
-      const { error: paymentError } = await supabase
-        .from("payments")
-        .update({
-          status_id: paymentStatusIds.failed,
-          confirmed_at: null,
-          updated_at: checkedAt,
-          notes: appendPaymentNote(row.payments?.notes, `Onchain reconciliation failed: ${failureNote}`),
-        })
-        .eq("id", row.payment_id)
-
-      if (paymentError) {
-        throw new Error(paymentError.message)
-      }
-    }
-
-    if (evaluation.status === "confirming") {
-      const { error: paymentError } = await supabase
-        .from("payments")
-        .update({
-          status_id: paymentStatusIds.awaitingConfirmation,
-          updated_at: checkedAt,
-        })
-        .eq("id", row.payment_id)
-
-      if (paymentError) {
-        throw new Error(paymentError.message)
-      }
-    }
+  if (finalizeError) {
+    throw new Error(finalizeError.message)
   }
 
   return {

--- a/lib/public-discovery.ts
+++ b/lib/public-discovery.ts
@@ -140,7 +140,7 @@ export async function getPublicProjectsDirectoryData({
 
     const { data: participantRows, error: participantError } =
       projectIds.length > 0
-        ? await supabase.from("participants").select("project_id, user_id").in("project_id", projectIds)
+        ? await supabase.from("participants").select("project_id, user_id, users(status)").in("project_id", projectIds)
         : { data: [], error: null }
 
     if (participantError) {
@@ -149,6 +149,11 @@ export async function getPublicProjectsDirectoryData({
 
     const participantCounts = new Map<number, Set<string>>()
     for (const row of participantRows ?? []) {
+      const participantUser = row.users as { status?: string } | null
+      if (participantUser?.status !== "active") {
+        continue
+      }
+
       const current = participantCounts.get(row.project_id) ?? new Set<string>()
       current.add(row.user_id)
       participantCounts.set(row.project_id, current)
@@ -336,6 +341,7 @@ export async function getPublicUsersDirectoryData({
     }
 
     const locationMap = new Map((locationRows ?? []).map((location) => [location.id, location.name]))
+    const projectSlugById = new Map((publicProjects ?? []).map((project) => [project.id, project.slug ?? String(project.id)]))
     const participantProjectsByUser = new Map<string, Set<number>>()
 
     for (const row of participantRows ?? []) {
@@ -360,9 +366,7 @@ export async function getPublicUsersDirectoryData({
           createdAt: user.created_at,
           location: user.location_id ? locationMap.get(user.location_id) ?? null : null,
           projectCount: projectIdsForUser.length,
-          projectSlugs: (publicProjects ?? [])
-            .filter((project) => projectIdsForUser.includes(project.id))
-            .map((project) => project.slug ?? String(project.id)),
+          projectSlugs: projectIdsForUser.map((userProjectId) => projectSlugById.get(userProjectId)).filter((slug): slug is string => Boolean(slug)),
           cubidIdentityStatus: user.cubid_identity_status ?? "unlinked",
           cubidScore: user.cubid_score ?? null,
         }
@@ -372,7 +376,12 @@ export async function getPublicUsersDirectoryData({
           return false
         }
 
-        if (projectId && !(participantProjectsByUser.get(user.userId) ?? new Set<number>()).has(projectId)) {
+        const userProjectIds = participantProjectsByUser.get(user.userId) ?? new Set<number>()
+        if (projectId && !userProjectIds.has(projectId)) {
+          return false
+        }
+
+        if (!projectId && userProjectIds.size === 0) {
           return false
         }
 

--- a/supabase/functions/_shared/command-runtime.js
+++ b/supabase/functions/_shared/command-runtime.js
@@ -91,6 +91,7 @@ export async function authenticateRequest(request) {
 
   return {
     ok: true,
+    authClient: clients.authClient,
     adminClient: clients.adminClient,
     user,
   }

--- a/supabase/functions/project-onboarding-publish/index.js
+++ b/supabase/functions/project-onboarding-publish/index.js
@@ -25,6 +25,7 @@ async function handleRequest(request) {
 
   const result = await executeProjectOnboardingPublishCommand(auth.adminClient, {
     actorUserId: auth.user.id,
+    rpcSupabase: auth.authClient,
   })
 
   if (!result.ok) {

--- a/supabase/functions/user-cubid-resolve-email/index.js
+++ b/supabase/functions/user-cubid-resolve-email/index.js
@@ -23,9 +23,18 @@ async function handleRequest(request) {
     return json(edgeCommandFailure(auth.code ?? "function_not_configured", auth.error))
   }
 
+  const sessionEmail = auth.user.email?.trim().toLowerCase() ?? null
+  if (!sessionEmail) {
+    return json(edgeCommandFailure("email_required", "A signed-in email is required to link CUBID identity."))
+  }
+
+  if (validation.data.emailOverride && validation.data.emailOverride !== sessionEmail) {
+    return json(edgeCommandFailure("email_mismatch", "CUBID identity must be linked with the signed-in email."))
+  }
+
   const result = await executeResolveCubidIdentityByEmailCommand(auth.adminClient, {
     actorUserId: auth.user.id,
-    actorEmail: validation.data.emailOverride ?? auth.user.email ?? null,
+    actorEmail: sessionEmail,
   })
 
   if (!result.ok) {

--- a/supabase/functions/user-cubid-sync-profile/index.js
+++ b/supabase/functions/user-cubid-sync-profile/index.js
@@ -23,9 +23,18 @@ async function handleRequest(request) {
     return json(edgeCommandFailure(auth.code ?? "function_not_configured", auth.error))
   }
 
+  const sessionEmail = auth.user.email?.trim().toLowerCase() ?? null
+  if (!sessionEmail) {
+    return json(edgeCommandFailure("email_required", "A signed-in email is required to sync CUBID identity."))
+  }
+
+  if (validation.data.emailOverride && validation.data.emailOverride !== sessionEmail) {
+    return json(edgeCommandFailure("email_mismatch", "CUBID identity must be synced with the signed-in email."))
+  }
+
   const result = await executeSyncCubidProfileCommand(auth.adminClient, {
     actorUserId: auth.user.id,
-    actorEmail: validation.data.emailOverride ?? auth.user.email ?? null,
+    actorEmail: sessionEmail,
   })
 
   if (!result.ok) {

--- a/supabase/migrations/20260417193000_onchain_reconciliation_atomic_update.sql
+++ b/supabase/migrations/20260417193000_onchain_reconciliation_atomic_update.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION public.finalize_onchain_payment_reconciliation(
+  p_submission_id bigint,
+  p_payment_id bigint,
+  p_submission_status text,
+  p_last_checked_at timestamp with time zone,
+  p_confirmation_count integer,
+  p_matched_log_index integer,
+  p_failure_code text,
+  p_failure_reason text,
+  p_submission_confirmed_at timestamp with time zone,
+  p_submission_reconciled_at timestamp with time zone,
+  p_payment_status_id bigint,
+  p_payment_confirmed_at timestamp with time zone,
+  p_payment_note text,
+  p_payment_updated_at timestamp with time zone
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.onchain_payment_submissions
+  SET
+    status = p_submission_status,
+    last_checked_at = p_last_checked_at,
+    confirmation_count = p_confirmation_count,
+    matched_log_index = p_matched_log_index,
+    failure_code = p_failure_code,
+    failure_reason = p_failure_reason,
+    confirmed_at = p_submission_confirmed_at,
+    reconciled_at = p_submission_reconciled_at
+  WHERE id = p_submission_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'onchain_payment_submission_not_found';
+  END IF;
+
+  IF p_payment_id IS NOT NULL AND p_payment_status_id IS NOT NULL THEN
+    UPDATE public.payments
+    SET
+      status_id = p_payment_status_id,
+      confirmed_at = p_payment_confirmed_at,
+      updated_at = p_payment_updated_at,
+      notes = CASE
+        WHEN p_payment_note IS NULL THEN notes
+        ELSE p_payment_note
+      END
+    WHERE id = p_payment_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'payment_not_found';
+    END IF;
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260417193000_onchain_reconciliation_atomic_update.sql
+++ b/supabase/migrations/20260417193000_onchain_reconciliation_atomic_update.sql
@@ -9,17 +9,22 @@ CREATE OR REPLACE FUNCTION public.finalize_onchain_payment_reconciliation(
   p_failure_reason text,
   p_submission_confirmed_at timestamp with time zone,
   p_submission_reconciled_at timestamp with time zone,
-  p_payment_status_id bigint,
+  p_payment_status_id integer,
   p_payment_confirmed_at timestamp with time zone,
   p_payment_note text,
   p_payment_updated_at timestamp with time zone
 )
 RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY INVOKER
 SET search_path = public
 AS $$
 BEGIN
+  IF auth.role() IS DISTINCT FROM 'service_role' THEN
+    RAISE EXCEPTION 'insufficient_privilege'
+      USING ERRCODE = '42501';
+  END IF;
+
   UPDATE public.onchain_payment_submissions
   SET
     status = p_submission_status,
@@ -30,7 +35,8 @@ BEGIN
     failure_reason = p_failure_reason,
     confirmed_at = p_submission_confirmed_at,
     reconciled_at = p_submission_reconciled_at
-  WHERE id = p_submission_id;
+  WHERE id = p_submission_id
+    AND payment_id IS NOT DISTINCT FROM p_payment_id;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'onchain_payment_submission_not_found';
@@ -54,3 +60,37 @@ BEGIN
   END IF;
 END;
 $$;
+
+REVOKE ALL ON FUNCTION public.finalize_onchain_payment_reconciliation(
+  bigint,
+  bigint,
+  text,
+  timestamp with time zone,
+  integer,
+  integer,
+  text,
+  text,
+  timestamp with time zone,
+  timestamp with time zone,
+  integer,
+  timestamp with time zone,
+  text,
+  timestamp with time zone
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.finalize_onchain_payment_reconciliation(
+  bigint,
+  bigint,
+  text,
+  timestamp with time zone,
+  integer,
+  integer,
+  text,
+  text,
+  timestamp with time zone,
+  timestamp with time zone,
+  integer,
+  timestamp with time zone,
+  text,
+  timestamp with time zone
+) TO service_role;

--- a/tests/onchain-reconciliation-route.test.ts
+++ b/tests/onchain-reconciliation-route.test.ts
@@ -72,4 +72,58 @@ describe("POST /api/internal/payments/reconcile-onchain", () => {
       },
     })
   })
+
+  it("coerces numeric JSON strings before running reconciliation", async () => {
+    runOnchainPaymentReconciliation.mockResolvedValue({
+      source: "cron",
+      processedCount: 0,
+      confirmedCount: 0,
+      failedCount: 0,
+      confirmingCount: 0,
+      unresolvedCount: 0,
+      results: [],
+      touchedProjectSlugs: [],
+    })
+
+    const { POST } = await import("@/app/api/internal/payments/reconcile-onchain/route")
+    const response = await POST(
+      new Request("http://localhost/api/internal/payments/reconcile-onchain", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ limit: "5", paymentId: "17", submissionId: "21" }),
+      }),
+    )
+
+    expect(runOnchainPaymentReconciliation).toHaveBeenCalledWith({
+      source: "cron",
+      limit: 5,
+      paymentId: 17,
+      submissionId: 21,
+    })
+    expect(response.status).toBe(200)
+  })
+
+  it("rejects invalid numeric filters", async () => {
+    const { POST } = await import("@/app/api/internal/payments/reconcile-onchain/route")
+    const response = await POST(
+      new Request("http://localhost/api/internal/payments/reconcile-onchain", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-secret",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ limit: -1 }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(runOnchainPaymentReconciliation).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "limit must be a positive integer.",
+    })
+  })
 })

--- a/tests/project-onboarding-commands.test.ts
+++ b/tests/project-onboarding-commands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import {
   executeProjectOnboardingDraftClearCommand,
   executeProjectOnboardingDraftUpsertCommand,
@@ -171,6 +171,70 @@ describe("project onboarding commands", () => {
         projectSlug: "civic-mesh",
       },
     })
+  })
+
+  it("uses the authenticated RPC client when publishing from an Edge Function", async () => {
+    const rpc = vi.fn(() => ({
+      single() {
+        return Promise.resolve({
+          data: { project_id: 99, project_slug: "civic-mesh" },
+          error: null,
+        })
+      },
+    }))
+    const rpcSupabase = { rpc }
+    const supabase = createSupabaseMock({
+      project_onboarding_drafts: [
+        {
+          data: {
+            id: 10,
+            user_id: "user-1",
+            current_screen: "review",
+            payload: {
+              name: "Civic Mesh",
+              slug: "civic-mesh",
+              logoUrl: "",
+              website: "",
+              description: "Routing public transit coordination.",
+              contactEmail: "",
+              detailedDescription: "",
+              categoryIds: [],
+              pledgeAccepted: true,
+              billingEmail: "",
+              billingFrequency: "monthly",
+              paymentPercentage: "1.5",
+              paymentPeriodicityId: "",
+              cryptoPaymentMethods: [],
+            },
+            started_at: "2026-04-15T00:00:00.000Z",
+            updated_at: "2026-04-15T00:00:00.000Z",
+            completed_at: null,
+          },
+          error: null,
+        },
+      ],
+      users: [{ data: { cubid_identity_status: "linked" }, error: null }],
+      projects: [{ data: null, error: null }],
+    })
+
+    await expect(
+      executeProjectOnboardingPublishCommand(supabase as never, {
+        actorUserId: "user-1",
+        rpcSupabase: rpcSupabase as never,
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        projectSlug: "civic-mesh",
+      },
+    })
+
+    expect(rpc).toHaveBeenCalledWith(
+      "publish_project_onboarding_draft_atomic",
+      expect.objectContaining({
+        p_slug: "civic-mesh",
+      }),
+    )
   })
 
   it("rejects incomplete project publish requirements", async () => {

--- a/tests/user-onboarding-commands.test.ts
+++ b/tests/user-onboarding-commands.test.ts
@@ -5,7 +5,13 @@ import {
   executeUserOnboardingPublishCommand,
 } from "@/lib/onboarding/user-onboarding-commands"
 
-function createQueryResponse(response: unknown) {
+type SupabaseOperation = {
+  table: string
+  operation: "update"
+  payload: unknown
+}
+
+function createQueryResponse(response: unknown, table: string, operations: SupabaseOperation[]) {
   return {
     select() {
       return this
@@ -25,7 +31,8 @@ function createQueryResponse(response: unknown) {
     delete() {
       return this
     },
-    update() {
+    update(payload: unknown) {
+      operations.push({ table, operation: "update", payload })
       return this
     },
     insert() {
@@ -39,12 +46,14 @@ function createQueryResponse(response: unknown) {
 
 function createSupabaseMock(responsesByTable: Record<string, unknown[]>) {
   const counters = new Map<string, number>()
+  const operations: SupabaseOperation[] = []
 
   return {
+    operations,
     from(table: string) {
       const nextIndex = counters.get(table) ?? 0
       counters.set(table, nextIndex + 1)
-      return createQueryResponse(responsesByTable[table]?.[nextIndex] ?? { data: null, error: null })
+      return createQueryResponse(responsesByTable[table]?.[nextIndex] ?? { data: null, error: null }, table, operations)
     },
   }
 }
@@ -175,6 +184,74 @@ describe("user onboarding commands", () => {
         relationshipChoice: "create_project",
       },
     })
+  })
+
+  it("preserves existing invite attribution when a draft has no new invite code", async () => {
+    const supabase = createSupabaseMock({
+      user_onboarding_drafts: [
+        {
+          data: {
+            id: 8,
+            user_id: "user-1",
+            current_screen: "review",
+            payload: {
+              fullName: "Maya Torres",
+              displayName: "Maya",
+              profileHeadline: "Builder",
+              avatarUrl: "",
+              bio: "",
+              occupationId: "",
+              locationId: "",
+              genderId: "",
+              interestIds: [],
+              inviteCode: "",
+              privacyPreset: "limited",
+              visibility: {
+                isPublic: true,
+                isNamePublic: true,
+                isPfpPublic: true,
+                isGenderPublic: false,
+                isOccupationPublic: true,
+                isLocationPublic: true,
+                isBirthyearPublic: false,
+                isBirthdayPublic: false,
+              },
+              relationshipChoice: "individual",
+              selectedProjectId: null,
+            },
+            started_at: "2026-04-15T00:00:00.000Z",
+            updated_at: "2026-04-15T00:00:00.000Z",
+            completed_at: null,
+          },
+          error: null,
+        },
+        { data: null, error: null },
+      ],
+      users: [
+        { data: { invited_by_code: "legacy-invite", cubid_identity_status: "linked", full_name: "Maya Torres" }, error: null },
+        { data: null, error: null },
+      ],
+      user_interests: [{ data: null, error: null }],
+    })
+
+    await expect(
+      executeUserOnboardingPublishCommand(supabase as never, {
+        actorUserId: "user-1",
+        actorEmail: "maya@example.com",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      data: {
+        nextFlow: null,
+        relationshipChoice: "individual",
+      },
+    })
+
+    expect(supabase.operations.find((operation) => operation.table === "users")?.payload).toEqual(
+      expect.objectContaining({
+        invited_by_code: "legacy-invite",
+      }),
+    )
   })
 
   it("returns a clear failure when the user draft is missing", async () => {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -3072,6 +3072,25 @@ export type Database = {
       }
     }
     Functions: {
+      finalize_onchain_payment_reconciliation: {
+        Args: {
+          p_confirmation_count: number
+          p_failure_code: string | null
+          p_failure_reason: string | null
+          p_last_checked_at: string
+          p_matched_log_index: number | null
+          p_payment_confirmed_at: string | null
+          p_payment_id: number | null
+          p_payment_note: string | null
+          p_payment_status_id: number | null
+          p_payment_updated_at: string
+          p_submission_confirmed_at: string | null
+          p_submission_id: number
+          p_submission_reconciled_at: string | null
+          p_submission_status: string
+        }
+        Returns: undefined
+      }
       get_active_org_members: {
         Args: { org_id: number }
         Returns: {


### PR DESCRIPTION
## Summary
- Addresses the unresolved review threads from merged PRs #18-#21 in one cleanup branch.
- Hardens onchain payment submission/reconciliation, app-shell navigation fallback behavior, public discovery semantics, and CUBID onboarding trust boundaries.
- Resolves doc portability issues called out by review by converting active machine-local links to repo-relative links.
- Includes one session-log entry per cleanup commit, matching the repo convention.

## Objective
Close the approved-but-unaddressed review feedback from the recent wallet stack PRs without rewriting the merged feature branches. The goal is to make `dev` safer and quieter before the next implementation sessions build on this work.

## Changes
- PR #18 cleanup: validates reconciliation request filters, validates onchain submissions against canonical payment amounts, and finalizes reconciliation through an atomic Postgres RPC.
- PR #19 cleanup: converts active planning/doc links to repo-relative targets, documents the Next.js 16 `proxy.ts` convention, and logs navigation-context Supabase read failures with conservative fallbacks.
- PR #20 cleanup: fixes session-log rendering, public discovery participant counts, user-directory membership filtering, FAQ CTA labeling, and blog-date fallback honesty.
- PR #21 cleanup: removes internal CUBID error wording, routes project publish RPC through the authenticated client, preserves invite attribution, and enforces signed-in email matching for CUBID resolve/sync.

## Validation
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/onchain-reconciliation-route.test.ts tests/payment-reconciliation.test.ts tests/project-payment-observability-actions.test.ts`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/project-onboarding-commands.test.ts tests/user-onboarding-commands.test.ts tests/onboarding-edge-adapters.test.ts tests/cubid-resolve-email-command.test.ts tests/cubid-read-model.test.ts`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`

## Reviewer Notes
- Recommended review order: read commits in PR order, starting with `36cfd26`, then `7a53688`, `f4ce96d`, and `07d8bf8`.
- The `proxy.ts` thread from PR #19 was handled by documenting the Next.js 16 convention rather than adding `middleware.ts`, because Next 16 treats `middleware.ts` as deprecated and rejects projects that define both.
- The PR #21 package/lockfile comments were already outdated on the merged tip; this branch verified the repo-vendored `vendor/cubid/*.tgz` paths and replied/resolved those threads.

## Follow-ups
- After CI is green, this PR should be marked ready for review.
- Broader runtime smoke testing is deferred unless CI or reviewers point to a specific flow regression.
