### PR TITLE
Fix Supabase CUBID Edge bundling on remote deploys

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,35 @@
+### session v80: Vendor a Deno-visible CUBID API shim for Supabase deploys
+- timestamp: 2026-04-26T15:56:07-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-cubid-vendor-repair**
+- head: pending final commit
+
+#### Objective
+Fix the remaining `dev` Supabase deploy failure by replacing the CI-fragile `node_modules` import-map path for `@cubid/api` with a repo-tracked Deno-visible runtime mirror.
+
+#### Actions Taken
+- Repointed `supabase/functions/deno.json` so `@cubid/api` resolves to a repo-owned file under `supabase/functions/_vendor/` instead of a runner-specific `node_modules` path.
+- Added a minimal runtime-compatible `@cubid/api` mirror for the Supabase Edge Function graph covering the CUBID methods used by the onboarding and identity sync commands.
+- Updated the Supabase deployment and Edge Function engineering docs to record that unpublished packages used by Edge Functions must resolve to repo-tracked Deno-visible files.
+
+#### Tests and Validation Notes
+- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts` resolved cleanly and loaded the vendored CUBID API mirror.
+- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts` resolved cleanly and loaded the vendored CUBID API mirror.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` passed after the build regenerated `.next/types`.
+- `git diff --check` passed.
+
+#### Reflections
+- The failure mode was path determinism inside the Supabase bundling container, not the CUBID command logic itself.
+- FundLoop is now insulated from pnpm layout differences, but the healthier long-term fix is still to publish a first-class Deno/Edge-consumable `@cubid/api` package from the Cubid repo.
+
+#### Suggested Next Steps
+- Run the standard repo gates, push this repair branch, open a PR to `dev`, and confirm both the PR dry-run and the post-merge `dev` Supabase deploy succeed end to end.
+
+---
+
 ### session v79: Map vendored CUBID packages for Supabase Deno bundling
 - timestamp: 2026-04-26T15:49:30-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -29,7 +29,7 @@ The app should treat a declared failure envelope differently from transport or i
 - each function directory should use an `index.ts` entrypoint so the Supabase CLI can bundle and deploy it consistently
 - shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
 - shared modules imported by Edge Functions must not rely on Next-only runtime markers such as `import "server-only"`; keep those markers on Next-only wrappers instead
-- vendored packages that are not published to npm or JSR must be mapped explicitly in `supabase/functions/deno.json` when Edge Functions import them through shared modules
+- vendored packages that are not published to npm or JSR must be mapped explicitly in `supabase/functions/deno.json` when Edge Functions import them through shared modules, and those mappings should point to repo-tracked Deno-visible files rather than CI-specific `node_modules` paths
 - the root Next.js `tsc` run excludes `supabase/functions/` because those files are Deno-targeted and validated through the Supabase CLI and deploy workflow rather than the app TypeScript program
 - the deploy workflow installs repo dependencies before function bundling and `supabase/functions/deno.json` enables `nodeModulesDir` so vendored package dependencies remain available during remote bundling
 

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -49,7 +49,7 @@ Edge Functions are deployed by enumerating each local function directory under `
 supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
-Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so vendored package dependencies such as the local CUBID packages are available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step and maps vendored bare package specifiers such as `@cubid/api` to their local ESM entrypoints.
+Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so vendored package dependencies remain available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step and maps unpublished bare package specifiers such as `@cubid/api` to repo-tracked Deno-visible ESM mirrors under `supabase/functions/_vendor/` instead of relying on runner-specific `node_modules` paths.
 
 The workflow pins the Supabase CLI version instead of using `latest`; update it deliberately during normal dependency/tooling triage.
 

--- a/supabase/functions/_vendor/cubid-api/index.mjs
+++ b/supabase/functions/_vendor/cubid-api/index.mjs
@@ -1,0 +1,271 @@
+// Repo-tracked Deno mirror for the unpublished @cubid/api runtime used by Supabase Edge Functions.
+// Keep this aligned with the vendored Cubid package until the package ships a stable Deno/Edge entrypoint.
+
+const DEFAULT_CUBID_API_BASE_URL = "https://passport.cubid.me/api/v2";
+
+class CubidApiError extends Error {
+  constructor({ code, endpoint, message, rawPayload, status }) {
+    super(message);
+    this.name = "CubidApiError";
+    this.code = code;
+    this.endpoint = endpoint;
+    this.rawPayload = rawPayload;
+    this.status = status;
+  }
+}
+
+function isCubidApiError(error) {
+  return error instanceof CubidApiError;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value) {
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value) {
+  return typeof value === "number" ? value : undefined;
+}
+
+function asCoordinates(value) {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const lat = value.lat;
+  const lng = value.lng;
+  if (typeof lat !== "number" || typeof lng !== "number") {
+    return undefined;
+  }
+
+  return { lat, lng };
+}
+
+function extractErrorCode(payload) {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  if (typeof payload.code === "string") {
+    return payload.code;
+  }
+
+  return typeof payload.error === "string" ? payload.error : undefined;
+}
+
+function extractErrorMessage(payload, fallback) {
+  if (typeof payload === "string" && payload.length > 0) {
+    return payload;
+  }
+
+  if (isRecord(payload)) {
+    if (typeof payload.message === "string" && payload.message.length > 0) {
+      return payload.message;
+    }
+
+    if (typeof payload.error === "string" && payload.error.length > 0) {
+      return payload.error;
+    }
+  }
+
+  return fallback;
+}
+
+async function parseResponsePayload(response) {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+
+  const text = await response.text();
+  if (text.length === 0) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function assertRecord(value, endpoint) {
+  if (!isRecord(value)) {
+    throw new CubidApiError({
+      code: "MALFORMED_RESPONSE",
+      endpoint,
+      message: `Malformed response from ${endpoint}.`,
+      rawPayload: value,
+    });
+  }
+
+  return value;
+}
+
+function normalizeCreateUser(payload) {
+  const record = assertRecord(payload, "create_user");
+  return {
+    error: record.error ?? null,
+    isBlacklisted: Boolean(record.is_blacklisted),
+    isNewAppUser: Boolean(record.is_new_app_user),
+    isSybilAttack: Boolean(record.is_sybil_attack),
+    userId: asString(record.user_id),
+  };
+}
+
+function normalizeFetchIdentity(payload) {
+  const record = assertRecord(payload, "identity/fetch_identity");
+  const stampDetails = Array.isArray(record.stamp_details) ? record.stamp_details : [];
+  return {
+    error: record.error ?? null,
+    stampDetails: stampDetails.map((item) => {
+      const detail = assertRecord(item, "identity/fetch_identity");
+      return {
+        stampType: asString(detail.stamp_type) ?? "unknown",
+        status: asString(detail.status),
+        value: asString(detail.value),
+      };
+    }),
+  };
+}
+
+function normalizeFetchScore(payload) {
+  const record = assertRecord(payload, "score/fetch_score");
+  return {
+    cubidScore: typeof record.cubid_score === "number" ? record.cubid_score : 0,
+    error: record.error ?? null,
+    scoringSchema:
+      typeof record.scoring_schema === "number" || typeof record.scoring_schema === "string"
+        ? record.scoring_schema
+        : null,
+  };
+}
+
+function normalizeFetchStamps(payload) {
+  const record = assertRecord(payload, "identity/fetch_stamps");
+  const allStamps = Array.isArray(record.all_stamps) ? record.all_stamps : [];
+  return {
+    allStamps: allStamps.map((rawStamp) => {
+      const stamp = assertRecord(rawStamp, "identity/fetch_stamps");
+      return {
+        emailForVerification: asString(stamp.emailForVerification),
+        id: asNumber(stamp.id),
+        identity: asString(stamp.identity),
+        isValid: typeof stamp.is_valid === "boolean" ? stamp.is_valid : undefined,
+        permAvailable: typeof stamp.permAvailable === "boolean" ? stamp.permAvailable : undefined,
+        raw: stamp,
+        stampType: asString(stamp.stamptype_string),
+        stampTypeId: asNumber(stamp.stamptype),
+        uniqueValue: asString(stamp.uniquevalue),
+      };
+    }),
+    email: asString(record.email),
+  };
+}
+
+function normalizeFetchUserData(payload) {
+  const record = assertRecord(payload, "identity/fetch_user_data");
+  return {
+    coordinates: asCoordinates(record.coordinates),
+    country: asString(record.country),
+    error: record.error ?? null,
+    name: asString(record.name),
+    placeName: asString(record.placename),
+  };
+}
+
+function toResolvedConfig(config) {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new CubidApiError({
+      code: "MISSING_FETCH",
+      endpoint: "config",
+      message: "A fetch implementation is required to create the Cubid API client.",
+      rawPayload: null,
+    });
+  }
+
+  return {
+    apiKey: config.apiKey,
+    baseUrl: (config.baseUrl ?? DEFAULT_CUBID_API_BASE_URL).replace(/\/+$/, ""),
+    dappId: config.dappId,
+    fetch: fetchImpl,
+    headers: config.headers,
+  };
+}
+
+function createClientRequest(resolvedConfig) {
+  return async function request(endpoint, body, normalize) {
+    const url = `${resolvedConfig.baseUrl}/${endpoint}`;
+
+    let response;
+    try {
+      response = await resolvedConfig.fetch(url, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          ...resolvedConfig.headers,
+        },
+        method: "POST",
+      });
+    } catch (error) {
+      throw new CubidApiError({
+        code: "NETWORK_ERROR",
+        endpoint,
+        message: error instanceof Error ? error.message : `Request to ${endpoint} failed.`,
+        rawPayload: error,
+      });
+    }
+
+    const payload = await parseResponsePayload(response);
+    if (!response.ok) {
+      throw new CubidApiError({
+        code: extractErrorCode(payload),
+        endpoint,
+        message: extractErrorMessage(payload, `Request to ${endpoint} failed.`),
+        rawPayload: payload,
+        status: response.status,
+      });
+    }
+
+    try {
+      return normalize(payload);
+    } catch (error) {
+      if (error instanceof CubidApiError) {
+        throw error;
+      }
+
+      throw new CubidApiError({
+        code: "MALFORMED_RESPONSE",
+        endpoint,
+        message: error instanceof Error ? error.message : `Malformed response from ${endpoint}.`,
+        rawPayload: payload,
+        status: response.status,
+      });
+    }
+  };
+}
+
+function createCubidApiClient(config) {
+  const resolvedConfig = toResolvedConfig(config);
+  const request = createClientRequest(resolvedConfig);
+
+  return {
+    createUser: ({ email }) =>
+      request("create_user", { apikey: resolvedConfig.apiKey, dapp_id: resolvedConfig.dappId, email }, normalizeCreateUser),
+    fetchIdentity: ({ userId }) =>
+      request("identity/fetch_identity", { apikey: resolvedConfig.apiKey, user_id: userId }, normalizeFetchIdentity),
+    fetchScore: ({ userId }) =>
+      request("score/fetch_score", { apikey: resolvedConfig.apiKey, dapp_id: resolvedConfig.dappId, user_id: userId }, normalizeFetchScore),
+    fetchStamps: ({ userId }) =>
+      request("identity/fetch_stamps", { apikey: resolvedConfig.apiKey, user_id: userId }, normalizeFetchStamps),
+    fetchUserData: ({ userId }) =>
+      request("identity/fetch_user_data", { apikey: resolvedConfig.apiKey, user_id: userId }, normalizeFetchUserData),
+  };
+}
+
+export { CubidApiError, DEFAULT_CUBID_API_BASE_URL, createCubidApiClient, isCubidApiError };

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@cubid/api": "../../node_modules/@cubid/api/dist/index.mjs",
+    "@cubid/api": "./_vendor/cubid-api/index.mjs",
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2.104.0"
   },
   "nodeModulesDir": "auto"


### PR DESCRIPTION
## Summary
- replace the Supabase Deno import-map path for `@cubid/api` with a repo-tracked vendor target
- add a minimal Deno-visible CUBID API runtime mirror for the Edge Function graph
- document the repo-tracked vendor rule for unpublished packages used by Supabase functions

## Objective
Fix the remaining `dev` Supabase deploy failure where the CUBID functions bundled locally but failed remotely because the import map pointed at a CI-specific `node_modules` file path.

## Changes
- updated `supabase/functions/deno.json` to map `@cubid/api` to `supabase/functions/_vendor/cubid-api/index.mjs`
- added the repo-tracked CUBID API runtime mirror used by the Supabase Edge Function graph
- updated Edge Function and Supabase deployment docs to capture the Deno-visible vendor requirement
- recorded the work in `agent-context/session-log.md`

## Validation
- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts`
- `deno info --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck`
- `git diff --check`

## Reviewer Notes
- the key review surface is the new repo-tracked vendor file and the updated Deno import map
- this is intentionally a narrow deploy repair, not a broader CUBID integration refactor

## Follow-ups
- longer term, publish a first-class Deno/Edge-consumable `@cubid/api` package from the Cubid repo so downstream apps do not need repo-local mirrors
- after merge, verify the push-triggered `dev` Supabase deploy goes fully green
