### PR TITLE
[codex] Repair Supabase function deploy step

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -169,4 +169,19 @@ jobs:
         if: steps.target.outputs.mode == 'deploy'
         env:
           SUPABASE_PROJECT_REF: ${{ steps.target.outputs.project_ref }}
-        run: supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF"
+        run: |
+          set -euo pipefail
+
+          function_names="$(
+            find supabase/functions -mindepth 1 -maxdepth 1 -type d ! -name "_shared" -exec basename {} \; | sort
+          )"
+
+          if [[ -z "${function_names}" ]]; then
+            echo "::error::No deployable Supabase Edge Functions were found under supabase/functions."
+            exit 1
+          fi
+
+          while IFS= read -r function_name; do
+            echo "Deploying Edge Function: ${function_name}"
+            supabase functions deploy "${function_name}" --project-ref "$SUPABASE_PROJECT_REF"
+          done <<< "${function_names}"

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,30 @@
+### session v73: Repair Supabase function deploy enumeration
+- timestamp: 2026-04-26T04:48:22-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-function-deploy-repair**
+- head: pending final commit
+
+#### Objective
+Fix the push-triggered Supabase deploy workflow after the migration repair landed but Edge Function deployment still failed on `dev`.
+
+#### Actions Taken
+- Changed the workflow's Edge Function deploy step to enumerate every directory under `supabase/functions/` except `_shared` and deploy each function explicitly.
+- Updated the Supabase deployment engineering doc to match the per-function deploy behavior required by the current Supabase CLI.
+
+#### Tests and Validation Notes
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'` passed.
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `git diff --check` passed.
+- `find supabase/functions -mindepth 1 -maxdepth 1 -type d ! -name '_shared' -exec basename {} \; | sort` returned the expected deployable function list.
+
+#### Reflections
+- The migration repair was correct; the remaining failure was a CLI-behavior mismatch in the workflow, not another remote schema problem.
+
+#### Suggested Next Steps
+- Validate the updated workflow statically, PR it into `dev`, and confirm the follow-up push-triggered `Supabase Deploy` run completes both migrations and function deploys.
+
+---
+
 ### session v72: Repair Supabase deploy path for remote sequence drift
 - timestamp: 2026-04-26T04:40:39-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -43,10 +43,10 @@ Pull requests use the same target resolution but run:
 supabase db push --yes --db-url "$SUPABASE_DB_URL" --dry-run
 ```
 
-Edge Functions are deployed in one command:
+Edge Functions are deployed by enumerating each local function directory under `supabase/functions/` except `_shared` and deploying them one by one:
 
 ```bash
-supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF"
+supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
 The workflow pins the Supabase CLI version instead of using `latest`; update it deliberately during normal dependency/tooling triage.


### PR DESCRIPTION
## Summary
- Repairs the second half of the Supabase deploy workflow: Edge Function deployment on `dev` after the migration repair landed.
- Changes the workflow to deploy each function explicitly instead of relying on a bare `supabase functions deploy`.
- Updates deployment docs to match the actual CLI behavior.

## Objective
Finish the focused Supabase deploy repair so the push-triggered `Supabase Deploy` workflow on `dev` completes both database migrations and Edge Function deployment.

## Changes
- Updated `.github/workflows/supabase-deploy.yml` to enumerate deployable function directories under `supabase/functions/` except `_shared` and deploy each one in sequence.
- Left the existing project-ref routing and environment targeting intact.
- Updated `docs/engineering/supabase-deployments.md` to document the per-function deploy contract.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml`
- `git diff --check`
- `find supabase/functions -mindepth 1 -maxdepth 1 -type d ! -name '_shared' -exec basename {} \; | sort`

## Reviewer Notes
- This PR is intentionally tiny and should be reviewed after PR #26 / merge commit `2b74565` context.
- The preceding dev deploy already proved the migration repair worked; this patch only addresses the function deployment step.

## Follow-ups
- Merge to `dev` and confirm the next push-triggered `Supabase Deploy` run succeeds end-to-end.
