### PR TITLE
fix: repair Supabase Edge Function bundle resolution

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -57,6 +57,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -164,6 +173,10 @@ jobs:
           esac
 
           supabase db push --yes --db-url "$supabase_db_url"
+
+      - name: Install function bundle dependencies
+        if: steps.target.outputs.mode == 'deploy'
+        run: pnpm install --frozen-lockfile
 
       - name: Deploy Edge Functions
         if: steps.target.outputs.mode == 'deploy'

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,39 @@
+### session v75: Repair Supabase Edge Function bundling for remote deploys
+- timestamp: 2026-04-26T05:11:00-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-function-bundling-repair**
+- head: pending final commit
+
+#### Objective
+Fix the remaining `Supabase Deploy` failure on `dev` after the entrypoint repair by making the shared Edge Function import graph and CI bundle environment Deno-compatible.
+
+#### Actions Taken
+- Rewrote the shared Edge Function dependency graph to use explicit `.ts` and `.json` local import specifiers anywhere the Supabase Deno bundle step reaches into `lib/`.
+- Replaced `@/` alias usage in the CUBID snapshot/sync modules that are imported by Edge Functions with explicit relative imports.
+- Added `allowImportingTsExtensions` to the root TypeScript config so the app-side typecheck and build continue to accept the Deno-safe import specifiers.
+- Added `supabase/functions/deno.json` with `nodeModulesDir` enabled so vendored package dependencies remain available during Supabase function bundling.
+- Updated the Supabase deploy workflow to install repo dependencies before deploying Edge Functions.
+- Updated the Edge Function and Supabase deployment engineering docs to capture the Deno import rules and bundle dependency install requirement.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build` passed.
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'` passed.
+- `git diff --check` passed.
+- A reachability script confirmed every TypeScript file in the Supabase function dependency graph now uses explicit `.ts` or `.json` local specifiers.
+- Local `supabase functions serve` smoke was blocked because the currently running local Supabase containers are under the older `everfund` project id while `supabase/config.toml` now targets `fundloop`, so the CLI reported the local stack as not running for this worktree.
+
+#### Reflections
+- The real deploy path is now healthy for migrations, directory enumeration, and entrypoint naming; the last unstable layer was the Deno bundler reaching app-shared modules that still assumed Node-style resolution and preinstalled dependencies.
+
+#### Suggested Next Steps
+- Push this branch, open a PR to `dev`, confirm the PR-scoped dry-run stays green, merge, and watch the follow-up push-triggered `Supabase Deploy` run until Edge Function deployment succeeds end to end.
+
+---
+
 ### session v74: Align Supabase function entrypoints with CLI deploy expectations
 - timestamp: 2026-04-26T04:57:45-04:00
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,28 @@
+### session v76: Fix pnpm bootstrap in Supabase deploy workflow
+- timestamp: 2026-04-26T05:16:30-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-function-bundling-repair**
+- head: pending final commit
+
+#### Objective
+Repair the follow-up PR dry-run failure from Session v75 so the Supabase deploy workflow can bootstrap Node tooling before the database dry-run executes.
+
+#### Actions Taken
+- Removed `cache: pnpm` from the `actions/setup-node@v4` step in `supabase-deploy.yml`.
+- Kept `corepack enable` as the pnpm bootstrap path so deploy runs can still execute `pnpm install --frozen-lockfile` before Edge Function bundling.
+
+#### Tests and Validation Notes
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'` passed.
+
+#### Reflections
+- The Deno bundle repair was sound; the PR dry-run caught a separate workflow bootstrap assumption before it could waste another full deploy cycle.
+
+#### Suggested Next Steps
+- Push this workflow-only follow-up to PR #29, confirm the PR dry-run turns green, then merge and watch the real `dev` deploy run again.
+
+---
+
 ### session v75: Repair Supabase Edge Function bundling for remote deploys
 - timestamp: 2026-04-26T05:11:00-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -27,7 +27,9 @@ The app should treat a declared failure envelope differently from transport or i
 - function-specific adapters live under `lib/edge-functions/`
 - function names should follow command-style naming such as `project-payment-drafts-create`
 - each function directory should use an `index.ts` entrypoint so the Supabase CLI can bundle and deploy it consistently
+- shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
 - the root Next.js `tsc` run excludes `supabase/functions/` because those files are Deno-targeted and validated through the Supabase CLI and deploy workflow rather than the app TypeScript program
+- the deploy workflow installs repo dependencies before function bundling and `supabase/functions/deno.json` enables `nodeModulesDir` so vendored package dependencies remain available during remote bundling
 
 ## Current First Command
 

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -49,6 +49,8 @@ Edge Functions are deployed by enumerating each local function directory under `
 supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
+Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so vendored package dependencies such as the local CUBID packages are available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step.
+
 The workflow pins the Supabase CLI version instead of using `latest`; update it deliberately during normal dependency/tooling triage.
 
 The workflow never runs remote seeds, never resets a remote database, and never writes Supabase function secrets.

--- a/lib/cubid/resolve-by-email.ts
+++ b/lib/cubid/resolve-by-email.ts
@@ -1,7 +1,7 @@
 import type { CubidApiClient, CubidApiClientConfig } from "@cubid/api"
 import { createCubidApiClient } from "@cubid/api"
-import { getCubidConfig, type CubidConfig } from "./config"
-import type { CubidIdentityLinkState } from "./types"
+import { getCubidConfig, type CubidConfig } from "./config.ts"
+import type { CubidIdentityLinkState } from "./types.ts"
 
 type ResolveCubidIdentityByEmailInput = {
   email: string

--- a/lib/cubid/resolve-email-command.ts
+++ b/lib/cubid/resolve-email-command.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database } from "../../types/supabase"
-import { resolveCubidIdentityByEmail } from "./resolve-by-email"
-import { type CubidIdentityLinkState, isResolvedCubidIdentityStatus } from "./types"
+import type { Database } from "../../types/supabase.ts"
+import { resolveCubidIdentityByEmail } from "./resolve-by-email.ts"
+import { type CubidIdentityLinkState, isResolvedCubidIdentityStatus } from "./types.ts"
 
 type CubidResolutionCommandFailureCode =
   | "missing_email"

--- a/lib/cubid/server-client.ts
+++ b/lib/cubid/server-client.ts
@@ -2,7 +2,7 @@ import "server-only"
 
 import { createCubidApiClient } from "@cubid/api"
 import { createCubidWeb2Client } from "@cubid/web2"
-import { getCubidConfig, getCubidWeb2Config } from "./config"
+import { getCubidConfig, getCubidWeb2Config } from "./config.ts"
 
 export function createServerCubidApiClient() {
   const config = getCubidConfig()

--- a/lib/cubid/snapshot.ts
+++ b/lib/cubid/snapshot.ts
@@ -1,11 +1,11 @@
 import type { FetchIdentityResponse, FetchScoreResponse, FetchStampsResponse, FetchUserDataResponse } from "@cubid/api"
-import type { Json } from "@/types/supabase"
+import type { Json } from "../../types/supabase.ts"
 import {
   CUBID_RECOMMENDED_STAMPS,
   type CubidIdentitySnapshot,
   type CubidIdentityStatus,
   toDistinctStrings,
-} from "./types"
+} from "./types.ts"
 
 type CubidSnapshotNormalizationInput = {
   cubidUserId: string

--- a/lib/cubid/sync-profile-command.ts
+++ b/lib/cubid/sync-profile-command.ts
@@ -1,16 +1,16 @@
 import "server-only"
 
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database } from "@/types/supabase"
-import { executeResolveCubidIdentityByEmailCommand } from "@/lib/cubid/resolve-email-command"
-import { createServerCubidApiClient } from "@/lib/cubid/server-client"
-import { getMissingRecommendedCredentials, inferSnapshotIdentityStatus, normalizeCubidIdentitySnapshot } from "@/lib/cubid/snapshot"
+import type { Database } from "../../types/supabase.ts"
+import { executeResolveCubidIdentityByEmailCommand } from "./resolve-email-command.ts"
+import { createServerCubidApiClient } from "./server-client.ts"
+import { getMissingRecommendedCredentials, inferSnapshotIdentityStatus, normalizeCubidIdentitySnapshot } from "./snapshot.ts"
 import {
   isResolvedCubidIdentityStatus,
   toCubidIdentitySnapshot,
   toCubidIdentitySnapshotSummary,
   type CubidIdentitySnapshotRecord,
-} from "@/lib/cubid/types"
+} from "./types.ts"
 
 type CubidSyncFailureCode =
   | "missing_email"

--- a/lib/cubid/types.ts
+++ b/lib/cubid/types.ts
@@ -1,4 +1,4 @@
-import type { Database, Json } from "../../types/supabase"
+import type { Database, Json } from "../../types/supabase.ts"
 
 export type CubidIdentityStatus = Database["public"]["Enums"]["cubid_identity_status"]
 

--- a/lib/edge-functions/onboarding-contract-utils.ts
+++ b/lib/edge-functions/onboarding-contract-utils.ts
@@ -1,4 +1,4 @@
-import type { Tables } from "../../types/supabase"
+import type { Tables } from "../../types/supabase.ts"
 
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value))

--- a/lib/edge-functions/project-onboarding-draft-clear-contract.ts
+++ b/lib/edge-functions/project-onboarding-draft-clear-contract.ts
@@ -1,4 +1,4 @@
-import { edgeCommandSuccess, type EdgeCommandResult } from "./result"
+import { edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const PROJECT_ONBOARDING_DRAFT_CLEAR_FUNCTION = "project-onboarding-draft-clear"
 

--- a/lib/edge-functions/project-onboarding-draft-upsert-contract.ts
+++ b/lib/edge-functions/project-onboarding-draft-upsert-contract.ts
@@ -4,10 +4,10 @@ import {
   sanitizeProjectOnboardingPayload,
   type ProjectOnboardingPayload,
   type ProjectOnboardingScreen,
-} from "../onboarding"
-import type { Tables } from "../../types/supabase"
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
-import { isPlainObject, isProjectOnboardingDraftRow } from "./onboarding-contract-utils"
+} from "../onboarding.ts"
+import type { Tables } from "../../types/supabase.ts"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
+import { isPlainObject, isProjectOnboardingDraftRow } from "./onboarding-contract-utils.ts"
 
 export const PROJECT_ONBOARDING_DRAFT_UPSERT_FUNCTION = "project-onboarding-draft-upsert"
 

--- a/lib/edge-functions/project-onboarding-publish-contract.ts
+++ b/lib/edge-functions/project-onboarding-publish-contract.ts
@@ -1,5 +1,5 @@
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
-import { isPlainObject, isNullableString } from "./onboarding-contract-utils"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
+import { isPlainObject, isNullableString } from "./onboarding-contract-utils.ts"
 
 export const PROJECT_ONBOARDING_PUBLISH_FUNCTION = "project-onboarding-publish"
 

--- a/lib/edge-functions/project-payment-drafts-create-contract.ts
+++ b/lib/edge-functions/project-payment-drafts-create-contract.ts
@@ -1,6 +1,6 @@
-import { validateProjectPaymentDrafts, type NormalizedProjectPaymentDraft, type ProjectPaymentDraftInput } from "../payments"
-import type { PaymentRecordSummary } from "../payments/payment-record-summary"
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
+import { validateProjectPaymentDrafts, type NormalizedProjectPaymentDraft, type ProjectPaymentDraftInput } from "../payments.ts"
+import type { PaymentRecordSummary } from "../payments/payment-record-summary.ts"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const PROJECT_PAYMENT_DRAFTS_CREATE_FUNCTION = "project-payment-drafts-create"
 

--- a/lib/edge-functions/project-payment-operations-contract.ts
+++ b/lib/edge-functions/project-payment-operations-contract.ts
@@ -1,4 +1,4 @@
-import type { Json } from "../../types/supabase"
+import type { Json } from "../../types/supabase.ts"
 import {
   type ManagedCryptoPaymentMethodSummary,
   type ProjectCryptoRouteCreateInput,
@@ -6,8 +6,8 @@ import {
   type ProjectCryptoRouteMoveInput,
   type ProjectCryptoRouteUpdateInput,
   type ProjectOnchainPaymentSubmissionRecordInput,
-} from "../payments/project-payment-operations-command"
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
+} from "../payments/project-payment-operations-command.ts"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const PROJECT_CRYPTO_ROUTE_CREATE_FUNCTION = "project-crypto-route-create"
 export const PROJECT_CRYPTO_ROUTE_UPDATE_FUNCTION = "project-crypto-route-update"

--- a/lib/edge-functions/user-cubid-resolve-email-contract.ts
+++ b/lib/edge-functions/user-cubid-resolve-email-contract.ts
@@ -1,4 +1,4 @@
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const USER_CUBID_RESOLVE_EMAIL_FUNCTION = "user-cubid-resolve-email"
 

--- a/lib/edge-functions/user-cubid-sync-profile-contract.ts
+++ b/lib/edge-functions/user-cubid-sync-profile-contract.ts
@@ -1,4 +1,4 @@
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const USER_CUBID_SYNC_PROFILE_FUNCTION = "user-cubid-sync-profile"
 

--- a/lib/edge-functions/user-onboarding-draft-clear-contract.ts
+++ b/lib/edge-functions/user-onboarding-draft-clear-contract.ts
@@ -1,4 +1,4 @@
-import { edgeCommandSuccess, type EdgeCommandResult } from "./result"
+import { edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
 
 export const USER_ONBOARDING_DRAFT_CLEAR_FUNCTION = "user-onboarding-draft-clear"
 

--- a/lib/edge-functions/user-onboarding-draft-upsert-contract.ts
+++ b/lib/edge-functions/user-onboarding-draft-upsert-contract.ts
@@ -4,10 +4,10 @@ import {
   sanitizeUserOnboardingPayload,
   type UserOnboardingPayload,
   type UserOnboardingScreen,
-} from "../onboarding"
-import type { Tables } from "../../types/supabase"
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
-import { isPlainObject, isUserOnboardingDraftRow } from "./onboarding-contract-utils"
+} from "../onboarding.ts"
+import type { Tables } from "../../types/supabase.ts"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
+import { isPlainObject, isUserOnboardingDraftRow } from "./onboarding-contract-utils.ts"
 
 export const USER_ONBOARDING_DRAFT_UPSERT_FUNCTION = "user-onboarding-draft-upsert"
 

--- a/lib/edge-functions/user-onboarding-publish-contract.ts
+++ b/lib/edge-functions/user-onboarding-publish-contract.ts
@@ -1,6 +1,6 @@
-import type { RelationshipChoice } from "../onboarding"
-import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result"
-import { isPlainObject } from "./onboarding-contract-utils"
+import type { RelationshipChoice } from "../onboarding.ts"
+import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "./result.ts"
+import { isPlainObject } from "./onboarding-contract-utils.ts"
 
 export const USER_ONBOARDING_PUBLISH_FUNCTION = "user-onboarding-publish"
 

--- a/lib/onboarding.ts
+++ b/lib/onboarding.ts
@@ -1,4 +1,4 @@
-import type { Tables } from "../types/supabase"
+import type { Tables } from "../types/supabase.ts"
 
 export const USER_ONBOARDING_SCREENS = [
   "welcome",

--- a/lib/onboarding/command-utils.ts
+++ b/lib/onboarding/command-utils.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database } from "../../types/supabase"
+import type { Database } from "../../types/supabase.ts"
 
 export type OnboardingCommandClient = SupabaseClient<Database>
 

--- a/lib/onboarding/project-onboarding-commands.ts
+++ b/lib/onboarding/project-onboarding-commands.ts
@@ -1,13 +1,13 @@
 import "server-only"
 
-import type { Json, Tables } from "../../types/supabase"
+import type { Json, Tables } from "../../types/supabase.ts"
 import {
   mergeProjectOnboardingPayload,
   type ProjectOnboardingPayload,
   type ProjectOnboardingScreen,
-} from "../onboarding"
-import type { OnboardingCommandClient } from "./command-utils"
-import { getCryptoContractMethodId, parseDecimal, parseInteger } from "./command-utils"
+} from "../onboarding.ts"
+import type { OnboardingCommandClient } from "./command-utils.ts"
+import { getCryptoContractMethodId, parseDecimal, parseInteger } from "./command-utils.ts"
 
 type ProjectDraftCommandFailureCode = "not_authenticated" | "draft_save_failed" | "draft_clear_failed"
 type ProjectPublishCommandFailureCode =

--- a/lib/onboarding/user-onboarding-commands.ts
+++ b/lib/onboarding/user-onboarding-commands.ts
@@ -1,13 +1,13 @@
 import "server-only"
 
-import type { Tables } from "../../types/supabase"
+import type { Tables } from "../../types/supabase.ts"
 import {
   mergeUserOnboardingPayload,
   type UserOnboardingPayload,
   type UserOnboardingScreen,
-} from "../onboarding"
-import type { OnboardingCommandClient } from "./command-utils"
-import { parseInteger } from "./command-utils"
+} from "../onboarding.ts"
+import type { OnboardingCommandClient } from "./command-utils.ts"
+import { parseInteger } from "./command-utils.ts"
 
 type UserDraftCommandFailureCode = "not_authenticated" | "draft_save_failed" | "draft_clear_failed"
 type UserPublishCommandFailureCode =

--- a/lib/payments/payment-record-summary.ts
+++ b/lib/payments/payment-record-summary.ts
@@ -1,4 +1,4 @@
-import type { OnchainSubmissionSummary } from "../onchain/payment-submissions"
+import type { OnchainSubmissionSummary } from "../onchain/payment-submissions.ts"
 
 export type PaymentRecordSummary = {
   id: number

--- a/lib/payments/project-payment-drafts-command.ts
+++ b/lib/payments/project-payment-drafts-command.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database } from "../../types/supabase"
-import type { NormalizedProjectPaymentDraft } from "../payments"
-import { mapPaymentRecordSummary, type PaymentRecordSummary, type PaymentRecordSummaryRow } from "./payment-record-summary"
+import type { Database } from "../../types/supabase.ts"
+import type { NormalizedProjectPaymentDraft } from "../payments.ts"
+import { mapPaymentRecordSummary, type PaymentRecordSummary, type PaymentRecordSummaryRow } from "./payment-record-summary.ts"
 
 type ProjectAdminProjectRow = {
   id: number

--- a/lib/payments/project-payment-operations-command.ts
+++ b/lib/payments/project-payment-operations-command.ts
@@ -1,12 +1,12 @@
 import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database, Json, Tables } from "../../types/supabase"
+import type { Database, Json, Tables } from "../../types/supabase.ts"
 import {
   getPromotedDefaultRouteId,
   moveProjectCryptoRouteState,
   renumberProjectCryptoRouteStates,
   type ProjectCryptoRouteState,
   type RouteMoveDirection,
-} from "../project-crypto-routes"
+} from "../project-crypto-routes.ts"
 
 export type ManagedCryptoPaymentMethodSummary = {
   id: number

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- fix the remaining `Supabase Deploy` failure on `dev` after migrations, function enumeration, and `index.ts` entrypoints were already repaired
- make the shared Edge Function dependency graph Deno-safe with explicit local `.ts` and `.json` imports
- install repo dependencies before remote function bundling and enable `nodeModulesDir` for the Supabase function runtime config
- document the new bundling rules and deployment requirement

## Objective
The previous repair sequence got the deploy pipeline as far as real function bundling, where it then failed because Deno was traversing shared app modules that still assumed Node-style extensionless resolution and preinstalled dependencies. This PR aligns the bundle graph and CI environment with Supabase Edge Function runtime expectations.

## Changes
- rewrote the Edge Function-reachable shared module imports to explicit `.ts` / `.json` local specifiers
- replaced `@/` alias usage in the CUBID sync/snapshot modules that are imported by Edge Functions with explicit relative imports
- added `allowImportingTsExtensions` to the root TypeScript config so app validation still accepts the Deno-safe imports
- added `supabase/functions/deno.json` with `nodeModulesDir` enabled
- updated the deploy workflow to run `pnpm install --frozen-lockfile` before Edge Function deployment
- updated `docs/engineering/edge-functions.md`, `docs/engineering/supabase-deployments.md`, and `agent-context/session-log.md`

## Validation
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'`
- `git diff --check`
- reachable-import smoke script confirming the function dependency graph only uses explicit `.ts` / `.json` local specifiers

## Reviewer Notes
- this is the last focused Supabase deploy repair after PRs #26, #27, and #28
- review the workflow and Deno import boundary first; there is no product-surface behavior change here
- the only blocked validation was local `supabase functions serve` from this worktree because the currently running local stack is still under the older `everfund` project id while this repo now targets `fundloop`

## Follow-ups
- after merge, confirm the push-triggered `Supabase Deploy` run on `dev` completes both migration and Edge Function deployment end to end
- once that run is green, the repo can move on to Session 20 without the remote Supabase deploy caveat
