### PR TITLE
fix: finish Cubid Edge Function bundling for Supabase deploys

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,38 @@
+### session v79: Map vendored CUBID packages for Supabase Deno bundling
+- timestamp: 2026-04-26T15:49:30-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-cubid-deno-repair**
+- head: pending final commit
+
+#### Objective
+Fix the remaining `dev` Supabase deploy failure after payment and onboarding functions were already deploying successfully by making the CUBID Edge Function bundle path Deno-compatible.
+
+#### Actions Taken
+- Removed the unused server-side `@cubid/web2` coupling from `lib/cubid/server-client.ts` so shared Edge Function code only depends on the API package.
+- Added explicit Deno import mappings in `supabase/functions/deno.json` for:
+  - `@cubid/api`
+  - `@supabase/supabase-js`
+- Updated the Edge Function and Supabase deployment docs to capture the rule that vendored bare package specifiers must be mapped explicitly for the Supabase Deno bundler.
+
+#### Tests and Validation Notes
+- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts` resolved cleanly with no missing import-map dependencies.
+- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts` resolved cleanly with no missing import-map dependencies.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build` passed.
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `git diff --check` passed.
+
+#### Reflections
+- The deploy repair is now down to a narrow runtime integration boundary with the vendored CUBID packages rather than a broader workflow or schema problem.
+- Longer term, publishing Deno-friendly `@cubid/api` and `@cubid/web2` packages from the Cubid repo would remove the need for local import-map wiring in downstream Edge runtimes.
+
+#### Suggested Next Steps
+- Push this branch, open a PR to `dev`, confirm the Supabase dry-run stays green, merge, and watch the push-triggered `dev` Supabase deploy until the CUBID functions deploy cleanly too.
+
+---
+
 ### session v78: Broaden Supabase deploy workflow path triggers
 - timestamp: 2026-04-26T05:25:30-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -29,6 +29,7 @@ The app should treat a declared failure envelope differently from transport or i
 - each function directory should use an `index.ts` entrypoint so the Supabase CLI can bundle and deploy it consistently
 - shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
 - shared modules imported by Edge Functions must not rely on Next-only runtime markers such as `import "server-only"`; keep those markers on Next-only wrappers instead
+- vendored packages that are not published to npm or JSR must be mapped explicitly in `supabase/functions/deno.json` when Edge Functions import them through shared modules
 - the root Next.js `tsc` run excludes `supabase/functions/` because those files are Deno-targeted and validated through the Supabase CLI and deploy workflow rather than the app TypeScript program
 - the deploy workflow installs repo dependencies before function bundling and `supabase/functions/deno.json` enables `nodeModulesDir` so vendored package dependencies remain available during remote bundling
 

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -49,7 +49,7 @@ Edge Functions are deployed by enumerating each local function directory under `
 supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
-Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so vendored package dependencies such as the local CUBID packages are available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step.
+Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so vendored package dependencies such as the local CUBID packages are available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step and maps vendored bare package specifiers such as `@cubid/api` to their local ESM entrypoints.
 
 The workflow pins the Supabase CLI version instead of using `latest`; update it deliberately during normal dependency/tooling triage.
 

--- a/lib/cubid/server-client.ts
+++ b/lib/cubid/server-client.ts
@@ -1,6 +1,5 @@
 import { createCubidApiClient } from "@cubid/api"
-import { createCubidWeb2Client } from "@cubid/web2"
-import { getCubidConfig, getCubidWeb2Config } from "./config.ts"
+import { getCubidConfig } from "./config.ts"
 
 export function createServerCubidApiClient() {
   const config = getCubidConfig()
@@ -10,15 +9,5 @@ export function createServerCubidApiClient() {
     baseUrl: config.baseUrl,
     dappId: config.dappId,
     fetch,
-  })
-}
-
-export function createServerCubidWeb2Client() {
-  const config = getCubidWeb2Config()
-  const apiClient = createServerCubidApiClient()
-
-  return createCubidWeb2Client(apiClient, {
-    allowPath: "/widget-allow",
-    passportOrigin: new URL(config.baseUrl).origin,
   })
 }

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,3 +1,7 @@
 {
+  "imports": {
+    "@cubid/api": "../../node_modules/@cubid/api/dist/index.mjs",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.104.0"
+  },
   "nodeModulesDir": "auto"
 }


### PR DESCRIPTION
## Summary
- fix the remaining `dev` Supabase deploy failure isolated to the Cubid Edge Functions
- map vendored Cubid and typed Supabase imports explicitly for the Supabase Deno bundler
- remove an unnecessary server-side web2 coupling from the shared Cubid server helper
- document the vendored-package bundling rule for future Edge Function work

## Objective
The Supabase deploy repair sequence is now succeeding through migrations, dependency install, payment functions, and onboarding functions. The last failure is isolated to the Cubid functions, where the Deno bundler rejects vendored bare package imports such as `@cubid/api`. This PR fixes that final Cubid runtime boundary.

## Changes
- removed the unused `@cubid/web2` coupling from `lib/cubid/server-client.ts`
- added explicit Deno import mappings in `supabase/functions/deno.json` for:
  - `@cubid/api`
  - `@supabase/supabase-js`
- updated Edge Function and Supabase deployment engineering docs
- added the matching session-log entry

## Validation
- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts`
- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml`
- `git diff --check`

## Reviewer Notes
- this is a narrow follow-up to the longer Supabase deploy repair sequence
- the key thing to review is the Deno import-map wiring for vendored Cubid packages
- the previous `dev` deploy was already successfully deploying all payment and onboarding functions before failing when the first Cubid function bundled

## Follow-ups
- after merge, watch the push-triggered `Supabase Deploy` run on `dev` and confirm the Cubid functions deploy cleanly too
- on the Cubid repo side, publishing Deno-friendly `@cubid/api` and `@cubid/web2` packages would remove the need for downstream import-map wiring like this
