### PR TITLE
[codex] Build regular user workspace home

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,29 @@
+### session v62: Address PR 23 Codex workspace read-model review comments
+- timestamp: 2026-04-20T04:07:11-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-17-user-workspace**
+- head: TBD
+
+#### Objective
+Address the chatgpt-codex-connector review comments on PR #23 around workspace discovery sparsity and participation counters.
+
+#### Actions Taken
+- Changed the workspace discovery query so joined project IDs are excluded before the recommendation limit is applied.
+- Changed participation metrics to count only participant rows that hydrate to non-deleted project rows.
+- Added an explicit unavailable-project-details flag so the workspace can avoid claiming there are no joined projects when project-detail reads fail.
+- Added read-model tests for soft-deleted/unhydrated project exclusion and temporary joined-project detail failures.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/user-workspace.test.ts` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed.
+
+#### Reflections
+- The workspace home should be optimistic but not misleading: counters should reflect visible, non-deleted projects, while read failures need a distinct temporary state.
+
+#### Suggested Next Steps
+- Push the Codex fixes, reply to the Codex threads with the commit reference, and resolve those threads.
+
 ### session v61: Address PR 23 Copilot workspace review comments
 - timestamp: 2026-04-20T03:54:49-04:00
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2,7 +2,7 @@
 - timestamp: 2026-04-20T03:54:49-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/session-17-user-workspace**
-- head: TBD
+- head: 6257ba7
 
 #### Objective
 Address the Copilot review comments on PR #23 before requesting the next Codex review pass.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,8 +1,38 @@
+### session v60: Build the regular-user workspace home
+- timestamp: 2026-04-20T03:24:45-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-17-user-workspace**
+- head: TBD
+
+#### Objective
+Complete Session 17 by turning `/workspace` into a useful signed-in user home that summarizes identity readiness, profile completion, participation, discovery, and current published results without pulling full payout/reporting routes forward.
+
+#### Actions Taken
+- Added a server-only user workspace read model under `lib/workspace/` that gathers participation rows, joined projects, public project recommendations, published zkAS results, run labels, and non-fatal warning state.
+- Rebuilt `/[locale]/workspace` around clear workspace sections for identity readiness, profile completion, participation footprint, discovery, current results visibility, and conditional founder shortcuts.
+- Localized the new workspace copy in English, French, and Spanish.
+- Added focused coverage for the workspace read model and updated engineering docs to record `/workspace` as the real Session 17 user home while `/settings/zkas` remains the interim detailed result history.
+- Updated Session 17 status metadata in `agent-context/todo.md`.
+
+#### Tests and Validation Notes
+- `pnpm exec vitest run tests/user-workspace.test.ts` passed.
+- `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` passed.
+- Re-ran the full gate set through `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm ...`; lint, test, typecheck, and build all passed in the repo's expected Node 22 runtime.
+- Smoke-checked `GET /en/workspace` against `next start` on port `3107`; unauthenticated access returned a `307` redirect to `/en/join`.
+- Did not complete an authenticated browser smoke in this session; the signed-in page behavior is covered by build, model tests, and existing app-shell redirect behavior.
+
+#### Reflections
+- Keeping detailed results under `/settings/zkas` preserves the current truthful endpoint while giving users a much better workspace summary now.
+- The read model intentionally degrades partial Supabase read failures into warnings and empty states because the signed-in home should remain useful even if one supporting table is temporarily unavailable.
+
+#### Suggested Next Steps
+- Start Session 18 to give founders and project members the same level of workspace orientation around managed projects, contribution operations, and project growth.
+
 ### session v59: Reconcile completed Edge Function backlog metadata
 - timestamp: 2026-04-20T03:19:55-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/session-17-user-workspace**
-- head: TBD
+- head: 0fb3eff1635824c53009b1dc7e23c05de5c05157
 
 #### Objective
 Correct stale backlog metadata for Sessions 04 and 05 so future agents do not re-run already-completed Edge Function contract and project payment draft migration work.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2,7 +2,7 @@
 - timestamp: 2026-04-20T03:24:45-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/session-17-user-workspace**
-- head: TBD
+- head: 13c9fa3
 
 #### Objective
 Complete Session 17 by turning `/workspace` into a useful signed-in user home that summarizes identity readiness, profile completion, participation, discovery, and current published results without pulling full payout/reporting routes forward.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,29 @@
+### session v61: Address PR 23 Copilot workspace review comments
+- timestamp: 2026-04-20T03:54:49-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-17-user-workspace**
+- head: TBD
+
+#### Objective
+Address the Copilot review comments on PR #23 before requesting the next Codex review pass.
+
+#### Actions Taken
+- Changed the workspace CUBID Passport link to use `navigationContext.cubidPassportOrigin` with the production Passport origin as a fallback.
+- Made workspace result publish-date formatting timezone-stable by formatting dates in UTC.
+- Reworked the participation empty-state branch so users with joined projects do not see "no joined projects" when project detail hydration is temporarily unavailable.
+- Added localized copy for the temporary participation-detail-unavailable state in English, French, and Spanish.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/user-workspace.test.ts` passed.
+
+#### Reflections
+- These fixes keep the workspace aligned with environment-specific CUBID configuration and avoid misleading user states when supporting reads partially fail.
+
+#### Suggested Next Steps
+- Push the Copilot fixes, reply to the three Copilot threads with the commit reference, and resolve those threads.
+
 ### session v60: Build the regular-user workspace home
 - timestamp: 2026-04-20T03:24:45-04:00
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -2,7 +2,7 @@
 - timestamp: 2026-04-20T04:07:11-04:00
 - agent: **Codex (GPT-5)**
 - branch: **codex/session-17-user-workspace**
-- head: TBD
+- head: 39da952
 
 #### Objective
 Address the chatgpt-codex-connector review comments on PR #23 around workspace discovery sparsity and participation counters.

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,26 @@
+### session v59: Reconcile completed Edge Function backlog metadata
+- timestamp: 2026-04-20T03:19:55-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-17-user-workspace**
+- head: TBD
+
+#### Objective
+Correct stale backlog metadata for Sessions 04 and 05 so future agents do not re-run already-completed Edge Function contract and project payment draft migration work.
+
+#### Actions Taken
+- Marked Session 04 complete in `agent-context/todo.md` using the existing `session v38` timestamp, branch, head, and reference.
+- Marked Session 05 complete in `agent-context/todo.md` using the existing `session v39` timestamp, branch, head, and reference.
+- Kept this pass limited to backlog hygiene; no product code or Edge Function implementation changed.
+
+#### Tests and Validation Notes
+- Not run; documentation metadata only.
+
+#### Reflections
+- The Edge Function contract and first payment draft command are already present in the repo and documented in `docs/engineering/edge-functions.md`; leaving the backlog as `Not started` would invite duplicate implementation work.
+
+#### Suggested Next Steps
+- Start Session 17 on this branch by rebuilding `/workspace` into the signed-in user workspace home.
+
 ### session v58: Address PR 22 reconciliation RPC review comments
 - timestamp: 2026-04-19T21:54:03-04:00
 - agent: **Codex (GPT-5)**

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -194,7 +194,7 @@ Update profile and account surfaces so they stop behaving like FundLoop is the c
 - Timestamp started: 2026-04-20T03:20:34-04:00
 - Timestamp completed: 2026-04-20T03:24:45-04:00
 - Feature branch: codex/session-17-user-workspace
-- Head: TBD
+- Head: 13c9fa3
 - Session-log reference(s): session v60
 
 Build a coherent signed-in home for users. It should combine identity status, project discovery, participation context, and earnings visibility into one clear workspace instead of scattering that experience across unrelated pages. This is not the full payout product yet, but it should establish the long-term structure: current status, next actions, participation opportunities, and money-related visibility. The session should prioritize clarity and reduction of friction so regular users can understand where they stand in the system without reading multiple explainer pages.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -47,23 +47,23 @@ Restructure the app map around the three real personas: regular users, founders/
 
 ## Session 04: Introduce a backend-contract layer for Supabase Edge Functions
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Complete
+- Timestamp started: 2026-04-14T23:28:41Z
+- Timestamp completed: 2026-04-14T23:28:41Z
+- Feature branch: codex/wallet-production-readiness
+- Head: 56599f9a9eb72692bdbafaa2b3ddbc6b6ccbf558
+- Session-log reference(s): session v38
 
 Create the application-side foundation for the future read/write model. The web app should gain a consistent client for calling Supabase Edge Functions, typed request and response envelopes, shared auth/error handling, and a clear place to put function-specific adapters. Do not migrate all behavior yet. The goal is to remove the current ambiguity where writes happen in server actions and reads often happen straight from the browser. This session creates the transport contract every later migration will depend on.
 
 ## Session 05: Stand up the first real Edge Function domain boundary
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
-- Head: TBD
-- Session-log reference(s): TBD
+- Status: Complete
+- Timestamp started: 2026-04-14T23:36:10Z
+- Timestamp completed: 2026-04-14T23:36:10Z
+- Feature branch: codex/wallet-production-readiness
+- Head: f2bd1b5f6d9876b48a579efb45d0f8f2eb8c38e2
+- Session-log reference(s): session v39
 
 Pick one narrow but meaningful domain, likely onboarding drafts or project payment draft creation, and implement the first production-style Supabase Edge Function with schema validation, auth checks, and a typed web adapter. This session proves the new backend pattern in a real workflow. It should include local development ergonomics, shared error shapes, and a small test harness. The goal is to establish a repeatable template so later sessions can migrate more domains without inventing a new style each time.
 

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -190,12 +190,12 @@ Update profile and account surfaces so they stop behaving like FundLoop is the c
 
 ## Session 17: Create a real regular-user workspace home
 
-- Status: Not started
-- Timestamp started: TBD
-- Timestamp completed: TBD
-- Feature branch: TBD
+- Status: Complete
+- Timestamp started: 2026-04-20T03:20:34-04:00
+- Timestamp completed: 2026-04-20T03:24:45-04:00
+- Feature branch: codex/session-17-user-workspace
 - Head: TBD
-- Session-log reference(s): TBD
+- Session-log reference(s): session v60
 
 Build a coherent signed-in home for users. It should combine identity status, project discovery, participation context, and earnings visibility into one clear workspace instead of scattering that experience across unrelated pages. This is not the full payout product yet, but it should establish the long-term structure: current status, next actions, participation opportunities, and money-related visibility. The session should prioritize clarity and reduction of friction so regular users can understand where they stand in the system without reading multiple explainer pages.
 

--- a/app/[locale]/(app)/workspace/page.tsx
+++ b/app/[locale]/(app)/workspace/page.tsx
@@ -224,7 +224,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
                   </Link>
                 ))}
               </div>
-            ) : workspace.participation.joinedProjectCount === 0 ? (
+            ) : workspace.participation.joinedProjectCount === 0 && !workspace.participation.hasUnavailableProjectDetails ? (
               <div className="rounded-2xl border border-dashed border-[color:var(--surface-border-strong)] bg-[var(--surface-panel)] p-5">
                 <p className="font-semibold text-[var(--text-strong)]">{t("participation.emptyTitle")}</p>
                 <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">{t("participation.emptyBody")}</p>

--- a/app/[locale]/(app)/workspace/page.tsx
+++ b/app/[locale]/(app)/workspace/page.tsx
@@ -36,6 +36,7 @@ function formatDate(locale: string, value: string | null) {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   }).format(date)
 }
 
@@ -59,6 +60,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
         : "border-amber-200 bg-amber-50/85 text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-100"
   const latestResultDate = formatDate(locale, workspace.results.latest?.publishedAt ?? null)
   const hasResolvedIdentity = isResolvedCubidIdentityStatus(cubidStatus)
+  const cubidPassportHref = new URL("/", navigationContext.cubidPassportOrigin ?? "https://passport.cubid.me").toString()
   const primaryActions = [
     {
       href: "/workspace/account",
@@ -144,7 +146,7 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
                 <Link href="/workspace/account">{t("identity.accountCta")}</Link>
               </Button>
               <Button asChild variant="outline">
-                <a href="https://passport.cubid.me" target="_blank" rel="noreferrer">
+                <a href={cubidPassportHref} target="_blank" rel="noreferrer">
                   {t("identity.passportCta")}
                 </a>
               </Button>
@@ -222,11 +224,15 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
                   </Link>
                 ))}
               </div>
-            ) : (
+            ) : workspace.participation.joinedProjectCount === 0 ? (
               <div className="rounded-2xl border border-dashed border-[color:var(--surface-border-strong)] bg-[var(--surface-panel)] p-5">
                 <p className="font-semibold text-[var(--text-strong)]">{t("participation.emptyTitle")}</p>
                 <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">{t("participation.emptyBody")}</p>
               </div>
+            ) : (
+              <p className="rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-5 text-sm leading-6 text-[var(--text-muted)]">
+                {t("participation.detailsUnavailable")}
+              </p>
             )}
           </CardContent>
         </Card>

--- a/app/[locale]/(app)/workspace/page.tsx
+++ b/app/[locale]/(app)/workspace/page.tsx
@@ -1,13 +1,42 @@
 import { redirect } from "next/navigation"
 import { getTranslations } from "next-intl/server"
-import { BadgeCheck, ShieldAlert, ShieldCheck } from "lucide-react"
+import { ArrowUpRight, BadgeCheck, CircleDollarSign, Compass, ShieldAlert, ShieldCheck, Sparkles, UsersRound } from "lucide-react"
 import { Link } from "@/i18n/navigation"
 import { isResolvedCubidIdentityStatus } from "@/lib/cubid/types"
 import { getNavigationContext } from "@/lib/navigation-context"
+import { getUserWorkspaceHome } from "@/lib/workspace/user-workspace"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
 
 type WorkspacePageProps = {
   params: Promise<{ locale: string }>
+}
+
+function formatCurrency(locale: string, value: number) {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatDate(locale: string, value: string | null) {
+  if (!value) {
+    return null
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date)
 }
 
 export default async function WorkspacePage({ params }: WorkspacePageProps) {
@@ -19,143 +48,279 @@ export default async function WorkspacePage({ params }: WorkspacePageProps) {
     redirect(`/${locale}/join`)
   }
 
-  const cubidStatus = navigationContext.user?.cubidIdentityStatus ?? "unlinked"
-  const cubidStatusIcon =
-    cubidStatus === "verified" ? BadgeCheck : cubidStatus === "linked" ? ShieldCheck : ShieldAlert
-  const CubidStatusIcon = cubidStatusIcon
+  const workspace = await getUserWorkspaceHome(navigationContext)
+  const cubidStatus = workspace.profileStatus.cubidStatus
+  const CubidStatusIcon = cubidStatus === "verified" ? BadgeCheck : cubidStatus === "linked" ? ShieldCheck : ShieldAlert
   const cubidToneClassName =
     cubidStatus === "verified"
-      ? "border-emerald-200 bg-emerald-50/70 text-emerald-950"
+      ? "border-emerald-200 bg-emerald-50/80 text-emerald-950 dark:border-emerald-400/30 dark:bg-emerald-400/10 dark:text-emerald-100"
       : cubidStatus === "linked"
-        ? "border-cyan-200 bg-cyan-50/70 text-cyan-950"
-        : "border-amber-200 bg-amber-50/80 text-amber-950"
-  const completionPercent = navigationContext.user?.profileCompletionPercent ?? 0
-  const completionMissingItems = navigationContext.user?.profileCompletionMissingItems ?? []
-  const managedName = navigationContext.user?.managedIdentity.fullName
-  const managedNameLabel =
-    managedName?.state === "synced"
-      ? "Synced from CUBID"
-      : managedName?.state === "legacy_local_fallback"
-        ? "Legacy FundLoop fallback"
-        : "Pending from CUBID"
-
-  const cards = [
+        ? "border-cyan-200 bg-cyan-50/80 text-cyan-950 dark:border-cyan-400/30 dark:bg-cyan-400/10 dark:text-cyan-100"
+        : "border-amber-200 bg-amber-50/85 text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-100"
+  const latestResultDate = formatDate(locale, workspace.results.latest?.publishedAt ?? null)
+  const hasResolvedIdentity = isResolvedCubidIdentityStatus(cubidStatus)
+  const primaryActions = [
     {
-      title: t("cards.account.title"),
-      description: t("cards.account.description"),
       href: "/workspace/account",
+      label: t("actions.account"),
+      description: t("actions.accountDescription"),
     },
     {
-      title: t("cards.participation.title"),
-      description: t("cards.participation.description"),
-      href: "/participation",
+      href: "/projects",
+      label: t("actions.discover"),
+      description: t("actions.discoverDescription"),
     },
     {
-      title: t("cards.results.title"),
-      description: t("cards.results.description"),
-      href: "/settings/zkas",
+      href: workspace.results.detailHref,
+      label: t("actions.results"),
+      description: t("actions.resultsDescription"),
     },
   ]
 
   if (navigationContext.hasFounderAccess) {
-    cards.push({
-      title: t("cards.founder.title"),
-      description: t("cards.founder.description"),
+    primaryActions.push({
       href: "/founder",
+      label: t("actions.founder"),
+      description: t("actions.founderDescription"),
     })
   }
 
   return (
     <div className="space-y-8">
-      <section className="rounded-[calc(var(--radius-2xl)+0.25rem)] border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-8 shadow-[var(--surface-shadow-panel)]">
+      <section className="overflow-hidden rounded-[calc(var(--radius-2xl)+0.35rem)] border border-[color:var(--surface-border)] bg-[radial-gradient(circle_at_top_left,var(--interactive-secondary),transparent_34%),linear-gradient(135deg,var(--surface-panel-strong),var(--surface-panel))] p-8 shadow-[var(--surface-shadow-panel)]">
         <div className="max-w-3xl space-y-4">
           <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-[var(--interactive-primary)]">{t("eyebrow")}</p>
-          <h1 className="text-4xl font-semibold tracking-[var(--tracking-display)] text-[var(--text-strong)]">
+          <h1 className="text-4xl font-semibold tracking-[var(--tracking-display)] text-[var(--text-strong)] md:text-5xl">
             {t("title")}
           </h1>
           <p className="max-w-2xl text-base leading-7 text-[var(--text-muted)]">{t("body")}</p>
         </div>
+        <div className="mt-8 grid gap-4 md:grid-cols-3">
+          <div className="rounded-3xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-5">
+            <p className="text-sm font-medium text-[var(--text-muted)]">{t("stats.projects")}</p>
+            <p className="mt-2 text-3xl font-semibold text-[var(--text-strong)]">{workspace.participation.joinedProjectCount}</p>
+          </div>
+          <div className="rounded-3xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-5">
+            <p className="text-sm font-medium text-[var(--text-muted)]">{t("stats.results")}</p>
+            <p className="mt-2 text-3xl font-semibold text-[var(--text-strong)]">{workspace.results.resultCount}</p>
+          </div>
+          <div className="rounded-3xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-5">
+            <p className="text-sm font-medium text-[var(--text-muted)]">{t("stats.totalAllocation")}</p>
+            <p className="mt-2 text-3xl font-semibold text-[var(--text-strong)]">
+              {formatCurrency(locale, workspace.results.totalAllocationUsd)}
+            </p>
+          </div>
+        </div>
       </section>
 
-      <section className={`rounded-[calc(var(--radius-2xl)+0.25rem)] border p-6 shadow-[var(--surface-shadow-panel)] ${cubidToneClassName}`}>
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex max-w-3xl items-start gap-3">
-            <CubidStatusIcon className="mt-0.5 h-5 w-5 shrink-0" />
-            <div className="space-y-2">
-              <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em]">{t(`identity.status.${cubidStatus}`)}</p>
-              <h2 className="text-xl font-semibold">{t("identity.title")}</h2>
-              <p className="text-sm leading-6">{t(`identity.body.${cubidStatus}`)}</p>
-              <div className="rounded-2xl border border-current/20 bg-white/40 px-4 py-3 text-sm dark:bg-black/10">
-                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em]">{managedNameLabel}</p>
-                <p className="mt-1 font-medium">
-                  {managedName?.value ?? "FundLoop is still waiting for a CUBID-managed full name for this account."}
-                </p>
+      {workspace.warnings.length > 0 ? (
+        <section className="rounded-3xl border border-amber-300/70 bg-amber-50/80 p-5 text-sm leading-6 text-amber-950 dark:border-amber-400/30 dark:bg-amber-400/10 dark:text-amber-100">
+          <p className="font-semibold">{t("warnings.title")}</p>
+          <p>{t("warnings.body")}</p>
+        </section>
+      ) : null}
+
+      <section className="grid gap-5 lg:grid-cols-2">
+        <Card className={`shadow-[var(--surface-shadow-panel)] ${cubidToneClassName}`}>
+          <CardHeader>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <CubidStatusIcon className="h-5 w-5" />
+                <CardTitle>{t("identity.title")}</CardTitle>
+              </div>
+              <Badge variant="outline" className="border-current/30 text-current">
+                {t(`identity.status.${cubidStatus}`)}
+              </Badge>
+            </div>
+            <CardDescription className="text-current/75">{t(`identity.body.${cubidStatus}`)}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="rounded-2xl border border-current/15 bg-white/35 px-4 py-3 text-sm dark:bg-black/10">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-current/65">{t("identity.signedIn")}</p>
+              <p className="mt-1 font-medium">{workspace.profileStatus.signedInEmail ?? t("identity.unknownEmail")}</p>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Button asChild variant={hasResolvedIdentity ? "outline" : "default"}>
+                <Link href="/workspace/account">{t("identity.accountCta")}</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <a href="https://passport.cubid.me" target="_blank" rel="noreferrer">
+                  {t("identity.passportCta")}
+                </a>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-[var(--surface-panel-strong)] shadow-[var(--surface-shadow-panel)]">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-4">
+              <CardTitle>{t("completion.title")}</CardTitle>
+              <span className="text-2xl font-semibold text-[var(--text-strong)]">{workspace.profileStatus.completionPercent}%</span>
+            </div>
+            <CardDescription>{t("completion.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Progress value={workspace.profileStatus.completionPercent} className="h-2 bg-[var(--surface-border)]" />
+            {workspace.profileStatus.missingItems.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {workspace.profileStatus.missingItems.map((item) => (
+                  <span
+                    key={item}
+                    className="rounded-full border border-[color:var(--surface-border)] bg-[var(--surface-panel)] px-3 py-1 text-xs font-medium text-[var(--text-muted)]"
+                  >
+                    {item.replaceAll("_", " ")}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-[var(--text-muted)]">{t("completion.complete")}</p>
+            )}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-5 xl:grid-cols-[1.1fr_0.9fr]">
+        <Card className="bg-[var(--surface-panel-strong)] shadow-[var(--surface-shadow-panel)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <UsersRound className="h-5 w-5 text-[var(--interactive-primary)]" />
+              <CardTitle>{t("participation.title")}</CardTitle>
+            </div>
+            <CardDescription>{t("participation.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">{t("participation.joined")}</p>
+                <p className="mt-2 text-2xl font-semibold text-[var(--text-strong)]">{workspace.participation.joinedProjectCount}</p>
+              </div>
+              <div className="rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">{t("participation.favorites")}</p>
+                <p className="mt-2 text-2xl font-semibold text-[var(--text-strong)]">{workspace.participation.favoriteProjectCount}</p>
+              </div>
+              <div className="rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-muted)]">{t("participation.admin")}</p>
+                <p className="mt-2 text-2xl font-semibold text-[var(--text-strong)]">{workspace.participation.founderProjectCount}</p>
               </div>
             </div>
-          </div>
-          <a
-            href="https://passport.cubid.me"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-full border border-current/20 px-4 py-2 text-sm font-semibold"
-          >
-            {t("identity.cta")}
-          </a>
-        </div>
-        {!isResolvedCubidIdentityStatus(cubidStatus) ? (
-          <p className="mt-4 text-sm leading-6">{t("identity.followUp")}</p>
-        ) : null}
+            {workspace.participation.recentProjects.length > 0 ? (
+              <div className="space-y-3">
+                {workspace.participation.recentProjects.map((project) => (
+                  <Link
+                    key={project.id}
+                    href={project.slug ? `/projects/${project.slug}` : "/projects"}
+                    className="flex items-center justify-between gap-4 rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4 transition hover:border-[color:var(--surface-border-strong)]"
+                  >
+                    <span>
+                      <span className="block font-semibold text-[var(--text-strong)]">{project.name}</span>
+                      <span className="line-clamp-1 text-sm text-[var(--text-muted)]">
+                        {project.description ?? t("participation.projectFallback")}
+                      </span>
+                    </span>
+                    <ArrowUpRight className="h-4 w-4 text-[var(--interactive-primary)]" />
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-[color:var(--surface-border-strong)] bg-[var(--surface-panel)] p-5">
+                <p className="font-semibold text-[var(--text-strong)]">{t("participation.emptyTitle")}</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">{t("participation.emptyBody")}</p>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="bg-[var(--surface-panel-strong)] shadow-[var(--surface-shadow-panel)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <CircleDollarSign className="h-5 w-5 text-[var(--interactive-primary)]" />
+              <CardTitle>{t("results.title")}</CardTitle>
+            </div>
+            <CardDescription>{t("results.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {workspace.results.latest ? (
+              <div className="rounded-3xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-5">
+                <p className="text-sm font-medium text-[var(--text-muted)]">{workspace.results.latest.monthLabel}</p>
+                <p className="mt-2 text-4xl font-semibold text-[var(--text-strong)]">
+                  {formatCurrency(locale, workspace.results.latest.allocationUsd)}
+                </p>
+                <p className="mt-2 text-sm text-[var(--text-muted)]">
+                  {t("results.latestMeta", {
+                    score: Math.round(workspace.results.latest.aggregateScore).toLocaleString(locale),
+                    date: latestResultDate ?? t("results.pendingDate"),
+                  })}
+                </p>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-[color:var(--surface-border-strong)] bg-[var(--surface-panel)] p-5">
+                <p className="font-semibold text-[var(--text-strong)]">{t("results.emptyTitle")}</p>
+                <p className="mt-2 text-sm leading-6 text-[var(--text-muted)]">{t("results.emptyBody")}</p>
+              </div>
+            )}
+            <Button asChild variant="outline" className="w-full">
+              <Link href={workspace.results.detailHref}>{t("results.cta")}</Link>
+            </Button>
+          </CardContent>
+        </Card>
       </section>
 
-      <section className="rounded-[calc(var(--radius-2xl)+0.25rem)] border border-[color:var(--surface-border)] bg-[var(--surface-panel-strong)] p-6 shadow-[var(--surface-shadow-panel)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl space-y-2">
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-[var(--interactive-primary)]">
-              Profile completion
-            </p>
-            <h2 className="text-xl font-semibold text-[var(--text-strong)]">{completionPercent}% complete</h2>
-            <p className="text-sm leading-6 text-[var(--text-muted)]">
-              Identity now comes from CUBID, while FundLoop still owns your display name, profile headline, discovery context,
-              and visibility preferences. This score combines those local preferences with optional CUBID trust signals.
-            </p>
-          </div>
-          <Link
-            href="/workspace/account"
-            className="inline-flex items-center rounded-full border border-[color:var(--surface-border-strong)] px-4 py-2 text-sm font-semibold text-[var(--text-strong)]"
-          >
-            Continue in account
-          </Link>
-        </div>
-        {completionMissingItems.length > 0 ? (
-          <div className="mt-4 flex flex-wrap gap-2">
-            {completionMissingItems.map((item) => (
-              <span
-                key={item}
-                className="rounded-full border border-[color:var(--surface-border)] bg-[var(--surface-panel)] px-3 py-1 text-xs font-medium text-[var(--text-muted)]"
+      <section className="grid gap-5 xl:grid-cols-[0.95fr_1.05fr]">
+        <Card className="bg-[var(--surface-panel-strong)] shadow-[var(--surface-shadow-panel)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <Compass className="h-5 w-5 text-[var(--interactive-primary)]" />
+              <CardTitle>{t("discovery.title")}</CardTitle>
+            </div>
+            <CardDescription>{t("discovery.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {workspace.discovery.recommendedProjects.length > 0 ? (
+              workspace.discovery.recommendedProjects.map((project) => (
+                <Link
+                  key={project.id}
+                  href={project.slug ? `/projects/${project.slug}` : "/projects"}
+                  className="block rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4 transition hover:border-[color:var(--surface-border-strong)]"
+                >
+                  <span className="font-semibold text-[var(--text-strong)]">{project.name}</span>
+                  <span className="mt-1 line-clamp-2 block text-sm leading-6 text-[var(--text-muted)]">
+                    {project.description ?? t("discovery.projectFallback")}
+                  </span>
+                </Link>
+              ))
+            ) : (
+              <p className="rounded-2xl border border-dashed border-[color:var(--surface-border-strong)] bg-[var(--surface-panel)] p-5 text-sm leading-6 text-[var(--text-muted)]">
+                {t("discovery.empty")}
+              </p>
+            )}
+            <Button asChild className="w-full">
+              <Link href="/projects">{t("discovery.cta")}</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-[var(--surface-panel-strong)] shadow-[var(--surface-shadow-panel)]">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <Sparkles className="h-5 w-5 text-[var(--interactive-primary)]" />
+              <CardTitle>{t("actions.title")}</CardTitle>
+            </div>
+            <CardDescription>{t("actions.description")}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2">
+            {primaryActions.map((action) => (
+              <Link
+                key={action.href}
+                href={action.href}
+                className="rounded-2xl border border-[color:var(--surface-border)] bg-[var(--surface-panel)] p-4 transition hover:-translate-y-0.5 hover:border-[color:var(--surface-border-strong)]"
               >
-                {item.replaceAll("_", " ")}
-              </span>
+                <span className="font-semibold text-[var(--text-strong)]">{action.label}</span>
+                <span className="mt-1 block text-sm leading-6 text-[var(--text-muted)]">{action.description}</span>
+              </Link>
             ))}
-          </div>
-        ) : (
-          <p className="mt-4 text-sm text-[var(--text-muted)]">All current Session 14 completion items are already covered.</p>
-        )}
-      </section>
-
-      <section className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-        {cards.map((card) => (
-          <Link key={card.href} href={card.href} className="block">
-            <Card className="h-full bg-[var(--surface-panel-strong)] transition-transform duration-200 hover:-translate-y-0.5 hover:border-[color:var(--surface-border-strong)] hover:shadow-[var(--surface-shadow-panel)]">
-              <CardHeader>
-                <CardTitle>{card.title}</CardTitle>
-                <CardDescription>{card.description}</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <span className="text-sm font-semibold text-[var(--interactive-primary)]">{t("open")}</span>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+          </CardContent>
+        </Card>
       </section>
     </div>
   )

--- a/docs/engineering/navigation-shell.md
+++ b/docs/engineering/navigation-shell.md
@@ -113,6 +113,12 @@ Session 13 made identity state a first-class part of the authenticated shell.
 - `/[locale]/workspace/account` now includes a dedicated identity panel that points users to `passport.cubid.me` as the source-of-truth identity authority
 - user and project onboarding now begin with an explicit CUBID prerequisite step, and both publish paths require a linked identity before completion
 
+Session 17 turned `/[locale]/workspace` into the real regular-user workspace home.
+
+- `/[locale]/workspace` now summarizes identity readiness, hybrid profile completion, participation footprint, project discovery, and current published zkAS result visibility.
+- The detailed personal result history temporarily remains at `/[locale]/settings/zkas` until the later reporting and payout workspace sessions create the final `/workspace/reporting` and `/workspace/earnings` surfaces.
+- Workspace data is read server-side and should degrade to safe empty/warning states rather than crashing the signed-in home when one non-critical read fails.
+
 ## Canonical Entry Routes
 
 Session 08 introduced the first IA-aligned entry routes:

--- a/docs/engineering/route-inventory.md
+++ b/docs/engineering/route-inventory.md
@@ -53,7 +53,7 @@ This inventory covers every current `page.tsx` and `route.ts` surface under `app
 
 | Path | Audience | Current state | Evidence / notes | Disposition | Canonical target | Follow-up session |
 | --- | --- | --- | --- | --- | --- | --- |
-| `/workspace` | Signed-in users | New lightweight user-workspace entry shell. | Session 08 introduced this as the canonical signed-in user start point before Session 17 rebuilds the fuller home. | finish | User workspace home | 17 |
+| `/workspace` | Signed-in users | Real regular-user workspace home. | Session 17 rebuilt the route around identity readiness, profile completion, participation footprint, discovery next actions, and current published result visibility. | finish | User workspace home | 17 |
 | `/workspace/account` | Signed-in users | Workspace account hub with explicit identity ownership split. | Sessions 15 and 16 made CUBID-managed identity read-only here and separated it from FundLoop-managed profile/preferences. | finish | User workspace account settings | 16, 42 |
 | `/founder` | Founders, project members | New lightweight founder-workspace entry shell. | Session 08 introduced this as the canonical founder start point while deeper project operations remain under project-specific routes. | finish | Founder workspace home | 18 |
 | `/founder/projects` | Founders, project members | New founder project index shell. | Bridges the new founder shell to existing project operations routes. | finish | Founder workspace projects | 18 |
@@ -65,7 +65,7 @@ This inventory covers every current `page.tsx` and `route.ts` surface under `app
 | `/projects/[slug]/zkas/uploads/[id]` | Project admins, operators | Transitional upload-detail leaf. | Should live under project contribution-data submission and audit flow. | merge | Founder workspace attribution/data submission history | 34 |
 | `/settings` | Signed-in users | Redirect-only legacy entry. | Session 08 collapsed the old settings hub into `/workspace/account` to remove dead-end settings navigation. | redirect | `/workspace/account` | 42 |
 | `/settings/account` | Signed-in users | Redirect-only legacy account leaf. | Session 08 redirected the old account route to the new workspace account surface. | redirect | `/workspace/account` | 16, 42 |
-| `/settings/zkas` | Signed-in users | Transitional personal zkAS results page. | Better treated as part of earnings/reporting than general settings. | merge | User workspace reporting and results | 35, 36 |
+| `/settings/zkas` | Signed-in users | Transitional personal zkAS results detail page. | Session 17 summarizes published results from `/workspace`, but keeps this route as the truthful interim detailed history until reporting/earnings routes are built. | merge | User workspace reporting and results | 35, 36 |
 
 ## Internal Operator and Admin Surfaces
 

--- a/i18n/messages/en.ts
+++ b/i18n/messages/en.ts
@@ -428,15 +428,24 @@ export const enMessages = {
   },
   workspace: {
     eyebrow: "User workspace",
-    title: "A clearer home for your FundLoop activity",
+    title: "Your participation, identity, and current results in one place",
     body:
-      "This is the new entry point for the participant side of FundLoop. The fuller workspace arrives later, but from here you can already track identity readiness, local profile preferences, participation context, and published results.",
-    open: "Open",
+      "Use this workspace to understand where you stand today: identity readiness, profile completion, project participation, discovery opportunities, and the published results FundLoop can already show.",
+    stats: {
+      projects: "Joined projects",
+      results: "Published result runs",
+      totalAllocation: "Published allocation",
+    },
+    warnings: {
+      title: "Some workspace data is temporarily unavailable.",
+      body: "The page is showing the parts that loaded safely. Try refreshing later if participation or results look incomplete.",
+    },
     identity: {
-      title: "Identity status now matters before value can move",
-      cta: "Open CUBID Passport",
-      followUp:
-        "If this still shows as unlinked, finish the CUBID resolution step in onboarding or visit the account tab to understand what is missing before publish and payout-touching actions.",
+      title: "Identity readiness",
+      signedIn: "Signed in as",
+      unknownEmail: "Email unavailable",
+      accountCta: "Open account",
+      passportCta: "Open CUBID Passport",
       status: {
         unlinked: "Not linked yet",
         linked: "Linked",
@@ -451,23 +460,50 @@ export const enMessages = {
           "Your signed-in account is linked to CUBID and the latest response shows a verified email identity, which is the strongest state currently surfaced in FundLoop.",
       },
     },
-    cards: {
-      account: {
-        title: "Account",
-        description: "Manage the account settings and payout-touching preferences that now belong in your workspace.",
-      },
-      participation: {
-        title: "Participation",
-        description: "Return to the public participation guide while the full workspace home is still being rebuilt.",
-      },
-      results: {
-        title: "Published results",
-        description: "Review the personal zkAS publication surface that will later move into workspace reporting.",
-      },
-      founder: {
-        title: "Founder workspace",
-        description: "Jump directly into the project-operations side of FundLoop when you are managing a project.",
-      },
+    completion: {
+      title: "Profile completion",
+      description:
+        "This blends FundLoop-managed profile context with CUBID-backed trust signals, so you can see which parts improve discoverability and future eligibility.",
+      complete: "All current completion items are covered.",
+    },
+    participation: {
+      title: "Participation footprint",
+      description: "Projects you have joined or help administer create the participation signal that future monthly cycles can use.",
+      joined: "Joined",
+      favorites: "Favorites",
+      admin: "Admin",
+      projectFallback: "Open this project to see the current public context.",
+      emptyTitle: "No joined projects yet",
+      emptyBody: "Start with public discovery, choose projects that fit your interests, and build signal before later payout flows arrive.",
+    },
+    results: {
+      title: "Current results visibility",
+      description:
+        "This is not the full payout workspace yet. It summarizes published zkAS results that are already available for your account.",
+      latestMeta: "Aggregate score {score}, published {date}",
+      pendingDate: "date pending",
+      emptyTitle: "No published results yet",
+      emptyBody: "When a verified monthly result is published for you, the latest allocation and score will appear here.",
+      cta: "Open result history",
+    },
+    discovery: {
+      title: "Projects to explore",
+      description: "Recommended public projects exclude the ones you already joined, so discovery stays useful.",
+      projectFallback: "Open this project to learn how people participate.",
+      empty: "No new public project recommendations are available right now.",
+      cta: "Browse all projects",
+    },
+    actions: {
+      title: "Next actions",
+      description: "Jump to the parts of FundLoop that matter most from the user workspace.",
+      account: "Account",
+      accountDescription: "Refresh identity, manage profile preferences, wallets, and account settings.",
+      discover: "Discover projects",
+      discoverDescription: "Find active public projects where your participation can build signal.",
+      results: "Result history",
+      resultsDescription: "Review the interim detailed publication view while reporting is consolidated.",
+      founder: "Founder workspace",
+      founderDescription: "Switch to project operations when you manage a project.",
     },
   },
   workspaceAccount: {

--- a/i18n/messages/en.ts
+++ b/i18n/messages/en.ts
@@ -475,6 +475,7 @@ export const enMessages = {
       projectFallback: "Open this project to see the current public context.",
       emptyTitle: "No joined projects yet",
       emptyBody: "Start with public discovery, choose projects that fit your interests, and build signal before later payout flows arrive.",
+      detailsUnavailable: "You have joined projects, but their details could not be loaded right now. Try refreshing in a moment.",
     },
     results: {
       title: "Current results visibility",

--- a/i18n/messages/es.ts
+++ b/i18n/messages/es.ts
@@ -467,6 +467,7 @@ export const esMessages = {
       projectFallback: "Abre este proyecto para ver su contexto público actual.",
       emptyTitle: "Todavía no te uniste a proyectos",
       emptyBody: "Empieza con el descubrimiento público, elige proyectos que encajen con tus intereses y construye señal antes de los futuros flujos de pago.",
+      detailsUnavailable: "Te uniste a proyectos, pero sus detalles no se pudieron cargar ahora mismo. Intenta actualizar en un momento.",
     },
     results: {
       title: "Visibilidad de resultados actuales",

--- a/i18n/messages/es.ts
+++ b/i18n/messages/es.ts
@@ -420,15 +420,24 @@ export const esMessages = {
   },
   workspace: {
     eyebrow: "Espacio de usuario",
-    title: "Un punto de partida más claro para tu actividad en FundLoop",
+    title: "Tu participación, identidad y resultados actuales en un solo lugar",
     body:
-      "Esta es la nueva entrada para el lado participante de FundLoop. El espacio completo llegará después, pero desde aquí ya puedes moverte hacia la cuenta, el contexto de participación y los resultados publicados.",
-    open: "Abrir",
+      "Usa este espacio para entender dónde estás hoy: preparación de identidad, completitud del perfil, participación en proyectos, oportunidades de descubrimiento y resultados publicados que FundLoop ya puede mostrar.",
+    stats: {
+      projects: "Proyectos unidos",
+      results: "Ciclos de resultados publicados",
+      totalAllocation: "Asignación publicada",
+    },
+    warnings: {
+      title: "Algunos datos del espacio no están disponibles temporalmente.",
+      body: "La página muestra las partes que cargaron con seguridad. Vuelve a intentar más tarde si la participación o los resultados parecen incompletos.",
+    },
     identity: {
-      title: "El estado de identidad ya importa antes de que el valor pueda moverse",
-      cta: "Abrir CUBID Passport",
-      followUp:
-        "Si esto sigue apareciendo como no enlazado, completa el paso de resolución de CUBID en onboarding o abre la pestaña de cuenta para entender qué falta antes de publicar o tocar flujos de pago.",
+      title: "Preparación de identidad",
+      signedIn: "Sesión iniciada como",
+      unknownEmail: "Correo no disponible",
+      accountCta: "Abrir cuenta",
+      passportCta: "Abrir CUBID Passport",
       status: {
         unlinked: "Aún sin enlazar",
         linked: "Enlazado",
@@ -443,23 +452,50 @@ export const esMessages = {
           "Tu cuenta conectada está enlazada con CUBID y la última respuesta muestra una identidad de correo verificada, el estado más fuerte que hoy expone FundLoop.",
       },
     },
-    cards: {
-      account: {
-        title: "Cuenta",
-        description: "Gestiona la configuración de cuenta y las preferencias relacionadas con pagos que ahora viven en tu espacio.",
-      },
-      participation: {
-        title: "Participación",
-        description: "Vuelve a la guía pública de participación mientras el hogar completo del espacio todavía se reconstruye.",
-      },
-      results: {
-        title: "Resultados publicados",
-        description: "Revisa la superficie personal de zkAS que más adelante se moverá al reporting del espacio.",
-      },
-      founder: {
-        title: "Espacio fundador",
-        description: "Salta directamente al lado operativo de proyectos en FundLoop cuando estés gestionando un proyecto.",
-      },
+    completion: {
+      title: "Completitud del perfil",
+      description:
+        "Combina el contexto de perfil gestionado por FundLoop con señales de confianza de CUBID, para mostrar qué mejora la descubribilidad y la elegibilidad futura.",
+      complete: "Todos los elementos actuales de completitud están cubiertos.",
+    },
+    participation: {
+      title: "Huella de participación",
+      description: "Los proyectos a los que te unes o ayudas a administrar crean la señal que podrán usar los futuros ciclos mensuales.",
+      joined: "Unidos",
+      favorites: "Favoritos",
+      admin: "Admin",
+      projectFallback: "Abre este proyecto para ver su contexto público actual.",
+      emptyTitle: "Todavía no te uniste a proyectos",
+      emptyBody: "Empieza con el descubrimiento público, elige proyectos que encajen con tus intereses y construye señal antes de los futuros flujos de pago.",
+    },
+    results: {
+      title: "Visibilidad de resultados actuales",
+      description:
+        "Este todavía no es el espacio completo de pagos. Resume los resultados zkAS publicados que ya están disponibles para tu cuenta.",
+      latestMeta: "Puntaje agregado {score}, publicado {date}",
+      pendingDate: "fecha pendiente",
+      emptyTitle: "Todavía no hay resultados publicados",
+      emptyBody: "Cuando se publique un resultado mensual verificado para ti, la última asignación y el puntaje aparecerán aquí.",
+      cta: "Abrir historial de resultados",
+    },
+    discovery: {
+      title: "Proyectos para explorar",
+      description: "Las recomendaciones públicas excluyen los proyectos a los que ya te uniste, para que el descubrimiento siga siendo útil.",
+      projectFallback: "Abre este proyecto para ver cómo participan las personas.",
+      empty: "No hay nuevas recomendaciones de proyectos públicos disponibles ahora mismo.",
+      cta: "Explorar todos los proyectos",
+    },
+    actions: {
+      title: "Próximas acciones",
+      description: "Salta a las partes de FundLoop más importantes desde el espacio de usuario.",
+      account: "Cuenta",
+      accountDescription: "Actualiza identidad, preferencias de perfil, wallets y configuración de cuenta.",
+      discover: "Descubrir proyectos",
+      discoverDescription: "Encuentra proyectos públicos activos donde tu participación pueda construir señal.",
+      results: "Historial de resultados",
+      resultsDescription: "Revisa la vista detallada provisional mientras se consolida el reporting.",
+      founder: "Espacio fundador",
+      founderDescription: "Cambia a operaciones de proyecto cuando gestionas un proyecto.",
     },
   },
   workspaceAccount: {

--- a/i18n/messages/fr.ts
+++ b/i18n/messages/fr.ts
@@ -467,6 +467,7 @@ export const frMessages = {
       projectFallback: "Ouvrez ce projet pour voir son contexte public actuel.",
       emptyTitle: "Aucun projet rejoint pour le moment",
       emptyBody: "Commencez par la découverte publique, choisissez des projets alignés avec vos intérêts et construisez du signal avant les futurs flux de paiement.",
+      detailsUnavailable: "Vous avez rejoint des projets, mais leurs détails ne peuvent pas être chargés pour le moment. Réessayez dans un instant.",
     },
     results: {
       title: "Visibilité des résultats actuels",

--- a/i18n/messages/fr.ts
+++ b/i18n/messages/fr.ts
@@ -420,15 +420,24 @@ export const frMessages = {
   },
   workspace: {
     eyebrow: "Espace utilisateur",
-    title: "Un point d’entrée plus clair pour votre activité FundLoop",
+    title: "Votre participation, votre identité et vos résultats actuels au même endroit",
     body:
-      "C’est la nouvelle porte d’entrée du côté participant. L’espace complet arrive plus tard, mais vous pouvez déjà aller vers le compte, le contexte de participation et les résultats publiés.",
-    open: "Ouvrir",
+      "Utilisez cet espace pour voir où vous en êtes aujourd’hui : identité, complétude du profil, participation aux projets, pistes de découverte et résultats publiés déjà visibles dans FundLoop.",
+    stats: {
+      projects: "Projets rejoints",
+      results: "Cycles de résultats publiés",
+      totalAllocation: "Allocation publiée",
+    },
+    warnings: {
+      title: "Certaines données de l’espace sont temporairement indisponibles.",
+      body: "La page affiche les parties chargées sans risque. Réessayez plus tard si la participation ou les résultats semblent incomplets.",
+    },
     identity: {
-      title: "Le statut d’identité compte désormais avant que la valeur puisse circuler",
-      cta: "Ouvrir CUBID Passport",
-      followUp:
-        "Si cet état reste non lié, terminez l’étape de résolution CUBID dans l’onboarding ou ouvrez l’onglet compte pour voir ce qui manque avant les publications et opérations liées aux paiements.",
+      title: "Préparation de l’identité",
+      signedIn: "Connecté en tant que",
+      unknownEmail: "E-mail indisponible",
+      accountCta: "Ouvrir le compte",
+      passportCta: "Ouvrir CUBID Passport",
       status: {
         unlinked: "Pas encore lié",
         linked: "Lié",
@@ -443,23 +452,50 @@ export const frMessages = {
           "Votre compte connecté est lié à CUBID et la dernière réponse montre une identité e-mail vérifiée, soit l’état le plus fort actuellement visible dans FundLoop.",
       },
     },
-    cards: {
-      account: {
-        title: "Compte",
-        description: "Gérez les préférences et réglages personnels qui appartiennent désormais à votre espace.",
-      },
-      participation: {
-        title: "Participation",
-        description: "Revenez au guide public de participation pendant que l’accueil complet de l’espace est encore en chantier.",
-      },
-      results: {
-        title: "Résultats publiés",
-        description: "Consultez la surface personnelle zkAS qui sera ensuite déplacée vers le reporting de l’espace.",
-      },
-      founder: {
-        title: "Espace fondateur",
-        description: "Accédez directement au côté opérations projet de FundLoop lorsque vous gérez un projet.",
-      },
+    completion: {
+      title: "Complétude du profil",
+      description:
+        "Ce score mélange le contexte de profil géré par FundLoop avec les signaux de confiance CUBID afin de montrer ce qui améliore la découvrabilité et l’éligibilité future.",
+      complete: "Tous les éléments de complétude actuels sont couverts.",
+    },
+    participation: {
+      title: "Empreinte de participation",
+      description: "Les projets que vous rejoignez ou administrez créent le signal que les futurs cycles mensuels pourront utiliser.",
+      joined: "Rejoints",
+      favorites: "Favoris",
+      admin: "Admin",
+      projectFallback: "Ouvrez ce projet pour voir son contexte public actuel.",
+      emptyTitle: "Aucun projet rejoint pour le moment",
+      emptyBody: "Commencez par la découverte publique, choisissez des projets alignés avec vos intérêts et construisez du signal avant les futurs flux de paiement.",
+    },
+    results: {
+      title: "Visibilité des résultats actuels",
+      description:
+        "Ce n’est pas encore l’espace complet de paiement. Cette carte résume les résultats zkAS publiés déjà disponibles pour votre compte.",
+      latestMeta: "Score agrégé {score}, publié le {date}",
+      pendingDate: "date en attente",
+      emptyTitle: "Aucun résultat publié pour le moment",
+      emptyBody: "Quand un résultat mensuel vérifié sera publié pour vous, la dernière allocation et le score apparaîtront ici.",
+      cta: "Ouvrir l’historique des résultats",
+    },
+    discovery: {
+      title: "Projets à explorer",
+      description: "Les recommandations publiques excluent les projets déjà rejoints afin que la découverte reste utile.",
+      projectFallback: "Ouvrez ce projet pour voir comment les personnes participent.",
+      empty: "Aucune nouvelle recommandation de projet public n’est disponible pour le moment.",
+      cta: "Parcourir tous les projets",
+    },
+    actions: {
+      title: "Prochaines actions",
+      description: "Accédez aux parties de FundLoop les plus utiles depuis l’espace utilisateur.",
+      account: "Compte",
+      accountDescription: "Actualisez l’identité, gérez les préférences de profil, les wallets et les réglages du compte.",
+      discover: "Découvrir des projets",
+      discoverDescription: "Trouvez des projets publics actifs où votre participation peut créer du signal.",
+      results: "Historique des résultats",
+      resultsDescription: "Consultez la vue détaillée intermédiaire pendant que le reporting est consolidé.",
+      founder: "Espace fondateur",
+      founderDescription: "Passez aux opérations projet lorsque vous gérez un projet.",
     },
   },
   workspaceAccount: {

--- a/lib/workspace/user-workspace.ts
+++ b/lib/workspace/user-workspace.ts
@@ -1,0 +1,305 @@
+import "server-only"
+
+import type { NavigationContext } from "@/lib/navigation-context"
+import { createServerSupabaseClient } from "@/lib/supabase-server"
+
+export type UserWorkspaceWarning = {
+  scope: string
+  message: string
+}
+
+export type UserWorkspaceProject = {
+  id: number
+  slug: string | null
+  name: string
+  description: string | null
+  logoUrl: string | null
+  joinedAt: string | null
+  isFavorite: boolean
+  isAdmin: boolean
+}
+
+export type UserWorkspaceRecommendedProject = {
+  id: number
+  slug: string | null
+  name: string
+  description: string | null
+  logoUrl: string | null
+}
+
+export type UserWorkspaceResultSummary = {
+  latest: {
+    allocationUsd: number
+    aggregateScore: number
+    publishedAt: string
+    monthLabel: string
+  } | null
+  totalAllocationUsd: number
+  resultCount: number
+  detailHref: "/settings/zkas"
+}
+
+export type UserWorkspaceHome = {
+  profileStatus: {
+    signedInEmail: string | null
+    cubidStatus: NonNullable<NavigationContext["user"]>["cubidIdentityStatus"]
+    completionPercent: number
+    missingItems: string[]
+  }
+  participation: {
+    joinedProjectCount: number
+    founderProjectCount: number
+    favoriteProjectCount: number
+    recentProjects: UserWorkspaceProject[]
+  }
+  discovery: {
+    recommendedProjects: UserWorkspaceRecommendedProject[]
+  }
+  results: UserWorkspaceResultSummary
+  warnings: UserWorkspaceWarning[]
+}
+
+type ParticipantRow = {
+  project_id: number
+  is_admin: boolean | null
+  is_favorite: boolean | null
+  joined_at: string | null
+}
+
+type ProjectRow = {
+  id: number
+  slug: string | null
+  name: string
+  description: string | null
+  logo_url: string | null
+}
+
+type PublishedResultRow = {
+  allocation_usd: number
+  aggregate_score: number
+  published_at: string
+  run_id: number
+}
+
+type RunRow = {
+  id: number
+  month: string
+}
+
+type SupabaseReadResult<T> = {
+  data: T | null
+  error: { message?: string } | null
+}
+
+function warningFromError(scope: string, error: { message?: string } | null | undefined): UserWorkspaceWarning | null {
+  if (!error) {
+    return null
+  }
+
+  return {
+    scope,
+    message: error.message ?? "Workspace data could not be loaded.",
+  }
+}
+
+async function readWorkspaceData<T>(
+  scope: string,
+  query: PromiseLike<SupabaseReadResult<T>>,
+  warnings: UserWorkspaceWarning[],
+  fallback: T,
+): Promise<T> {
+  try {
+    const { data, error } = await query
+    const warning = warningFromError(scope, error)
+    if (warning) {
+      warnings.push(warning)
+      return fallback
+    }
+
+    return data ?? fallback
+  } catch (error) {
+    warnings.push({
+      scope,
+      message: error instanceof Error ? error.message : "Workspace data could not be loaded.",
+    })
+    return fallback
+  }
+}
+
+function mapProjectWithParticipation(project: ProjectRow, participant: ParticipantRow): UserWorkspaceProject {
+  return {
+    id: project.id,
+    slug: project.slug,
+    name: project.name,
+    description: project.description,
+    logoUrl: project.logo_url,
+    joinedAt: participant.joined_at,
+    isFavorite: participant.is_favorite === true,
+    isAdmin: participant.is_admin === true,
+  }
+}
+
+function mapRecommendedProject(project: ProjectRow): UserWorkspaceRecommendedProject {
+  return {
+    id: project.id,
+    slug: project.slug,
+    name: project.name,
+    description: project.description,
+    logoUrl: project.logo_url,
+  }
+}
+
+export function buildUserWorkspaceHome({
+  navigationContext,
+  participantRows,
+  joinedProjects,
+  recommendedProjects,
+  publishedResults,
+  runs,
+  warnings,
+}: {
+  navigationContext: NavigationContext
+  participantRows: ParticipantRow[]
+  joinedProjects: ProjectRow[]
+  recommendedProjects: ProjectRow[]
+  publishedResults: PublishedResultRow[]
+  runs: RunRow[]
+  warnings: UserWorkspaceWarning[]
+}): UserWorkspaceHome {
+  const user = navigationContext.user
+  const joinedProjectById = new Map(joinedProjects.map((project) => [project.id, project]))
+  const runById = new Map(runs.map((run) => [run.id, run]))
+  const recentProjects = participantRows
+    .map((participant) => {
+      const project = joinedProjectById.get(participant.project_id)
+      return project ? mapProjectWithParticipation(project, participant) : null
+    })
+    .filter((project): project is UserWorkspaceProject => Boolean(project))
+    .sort((left, right) => new Date(right.joinedAt ?? 0).getTime() - new Date(left.joinedAt ?? 0).getTime())
+    .slice(0, 3)
+
+  const latestResult = publishedResults[0] ?? null
+
+  return {
+    profileStatus: {
+      signedInEmail: user?.email ?? null,
+      cubidStatus: user?.cubidIdentityStatus ?? "unlinked",
+      completionPercent: user?.profileCompletionPercent ?? 0,
+      missingItems: user?.profileCompletionMissingItems ?? [],
+    },
+    participation: {
+      joinedProjectCount: participantRows.length,
+      founderProjectCount: participantRows.filter((participant) => participant.is_admin === true).length,
+      favoriteProjectCount: participantRows.filter((participant) => participant.is_favorite === true).length,
+      recentProjects,
+    },
+    discovery: {
+      recommendedProjects: recommendedProjects.slice(0, 3).map(mapRecommendedProject),
+    },
+    results: {
+      latest: latestResult
+        ? {
+            allocationUsd: Number(latestResult.allocation_usd),
+            aggregateScore: Number(latestResult.aggregate_score),
+            publishedAt: latestResult.published_at,
+            monthLabel: runById.get(latestResult.run_id)?.month ?? `Run ${latestResult.run_id}`,
+          }
+        : null,
+      totalAllocationUsd: publishedResults.reduce((sum, result) => sum + Number(result.allocation_usd), 0),
+      resultCount: publishedResults.length,
+      detailHref: "/settings/zkas",
+    },
+    warnings,
+  }
+}
+
+export async function getUserWorkspaceHome(navigationContext: NavigationContext): Promise<UserWorkspaceHome> {
+  const warnings: UserWorkspaceWarning[] = []
+  const user = navigationContext.user
+
+  if (!user) {
+    return buildUserWorkspaceHome({
+      navigationContext,
+      participantRows: [],
+      joinedProjects: [],
+      recommendedProjects: [],
+      publishedResults: [],
+      runs: [],
+      warnings,
+    })
+  }
+
+  const supabase = await createServerSupabaseClient()
+  const [participantRows, publishedResults, publicProjects] = await Promise.all([
+    readWorkspaceData<ParticipantRow[]>(
+      "participation",
+      supabase
+        .from("participants")
+        .select("project_id, is_admin, is_favorite, joined_at")
+        .eq("user_id", user.id)
+        .order("joined_at", { ascending: false }),
+      warnings,
+      [],
+    ),
+    readWorkspaceData<PublishedResultRow[]>(
+      "results",
+      supabase
+        .from("zkas_published_user_results")
+        .select("allocation_usd, aggregate_score, published_at, run_id")
+        .eq("user_id", user.id)
+        .order("published_at", { ascending: false }),
+      warnings,
+      [],
+    ),
+    readWorkspaceData<ProjectRow[]>(
+      "discovery",
+      supabase
+        .from("projects")
+        .select("id, slug, name, description, logo_url")
+        .eq("status", "active")
+        .eq("is_public", true)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: false })
+        .limit(8),
+      warnings,
+      [],
+    ),
+  ])
+
+  const joinedProjectIds = Array.from(new Set(participantRows.map((participant) => participant.project_id)))
+  const joinedProjects =
+    joinedProjectIds.length > 0
+      ? await readWorkspaceData<ProjectRow[]>(
+          "joined-projects",
+          supabase
+            .from("projects")
+            .select("id, slug, name, description, logo_url")
+            .in("id", joinedProjectIds)
+            .is("deleted_at", null),
+          warnings,
+          [],
+        )
+      : []
+  const resultRunIds = Array.from(new Set(publishedResults.map((result) => result.run_id)))
+  const runs =
+    resultRunIds.length > 0
+      ? await readWorkspaceData<RunRow[]>(
+          "result-runs",
+          supabase.from("zkas_runs").select("id, month").in("id", resultRunIds),
+          warnings,
+          [],
+        )
+      : []
+  const joinedProjectIdSet = new Set(joinedProjectIds)
+  const recommendedProjects = publicProjects.filter((project) => !joinedProjectIdSet.has(project.id))
+
+  return buildUserWorkspaceHome({
+    navigationContext,
+    participantRows,
+    joinedProjects,
+    recommendedProjects,
+    publishedResults,
+    runs,
+    warnings,
+  })
+}

--- a/lib/workspace/user-workspace.ts
+++ b/lib/workspace/user-workspace.ts
@@ -51,6 +51,7 @@ export type UserWorkspaceHome = {
     founderProjectCount: number
     favoriteProjectCount: number
     recentProjects: UserWorkspaceProject[]
+    hasUnavailableProjectDetails: boolean
   }
   discovery: {
     recommendedProjects: UserWorkspaceRecommendedProject[]
@@ -169,7 +170,9 @@ export function buildUserWorkspaceHome({
   const user = navigationContext.user
   const joinedProjectById = new Map(joinedProjects.map((project) => [project.id, project]))
   const runById = new Map(runs.map((run) => [run.id, run]))
-  const recentProjects = participantRows
+  const visibleParticipantRows = participantRows.filter((participant) => joinedProjectById.has(participant.project_id))
+  const hasJoinedProjectReadWarning = warnings.some((warning) => warning.scope === "joined-projects")
+  const recentProjects = visibleParticipantRows
     .map((participant) => {
       const project = joinedProjectById.get(participant.project_id)
       return project ? mapProjectWithParticipation(project, participant) : null
@@ -188,10 +191,11 @@ export function buildUserWorkspaceHome({
       missingItems: user?.profileCompletionMissingItems ?? [],
     },
     participation: {
-      joinedProjectCount: participantRows.length,
-      founderProjectCount: participantRows.filter((participant) => participant.is_admin === true).length,
-      favoriteProjectCount: participantRows.filter((participant) => participant.is_favorite === true).length,
+      joinedProjectCount: visibleParticipantRows.length,
+      founderProjectCount: visibleParticipantRows.filter((participant) => participant.is_admin === true).length,
+      favoriteProjectCount: visibleParticipantRows.filter((participant) => participant.is_favorite === true).length,
       recentProjects,
+      hasUnavailableProjectDetails: hasJoinedProjectReadWarning && participantRows.length > 0,
     },
     discovery: {
       recommendedProjects: recommendedProjects.slice(0, 3).map(mapRecommendedProject),
@@ -230,7 +234,7 @@ export async function getUserWorkspaceHome(navigationContext: NavigationContext)
   }
 
   const supabase = await createServerSupabaseClient()
-  const [participantRows, publishedResults, publicProjects] = await Promise.all([
+  const [participantRows, publishedResults] = await Promise.all([
     readWorkspaceData<ParticipantRow[]>(
       "participation",
       supabase
@@ -251,22 +255,19 @@ export async function getUserWorkspaceHome(navigationContext: NavigationContext)
       warnings,
       [],
     ),
-    readWorkspaceData<ProjectRow[]>(
-      "discovery",
-      supabase
-        .from("projects")
-        .select("id, slug, name, description, logo_url")
-        .eq("status", "active")
-        .eq("is_public", true)
-        .is("deleted_at", null)
-        .order("created_at", { ascending: false })
-        .limit(8),
-      warnings,
-      [],
-    ),
   ])
 
   const joinedProjectIds = Array.from(new Set(participantRows.map((participant) => participant.project_id)))
+  const publicProjectsQuery = supabase
+    .from("projects")
+    .select("id, slug, name, description, logo_url")
+    .eq("status", "active")
+    .eq("is_public", true)
+    .is("deleted_at", null)
+    .order("created_at", { ascending: false })
+    .limit(3)
+  const unjoinedPublicProjectsQuery =
+    joinedProjectIds.length > 0 ? publicProjectsQuery.not("id", "in", `(${joinedProjectIds.join(",")})`) : publicProjectsQuery
   const joinedProjects =
     joinedProjectIds.length > 0
       ? await readWorkspaceData<ProjectRow[]>(
@@ -281,17 +282,17 @@ export async function getUserWorkspaceHome(navigationContext: NavigationContext)
         )
       : []
   const resultRunIds = Array.from(new Set(publishedResults.map((result) => result.run_id)))
-  const runs =
+  const [runs, recommendedProjects] = await Promise.all([
     resultRunIds.length > 0
-      ? await readWorkspaceData<RunRow[]>(
+      ? readWorkspaceData<RunRow[]>(
           "result-runs",
           supabase.from("zkas_runs").select("id, month").in("id", resultRunIds),
           warnings,
           [],
         )
-      : []
-  const joinedProjectIdSet = new Set(joinedProjectIds)
-  const recommendedProjects = publicProjects.filter((project) => !joinedProjectIdSet.has(project.id))
+      : Promise.resolve([]),
+    readWorkspaceData<ProjectRow[]>("discovery", unjoinedPublicProjectsQuery, warnings, []),
+  ])
 
   return buildUserWorkspaceHome({
     navigationContext,

--- a/tests/user-workspace.test.ts
+++ b/tests/user-workspace.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest"
+import type { NavigationContext } from "@/lib/navigation-context"
+import { buildUserWorkspaceHome } from "@/lib/workspace/user-workspace"
+
+function navigationContext(overrides: Partial<NavigationContext["user"]> = {}): NavigationContext {
+  return {
+    user: {
+      id: "user-1",
+      email: "maya@example.com",
+      fullName: "Maya Torres",
+      avatarUrl: null,
+      status: "active",
+      cubidIdentityStatus: "linked",
+      cubidId: "cubid-user-1",
+      primaryEmailIdentity: "maya@example.com",
+      cubidScore: 82,
+      cubidSnapshot: null,
+      managedIdentity: {
+        fullName: { value: "Maya Torres", state: "synced" },
+        primaryEmail: { value: "maya@example.com", state: "synced" },
+        primaryPhone: { value: null, state: "pending" },
+      },
+      identityOwnership: {
+        cubidManaged: ["full_name", "email"],
+        fundloopManaged: ["display_name", "bio"],
+      },
+      localProfile: {
+        displayName: "Maya",
+        profileHeadline: "Builder",
+        bio: "Bio",
+        occupationName: "Designer",
+        locationName: "Toronto",
+        interestCount: 2,
+        interestNames: ["Climate", "Open source"],
+        visibility: {
+          isPublic: true,
+          isNamePublic: true,
+          isPfpPublic: true,
+          isGenderPublic: false,
+          isOccupationPublic: true,
+          isLocationPublic: true,
+        },
+      },
+      profileCompletionPercent: 70,
+      profileCompletionMissingItems: ["cubid_phone"],
+      ...overrides,
+    },
+    isAuthenticated: true,
+    hasWorkspaceAccess: true,
+    hasFounderAccess: false,
+    hasAdminAccess: false,
+    managedProjects: [],
+    cubidPassportOrigin: "https://passport.cubid.me",
+    cubidStampPageId: "123",
+  }
+}
+
+describe("buildUserWorkspaceHome", () => {
+  it("builds calm empty states for an active user with no project participation", () => {
+    const home = buildUserWorkspaceHome({
+      navigationContext: navigationContext(),
+      participantRows: [],
+      joinedProjects: [],
+      recommendedProjects: [
+        {
+          id: 10,
+          slug: "solar-commons",
+          name: "Solar Commons",
+          description: "Community solar project",
+          logo_url: null,
+        },
+      ],
+      publishedResults: [],
+      runs: [],
+      warnings: [],
+    })
+
+    expect(home.profileStatus).toMatchObject({
+      signedInEmail: "maya@example.com",
+      cubidStatus: "linked",
+      completionPercent: 70,
+      missingItems: ["cubid_phone"],
+    })
+    expect(home.participation.joinedProjectCount).toBe(0)
+    expect(home.participation.recentProjects).toEqual([])
+    expect(home.discovery.recommendedProjects).toHaveLength(1)
+    expect(home.results.latest).toBeNull()
+  })
+
+  it("summarizes joined projects, favorites, founder-admin participation, and published results", () => {
+    const home = buildUserWorkspaceHome({
+      navigationContext: navigationContext({ cubidIdentityStatus: "verified", profileCompletionPercent: 100, profileCompletionMissingItems: [] }),
+      participantRows: [
+        {
+          project_id: 2,
+          is_admin: true,
+          is_favorite: false,
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+        {
+          project_id: 1,
+          is_admin: false,
+          is_favorite: true,
+          joined_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      joinedProjects: [
+        {
+          id: 1,
+          slug: "open-gardens",
+          name: "Open Gardens",
+          description: "Garden coordination",
+          logo_url: null,
+        },
+        {
+          id: 2,
+          slug: "solar-commons",
+          name: "Solar Commons",
+          description: "Solar coordination",
+          logo_url: null,
+        },
+      ],
+      recommendedProjects: [],
+      publishedResults: [
+        {
+          allocation_usd: 125,
+          aggregate_score: 220,
+          published_at: "2026-04-10T00:00:00Z",
+          run_id: 7,
+        },
+        {
+          allocation_usd: 75,
+          aggregate_score: 180,
+          published_at: "2026-03-10T00:00:00Z",
+          run_id: 6,
+        },
+      ],
+      runs: [
+        { id: 7, month: "2026-04" },
+        { id: 6, month: "2026-03" },
+      ],
+      warnings: [],
+    })
+
+    expect(home.profileStatus.cubidStatus).toBe("verified")
+    expect(home.participation.joinedProjectCount).toBe(2)
+    expect(home.participation.favoriteProjectCount).toBe(1)
+    expect(home.participation.founderProjectCount).toBe(1)
+    expect(home.participation.recentProjects[0]?.name).toBe("Solar Commons")
+    expect(home.results.latest).toMatchObject({
+      allocationUsd: 125,
+      aggregateScore: 220,
+      monthLabel: "2026-04",
+    })
+    expect(home.results.totalAllocationUsd).toBe(200)
+    expect(home.results.resultCount).toBe(2)
+  })
+
+  it("preserves non-fatal read warnings for the page to render softly", () => {
+    const home = buildUserWorkspaceHome({
+      navigationContext: navigationContext(),
+      participantRows: [],
+      joinedProjects: [],
+      recommendedProjects: [],
+      publishedResults: [],
+      runs: [],
+      warnings: [{ scope: "results", message: "network unavailable" }],
+    })
+
+    expect(home.warnings).toEqual([{ scope: "results", message: "network unavailable" }])
+    expect(home.results.detailHref).toBe("/settings/zkas")
+  })
+})

--- a/tests/user-workspace.test.ts
+++ b/tests/user-workspace.test.ts
@@ -82,6 +82,7 @@ describe("buildUserWorkspaceHome", () => {
       missingItems: ["cubid_phone"],
     })
     expect(home.participation.joinedProjectCount).toBe(0)
+    expect(home.participation.hasUnavailableProjectDetails).toBe(false)
     expect(home.participation.recentProjects).toEqual([])
     expect(home.discovery.recommendedProjects).toHaveLength(1)
     expect(home.results.latest).toBeNull()
@@ -146,6 +147,7 @@ describe("buildUserWorkspaceHome", () => {
     expect(home.participation.joinedProjectCount).toBe(2)
     expect(home.participation.favoriteProjectCount).toBe(1)
     expect(home.participation.founderProjectCount).toBe(1)
+    expect(home.participation.hasUnavailableProjectDetails).toBe(false)
     expect(home.participation.recentProjects[0]?.name).toBe("Solar Commons")
     expect(home.results.latest).toMatchObject({
       allocationUsd: 125,
@@ -169,5 +171,66 @@ describe("buildUserWorkspaceHome", () => {
 
     expect(home.warnings).toEqual([{ scope: "results", message: "network unavailable" }])
     expect(home.results.detailHref).toBe("/settings/zkas")
+  })
+
+  it("excludes participant rows without hydrated non-deleted projects from counters", () => {
+    const home = buildUserWorkspaceHome({
+      navigationContext: navigationContext(),
+      participantRows: [
+        {
+          project_id: 1,
+          is_admin: true,
+          is_favorite: true,
+          joined_at: "2026-04-01T00:00:00Z",
+        },
+        {
+          project_id: 99,
+          is_admin: true,
+          is_favorite: true,
+          joined_at: "2026-04-02T00:00:00Z",
+        },
+      ],
+      joinedProjects: [
+        {
+          id: 1,
+          slug: "open-gardens",
+          name: "Open Gardens",
+          description: "Garden coordination",
+          logo_url: null,
+        },
+      ],
+      recommendedProjects: [],
+      publishedResults: [],
+      runs: [],
+      warnings: [],
+    })
+
+    expect(home.participation.joinedProjectCount).toBe(1)
+    expect(home.participation.favoriteProjectCount).toBe(1)
+    expect(home.participation.founderProjectCount).toBe(1)
+    expect(home.participation.recentProjects).toHaveLength(1)
+  })
+
+  it("flags temporarily unavailable project details without inflating counters", () => {
+    const home = buildUserWorkspaceHome({
+      navigationContext: navigationContext(),
+      participantRows: [
+        {
+          project_id: 1,
+          is_admin: true,
+          is_favorite: true,
+          joined_at: "2026-04-01T00:00:00Z",
+        },
+      ],
+      joinedProjects: [],
+      recommendedProjects: [],
+      publishedResults: [],
+      runs: [],
+      warnings: [{ scope: "joined-projects", message: "network unavailable" }],
+    })
+
+    expect(home.participation.joinedProjectCount).toBe(0)
+    expect(home.participation.hasUnavailableProjectDetails).toBe(true)
+    expect(home.participation.recentProjects).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Reconciles stale Sessions 04 and 05 backlog metadata with the Edge Function work that already landed.
- Rebuilds `/workspace` into a real signed-in user home for Session 17.
- Adds a server-only workspace read model for identity, participation, discovery, and current published result summaries.
- Keeps `/settings/zkas` as the interim detailed result history until later reporting/payout sessions.

## Objective
Give regular users a useful canonical workspace entry point now that the public funnels, app shell, onboarding, and CUBID identity foundations are in place, while avoiding premature payout/reporting route expansion.

## Changes
- Marks Sessions 04 and 05 complete in `agent-context/todo.md` using existing session-log references.
- Adds `lib/workspace/user-workspace.ts` to gather workspace summary data with safe warning/empty-state behavior.
- Reworks `/[locale]/workspace` around identity readiness, profile completion, participation footprint, project discovery, current results visibility, and conditional founder shortcuts.
- Updates workspace translations in English, French, and Spanish.
- Updates engineering docs and route inventory to record `/workspace` as the real Session 17 user home.
- Adds focused read-model tests in `tests/user-workspace.test.ts`.

## Validation
- `pnpm exec vitest run tests/user-workspace.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build`
- `next start` smoke: unauthenticated `GET /en/workspace` returned `307` to `/en/join`.

## Reviewer Notes
- Review the backlog hygiene commit first, then the Session 17 implementation commit.
- The workspace read model intentionally degrades partial read failures into warnings/empty states instead of crashing the user home.
- No schema, authorization, Edge Function, payout, or new workspace subroute changes are included.

## Follow-ups
- Session 18 should build the founder/project workspace home.
- Later reporting and payout sessions should move detailed personal results out of `/settings/zkas` and into canonical workspace reporting/earnings routes.
- A signed-in browser smoke is still useful when a local authenticated session is available.
