### PR TITLE
Skip helper directories in Supabase function deploys

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -195,7 +195,13 @@ jobs:
           set -euo pipefail
 
           function_names="$(
-            find supabase/functions -mindepth 1 -maxdepth 1 -type d ! -name "_shared" -exec basename {} \; | sort
+            find supabase/functions \
+              -mindepth 1 \
+              -maxdepth 1 \
+              -type d \
+              ! -name "_shared" \
+              ! -name "_vendor" \
+              -exec basename {} \; | sort
           )"
 
           if [[ -z "${function_names}" ]]; then

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,31 @@
+### session v81: Exclude Supabase helper directories from function deployment
+- timestamp: 2026-04-26T16:02:58-04:00
+- agent: **Codex (GPT-5)**
+- branch: **codex/supabase-skip-vendor-dir**
+- head: pending final commit
+
+#### Objective
+Fix the follow-up `dev` Supabase deploy failure after PR #32 by teaching the deploy workflow to skip helper-only directories such as `_vendor` when enumerating Edge Functions.
+
+#### Actions Taken
+- Updated `.github/workflows/supabase-deploy.yml` so the function deploy loop ignores both `_shared` and `_vendor`.
+- Updated the Supabase deployment and Edge Function docs to record that helper directories participate in bundling but are not deployable functions.
+
+#### Tests and Validation Notes
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml` passed.
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "yaml ok"'` passed.
+- `git diff --check` passed.
+- End-to-end confirmation will come from the PR dry-run plus the post-merge `dev` Supabase deploy workflow.
+
+#### Reflections
+- The Cubid import-path repair is holding; this second failure is just a deployment enumerator assumption that no longer matches the repo layout.
+- Keeping helper directories prefixed and documented reduces the chance of repeating this class of workflow mistake as more function-local runtime assets are added.
+
+#### Suggested Next Steps
+- Validate the workflow, land this narrow follow-up, and confirm the next `dev` Supabase deploy runs green end to end.
+
+---
+
 ### session v80: Vendor a Deno-visible CUBID API shim for Supabase deploys
 - timestamp: 2026-04-26T15:56:07-04:00
 - agent: **Codex (GPT-5)**

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -27,6 +27,7 @@ The app should treat a declared failure envelope differently from transport or i
 - function-specific adapters live under `lib/edge-functions/`
 - function names should follow command-style naming such as `project-payment-drafts-create`
 - each function directory should use an `index.ts` entrypoint so the Supabase CLI can bundle and deploy it consistently
+- helper-only directories under `supabase/functions/` such as `_shared` and `_vendor` are part of the bundle graph, but they must be excluded from function deployment enumeration
 - shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
 - shared modules imported by Edge Functions must not rely on Next-only runtime markers such as `import "server-only"`; keep those markers on Next-only wrappers instead
 - vendored packages that are not published to npm or JSR must be mapped explicitly in `supabase/functions/deno.json` when Edge Functions import them through shared modules, and those mappings should point to repo-tracked Deno-visible files rather than CI-specific `node_modules` paths

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -43,7 +43,7 @@ Pull requests use the same target resolution but run:
 supabase db push --yes --db-url "$SUPABASE_DB_URL" --dry-run
 ```
 
-Edge Functions are deployed by enumerating each local function directory under `supabase/functions/` except `_shared` and deploying them one by one:
+Edge Functions are deployed by enumerating each local function directory under `supabase/functions/` except `_shared` and `_vendor`, then deploying the remaining function directories one by one:
 
 ```bash
 supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"


### PR DESCRIPTION
## Summary
- exclude helper-only directories from Supabase function deployment enumeration
- document the difference between bundle helper directories and deployable function directories
- record the follow-up workflow repair after PR #32

## Objective
Fix the remaining `dev` Supabase deploy failure after the CUBID bundling repair by ensuring the deploy workflow does not try to publish `_vendor` as if it were a real Edge Function.

## Changes
- updated `.github/workflows/supabase-deploy.yml` to skip `_vendor` and `_shared` when enumerating functions
- updated the Supabase deployment and Edge Function docs to capture the helper-directory rule
- added the session-log entry for this narrow workflow follow-up

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/supabase-deploy.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/supabase-deploy.yml"); puts "yaml ok"'`
- `git diff --check`

## Reviewer Notes
- the key review surface is the workflow directory filter in the deploy step
- this PR intentionally does not change app code or Supabase function code

## Follow-ups
- after merge, confirm the push-triggered `dev` Supabase deploy completes successfully end to end
