### PR TITLE
fix: finish Supabase Edge Function runtime compatibility repair

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -7,18 +7,28 @@ on:
       - main
     paths:
       - ".github/workflows/supabase-deploy.yml"
+      - "lib/**"
+      - "types/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
       - "supabase/config.toml"
       - "supabase/functions/**"
       - "supabase/migrations/**"
+      - "vendor/cubid/**"
   push:
     branches:
       - dev
       - main
     paths:
       - ".github/workflows/supabase-deploy.yml"
+      - "lib/**"
+      - "types/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
       - "supabase/config.toml"
       - "supabase/functions/**"
       - "supabase/migrations/**"
+      - "vendor/cubid/**"
   workflow_dispatch:
     inputs:
       target_environment:

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,32 @@
+### session v77: Remove Next-only server markers from Edge Function shared modules
+- timestamp: 2026-04-26T05:20:30-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-function-bundling-repair**
+- head: pending final commit
+
+#### Objective
+Fix the latest `dev` deploy failure after PR #29 by removing Next-only `server-only` imports from modules that are shared with Supabase Edge Functions.
+
+#### Actions Taken
+- Removed `import "server-only"` from the shared onboarding and CUBID command modules that the Edge Function deploy step bundles.
+- Removed the same marker from the shared CUBID server client helper used by the sync command.
+- Updated the Edge Function engineering doc to state that Next-only runtime markers must stay on Next-only wrappers rather than shared modules imported by Edge Functions.
+
+#### Tests and Validation Notes
+- A reachability script confirmed there are no remaining `server-only` markers in the 46 TypeScript files reachable from `supabase/functions/`.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build` passed.
+
+#### Reflections
+- The remote deploy path is now failing on genuinely incremental runtime-compatibility issues rather than broad workflow design problems, which means the repair work is converging.
+
+#### Suggested Next Steps
+- Push this follow-up to the same repair branch, confirm the PR checks stay green, and rerun the push-triggered `dev` Supabase deploy until every tracked function deploys successfully.
+
+---
+
 ### session v76: Fix pnpm bootstrap in Supabase deploy workflow
 - timestamp: 2026-04-26T05:16:30-04:00
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,33 @@
+### session v78: Broaden Supabase deploy workflow path triggers
+- timestamp: 2026-04-26T05:25:30-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-function-bundling-repair**
+- head: pending final commit
+
+#### Objective
+Ensure the Supabase deploy workflow actually runs when shared Edge Function dependencies change outside `supabase/functions/`, `supabase/migrations/`, or the workflow file itself.
+
+#### Actions Taken
+- Expanded the `Supabase Deploy` workflow `pull_request` and `push` path filters to include:
+  - `lib/**`
+  - `types/**`
+  - `package.json`
+  - `pnpm-lock.yaml`
+  - `vendor/cubid/**`
+- Kept the existing Supabase-specific path filters intact so direct schema/function changes still route the same way.
+
+#### Tests and Validation Notes
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "workflow yaml parsed"'` passed.
+
+#### Reflections
+- Shared command logic living under `lib/` is now part of the effective Edge Function deployment surface, so the workflow trigger contract needed to reflect the real architecture instead of just the filesystem location of entrypoints.
+
+#### Suggested Next Steps
+- Push this trigger-scope follow-up to PR #30 so the Supabase dry-run reruns on the PR, then merge and watch the real `dev` deploy again.
+
+---
+
 ### session v77: Remove Next-only server markers from Edge Function shared modules
 - timestamp: 2026-04-26T05:20:30-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -28,6 +28,7 @@ The app should treat a declared failure envelope differently from transport or i
 - function names should follow command-style naming such as `project-payment-drafts-create`
 - each function directory should use an `index.ts` entrypoint so the Supabase CLI can bundle and deploy it consistently
 - shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
+- shared modules imported by Edge Functions must not rely on Next-only runtime markers such as `import "server-only"`; keep those markers on Next-only wrappers instead
 - the root Next.js `tsc` run excludes `supabase/functions/` because those files are Deno-targeted and validated through the Supabase CLI and deploy workflow rather than the app TypeScript program
 - the deploy workflow installs repo dependencies before function bundling and `supabase/functions/deno.json` enables `nodeModulesDir` so vendored package dependencies remain available during remote bundling
 

--- a/lib/cubid/server-client.ts
+++ b/lib/cubid/server-client.ts
@@ -1,5 +1,3 @@
-import "server-only"
-
 import { createCubidApiClient } from "@cubid/api"
 import { createCubidWeb2Client } from "@cubid/web2"
 import { getCubidConfig, getCubidWeb2Config } from "./config.ts"

--- a/lib/cubid/sync-profile-command.ts
+++ b/lib/cubid/sync-profile-command.ts
@@ -1,5 +1,3 @@
-import "server-only"
-
 import type { SupabaseClient } from "@supabase/supabase-js"
 import type { Database } from "../../types/supabase.ts"
 import { executeResolveCubidIdentityByEmailCommand } from "./resolve-email-command.ts"

--- a/lib/onboarding/project-onboarding-commands.ts
+++ b/lib/onboarding/project-onboarding-commands.ts
@@ -1,5 +1,3 @@
-import "server-only"
-
 import type { Json, Tables } from "../../types/supabase.ts"
 import {
   mergeProjectOnboardingPayload,

--- a/lib/onboarding/user-onboarding-commands.ts
+++ b/lib/onboarding/user-onboarding-commands.ts
@@ -1,5 +1,3 @@
-import "server-only"
-
 import type { Tables } from "../../types/supabase.ts"
 import {
   mergeUserOnboardingPayload,


### PR DESCRIPTION
## Summary
- remove Next-only `server-only` markers from shared modules that are bundled into Supabase Edge Functions
- finish the last runtime-compatibility fix exposed by the post-merge `dev` deploy after PR #29
- keep the Deno/runtime guidance documented for future shared command modules

## Objective
PR #29 got the remote `dev` deploy all the way through migration deploy, dependency install, and several successful function deploys before failing on shared onboarding/CUBID modules that still imported Next’s `server-only` marker. This PR removes that last known incompatibility from the shared Edge Function graph.

## Changes
- removed `import "server-only"` from:
  - `lib/onboarding/project-onboarding-commands.ts`
  - `lib/onboarding/user-onboarding-commands.ts`
  - `lib/cubid/sync-profile-command.ts`
  - `lib/cubid/server-client.ts`
- updated `docs/engineering/edge-functions.md` to make the shared-module rule explicit
- added the matching session-log entry

## Validation
- reachable graph check confirming no `server-only` markers remain in TypeScript files reachable from `supabase/functions/`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build`

## Reviewer Notes
- this is a narrow follow-up to the already-merged PR #29
- review the four shared modules first; there is no intended product-surface behavior change
- the important context is that the prior `dev` deploy already successfully deployed the payment-route Edge Functions before encountering this `server-only` issue in onboarding/CUBID modules

## Follow-ups
- after merge, watch the push-triggered `Supabase Deploy` run on `dev` and confirm every tracked function deploys successfully
- if another Deno-runtime incompatibility appears, fix it as the next focused follow-up rather than broadening this PR
