### PR TITLE
[codex] repair session 46 supabase deploy health

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,30 @@
+### session v124: Add the next roadmap tranche
+- timestamp: 2026-05-03T13:50:16Z
+- agent: **Codex (GPT-5)**
+- branch: **codex/next-roadmap-pass**
+- head: pending roadmap commit
+
+#### Objective
+Create a short, repo-grounded next-roadmap pass after PR #39 merged Sessions 37-45 and the prior execution roadmap reached its planned end.
+
+#### Actions Taken
+- Confirmed local `dev` was clean and aligned with `origin/dev` after approved cleanup.
+- Reviewed the current backlog tail, recent session-log entries, and engineering docs signals from the merged operations/MCP stack.
+- Added Sessions 46-52 to `agent-context/todo.md` covering deploy verification, beta smoke/blocker audit, seed persona hardening, MCP runtime packaging, operator read-contract consolidation, beta safety guardrails, and the dev-to-main release-candidate path.
+
+#### Tests and Validation Notes
+- No code validation was run because this was a planning-only backlog update.
+- Git status was checked before editing and showed a clean branch baseline.
+
+#### Reflections
+- The roadmap has shifted from “build the missing product architecture” to “prove, harden, package, and promote the product safely.”
+- Keeping the next tranche short should prevent the backlog from becoming another moth-bag, little irony gremlin that it is.
+
+#### Suggested Next Steps
+- Start with Session 46 to verify the post-merge dev deploy and Supabase function/migration health before adding more product scope.
+
+---
+
 ### session v123: Address PR #39 MCP and Edge read review feedback
 - timestamp: 2026-05-03T00:43:17Z
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,39 @@
+### session v125: Repair CUBID Edge deploy package resolution
+- timestamp: 2026-05-03T17:13:21-0400
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-46-deploy-health**
+- head: pending final commit
+
+#### Objective
+Implement Session 46 by repairing the post-merge `dev` Supabase deploy failure where `user-cubid-resolve-email` could not bundle `node_modules/@cubid/api/dist/index.mjs`.
+
+#### Actions Taken
+- Inspected the failed `dev` Supabase Deploy run for merge commit `1332f3f` and confirmed migrations applied before function bundling failed on the CUBID package import path.
+- Added `@cubid/core@0.1.0` and moved server/Edge-facing CUBID identity resolution and snapshot normalization imports from `@cubid/api` to `@cubid/core`.
+- Updated `supabase/functions/deno.json` so Supabase Deno resolves `@cubid/core` from `jsr:@cubid/core@0.1.0`.
+- Kept the local `@cubid/api`, `@cubid/web2`, and `@cubid/web2-react` tarballs for browser compatibility flows that still need them.
+- Updated deployment, Edge Function, and CUBID identity docs to record that Edge Functions must use `@cubid/core` rather than the old `node_modules/@cubid/api/dist/index.mjs` path.
+- Added Session 46.1 as a narrow post-merge deploy-confirmation spillover, because the push-triggered dev deploy can only be verified after this repair lands on `dev`.
+
+#### Tests and Validation Notes
+- `pnpm install --frozen-lockfile` passed.
+- `deno cache --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts` passed.
+- `deno cache --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts` passed.
+- `deno cache --config supabase/functions/deno.json supabase/functions/mcp-workflow-read/index.ts` passed.
+- `pnpm lint` passed, then `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` also passed.
+- `pnpm test` passed: 74 files and 287 tests; the Node 22 rerun also passed with the same file/test counts.
+- `pnpm typecheck` passed, then `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm typecheck` also passed.
+- `pnpm build` passed, then `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm build` also passed.
+
+#### Reflections
+- The PR dry-run was not enough to catch this because it did not deploy or bundle Edge Functions; the failure only appeared in the push-triggered deploy path.
+- Using the JSR-published runtime-agnostic CUBID core package gives Supabase Edge a stable Deno-native import path and removes the brittle repo-root `node_modules` dependency from function bundling.
+
+#### Suggested Next Steps
+- Yeet this repair to `dev`; after merge, complete Session 46.1 by confirming the push-triggered dev Supabase Deploy run succeeds through all functions.
+
+---
+
 ### session v124: Add the next roadmap tranche
 - timestamp: 2026-05-03T13:50:16Z
 - agent: **Codex (GPT-5)**

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,26 @@
+### session v126: Address PR #40 Copilot documentation feedback
+- timestamp: 2026-05-03T17:32:02-0400
+- agent: **Codex (GPT-5)**
+- branch: **codex/session-46-deploy-health**
+- head: pending review-fix commit
+
+#### Objective
+Address Copilot feedback on PR #40 without changing the Session 46 deploy repair behavior.
+
+#### Actions Taken
+- Reworded the CUBID identity engineering doc so the `@cubid/core` and browser-package split is described as the current runtime model, not as something introduced by Session 14.
+
+#### Tests and Validation Notes
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm lint` passed.
+
+#### Reflections
+- The package split is important deploy truth, but the historical attribution needed to be precise so future agents do not misread old sessions.
+
+#### Suggested Next Steps
+- Push the review-fix commit, reply to the Copilot thread, resolve it, and re-check CI before moving to the Codex review gate.
+
+---
+
 ### session v125: Repair CUBID Edge deploy package resolution
 - timestamp: 2026-05-03T17:13:21-0400
 - agent: **Codex (GPT-5)**

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -506,3 +506,80 @@ Translate the architecture into operational reliability. This session should pro
 - Session-log reference(s): session v122
 
 After the heavy architecture and workflow work is in place, do the intentional finish pass. This session should refine copy, empty states, motion, visual hierarchy, multilingual edge cases, and the most important conversion points for both users and founders. It should also tighten the balance between “visually stunning” and “simple, clean UX.” The goal is not random polish. It is aligning the product’s presentation with the fact that the underlying system is now real, operational, and trustworthy.
+
+## Session 46: Verify remote deploy health after the operations and MCP merge
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Confirm that the merged Sessions 37-45 stack actually landed cleanly in shared infrastructure, not just in local tests. This session should inspect the post-merge GitHub Actions results, verify the Supabase deploy workflow applied the new migrations and deployed the new Edge Functions on the dev target, and smoke the new operator/MCP-adjacent surfaces against the deployed environment where credentials allow. Fix small deployment-script, Deno import, or environment-documentation issues if discovered. Do not add product scope unless the deploy verification reveals a real blocker.
+
+## Session 47: Run a production-readiness smoke and beta blocker audit
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Perform a focused end-to-end beta readiness audit now that the public funnels, workspaces, monthly cycle pipeline, reporting, storage, and MCP foundation exist. Cover the highest-risk user journeys: visitor conversion, user onboarding, founder onboarding, contribution submission, monthly cycle operator flow, user earnings/reporting, admin operations, and key localization paths. Record concrete blockers in this backlog, fix only small obvious breakages, and avoid reopening completed architecture decisions unless runtime evidence proves they are wrong. The output should be a launch-oriented punch list with severity, owner surface, and suggested session order.
+
+## Session 48: Harden seeded local and preview smoke personas
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Make the local and preview smoke environment more dependable for future agents and reviewers. Ensure the tracked seed supports at least one regular user, one founder/project admin, one internal operator, active projects, payment routes, monthly cycles across multiple statuses, published reports, payout rows, and representative identity states without requiring remote data pulls. Keep secrets out of the seed, keep the dataset small, and update `docs/engineering/local-seed.md` plus testing guidance so smoke credentials and expected routes are obvious. This session should reduce the recurring “can we even smoke this?” drag.
+
+## Session 49: Package and document MCP runtime deployment
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Turn the MCP server from a repo package into a deployable and supportable runtime artifact. Add a documented local launch path, environment contract, health or version command, and packaging guidance for whichever host or agent runtime will consume it first. Verify the stdio framing path and Edge-backed readers in a realistic local smoke, then update `docs/engineering/mcp.md` with setup, auth, troubleshooting, and safe tool-extension rules. Do not expand tool scope in this session; the goal is making the existing MCP surface easy to run and hard to misuse.
+
+## Session 50: Move operator dashboard reads fully onto stable read contracts
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Complete the remaining high-value operator read-model migration by aligning admin dashboard, monthly cycle, observability, reconciliation, reporting, and operations-runbook surfaces with stable server or Edge Function read contracts. The current app has the right architectural direction, but this session should verify no operator page still depends on scattered page-local Supabase queries that duplicate authorization or shape data differently from MCP. Preserve current UI behavior while consolidating read boundaries, adding tests for partial-read failure states, and updating Edge Function/read-path documentation where the contract becomes canonical.
+
+## Session 51: Add runtime guardrails for beta-critical abuse and data safety
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Move the most important beta safety expectations from docs into runtime checks where practical. Prioritize rate limits or idempotency on expensive command paths, clearer authorization failures for founder/operator commands, safer file-artifact access patterns, and explicit audit events for sensitive cycle or payout operations that are not yet covered. This should be a precise hardening pass, not broad security theater: document what is actually enforced, what remains runbook-only, and which deferred controls need external infrastructure later. Add tests around the new guardrails and avoid weakening existing RLS or Edge Function ownership checks.
+
+## Session 52: Prepare the dev-to-main release candidate path
+
+- Status: Not started
+- Timestamp started: TBD
+- Timestamp completed: TBD
+- Feature branch: TBD
+- Head: TBD
+- Session-log reference(s): TBD
+
+Once dev deploy health and beta smoke blockers are understood, prepare the first credible release-candidate path from `dev` toward `main`. This session should verify branch protection, production environment approval, Supabase main-target deployment settings, required secrets, migration ordering, rollback notes, and the minimum manual smoke checklist for Production. Update the README and operations runbook only where they differ from current truth. The output should be a small release-readiness PR that makes the main promotion path boring, explicit, and reviewable before any production data is touched.

--- a/agent-context/todo.md
+++ b/agent-context/todo.md
@@ -509,6 +509,17 @@ After the heavy architecture and workflow work is in place, do the intentional f
 
 ## Session 46: Verify remote deploy health after the operations and MCP merge
 
+- Status: Complete
+- Timestamp started: 2026-05-03T17:10:26-0400
+- Timestamp completed: 2026-05-03T17:13:21-0400
+- Feature branch: codex/session-46-deploy-health
+- Head: pending final commit
+- Session-log reference(s): session v125
+
+Confirm that the merged Sessions 37-45 stack actually landed cleanly in shared infrastructure, not just in local tests. This session should inspect the post-merge GitHub Actions results, verify the Supabase deploy workflow applied the new migrations and deployed the new Edge Functions on the dev target, and smoke the new operator/MCP-adjacent surfaces against the deployed environment where credentials allow. Fix small deployment-script, Deno import, or environment-documentation issues if discovered. Do not add product scope unless the deploy verification reveals a real blocker.
+
+## Session 46.1: Confirm the post-merge dev Supabase deploy
+
 - Status: Not started
 - Timestamp started: TBD
 - Timestamp completed: TBD
@@ -516,7 +527,7 @@ After the heavy architecture and workflow work is in place, do the intentional f
 - Head: TBD
 - Session-log reference(s): TBD
 
-Confirm that the merged Sessions 37-45 stack actually landed cleanly in shared infrastructure, not just in local tests. This session should inspect the post-merge GitHub Actions results, verify the Supabase deploy workflow applied the new migrations and deployed the new Edge Functions on the dev target, and smoke the new operator/MCP-adjacent surfaces against the deployed environment where credentials allow. Fix small deployment-script, Deno import, or environment-documentation issues if discovered. Do not add product scope unless the deploy verification reveals a real blocker.
+After the Session 46 repair PR merges to `dev`, verify the push-triggered `Supabase Deploy` workflow succeeds end to end against the dev Supabase target. Confirm the deploy run includes `user-cubid-resolve-email`, `user-cubid-sync-profile`, and `mcp-workflow-read`, and that no function attempts to resolve `node_modules/@cubid/api/dist/index.mjs`. If the deploy still fails, keep the follow-up narrow and repair only the failing deploy/runtime boundary before moving to Session 47.
 
 ## Session 47: Run a production-readiness smoke and beta blocker audit
 

--- a/docs/engineering/cubid-identity.md
+++ b/docs/engineering/cubid-identity.md
@@ -71,7 +71,7 @@ Phone and extra provider stamps improve profile completion but do not block publ
 
 ## Browser Bridge
 
-Session 14 uses a split CUBID package model:
+The current CUBID package model is split by runtime:
 
 - server and Edge identity resolution/sync use `@cubid/core`
 - `@cubid/api`

--- a/docs/engineering/cubid-identity.md
+++ b/docs/engineering/cubid-identity.md
@@ -71,11 +71,14 @@ Phone and extra provider stamps improve profile completion but do not block publ
 
 ## Browser Bridge
 
-Session 14 uses the local CUBID v2 packages:
+Session 14 uses a split CUBID package model:
 
+- server and Edge identity resolution/sync use `@cubid/core`
 - `@cubid/api`
 - `@cubid/web2`
 - `@cubid/web2-react`
+
+`@cubid/api` remains present for the local browser compatibility tarballs. Edge Functions should import `@cubid/core`, which is available to Supabase Deno through JSR.
 
 The browser does not receive `CUBID_API_KEY`.
 

--- a/docs/engineering/edge-functions.md
+++ b/docs/engineering/edge-functions.md
@@ -31,7 +31,7 @@ The app should treat a declared failure envelope differently from transport or i
 - shared modules imported by Edge Functions should use explicit `.ts` or `.json` local specifiers because the Supabase bundle step runs on Deno resolution rules, not Node-style extension guessing
 - shared modules imported by Edge Functions must not rely on Next-only runtime markers such as `import "server-only"`; keep those markers on Next-only wrappers instead
 - packages consumed by Edge Functions through shared modules must be mapped explicitly in `supabase/functions/deno.json` when Deno cannot resolve the normal app import directly
-- the current `@cubid/api` mapping points at the installed package entrypoint under the repo root `node_modules/` so the app no longer needs a function-local `_vendor` mirror; switch that mapping to a `jsr:` package import once the Cubid repo publishes the package
+- CUBID server and Edge code uses the runtime-agnostic `@cubid/core` package and maps it to `jsr:@cubid/core@0.1.0`; do not reintroduce Edge imports that depend on `node_modules/@cubid/api/dist/index.mjs`
 - the root Next.js `tsc` run excludes `supabase/functions/` because those files are Deno-targeted and validated through the Supabase CLI and deploy workflow rather than the app TypeScript program
 - the deploy workflow installs repo dependencies before function bundling and `supabase/functions/deno.json` enables `nodeModulesDir` so vendored package dependencies remain available during remote bundling
 

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -49,9 +49,9 @@ Edge Functions are deployed by enumerating each local function directory under `
 supabase functions deploy "<function-name>" --project-ref "$SUPABASE_PROJECT_REF"
 ```
 
-Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so package dependencies remain available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step and can map shared-package imports explicitly when Deno cannot resolve the normal app import path on its own.
+Before bundling functions on deploy runs, the workflow installs repo dependencies with `pnpm install --frozen-lockfile` so package dependencies remain available to the Deno bundler. `supabase/functions/deno.json` enables `nodeModulesDir` for that bundle step and maps Edge-safe package imports explicitly when needed.
 
-FundLoop no longer keeps a function-local CUBID mirror under `supabase/functions/_vendor/`. Until the Cubid repo publishes a first-class JSR package for `@cubid/api`, the Edge runtime maps `@cubid/api` to the installed package entrypoint under the repo root `node_modules/`. That means remote deploys still require the workflow’s `pnpm install --frozen-lockfile` bootstrap before function bundling.
+FundLoop no longer keeps a function-local CUBID mirror under `supabase/functions/_vendor/`. CUBID server and Edge code imports the runtime-agnostic `@cubid/core` package, and the Supabase Deno import map resolves it through `jsr:@cubid/core@0.1.0`. Browser-only CUBID compatibility helpers may still depend on local vendored tarballs, but Edge Functions must not depend on `node_modules/@cubid/api/dist/index.mjs`.
 
 The workflow pins the Supabase CLI version instead of using `latest`; update it deliberately during normal dependency/tooling triage.
 

--- a/lib/cubid/resolve-by-email.ts
+++ b/lib/cubid/resolve-by-email.ts
@@ -1,5 +1,5 @@
-import type { CubidApiClient, CubidApiClientConfig } from "@cubid/api"
-import { createCubidApiClient } from "@cubid/api"
+import type { CubidApiClient, CubidApiClientOptions } from "@cubid/core"
+import { createCubidApiClient } from "@cubid/core"
 import { getCubidConfig, type CubidConfig } from "./config.ts"
 import type { CubidIdentityLinkState } from "./types.ts"
 
@@ -22,7 +22,8 @@ function isVerifiedIdentityEmail(
   return response.stampDetails.some(
     (detail) =>
       detail.stampType === "email" &&
-      detail.value?.trim().toLowerCase() === normalizedEmail &&
+      typeof detail.value === "string" &&
+      detail.value.trim().toLowerCase() === normalizedEmail &&
       detail.status?.trim().toLowerCase() === "verified",
   )
 }
@@ -33,7 +34,7 @@ function createClientFromInput(input: ResolveCubidIdentityByEmailInput) {
   }
 
   const config = input.config ?? getCubidConfig()
-  const clientConfig: CubidApiClientConfig = {
+  const clientConfig: CubidApiClientOptions = {
     apiKey: config.apiKey,
     baseUrl: config.baseUrl,
     dappId: config.dappId,
@@ -52,7 +53,7 @@ export async function resolveCubidIdentityByEmail(
   }
 
   const client = createClientFromInput(input)
-  const created = await client.createUser({ email })
+  const created = await client.ensureUserByEmail({ email })
 
   if (!created.userId) {
     throw new Error("CUBID did not return a user identifier for this email.")

--- a/lib/cubid/server-client.ts
+++ b/lib/cubid/server-client.ts
@@ -1,4 +1,4 @@
-import { createCubidApiClient } from "@cubid/api"
+import { createCubidApiClient } from "@cubid/core"
 import { getCubidConfig } from "./config.ts"
 
 export function createServerCubidApiClient() {

--- a/lib/cubid/snapshot.ts
+++ b/lib/cubid/snapshot.ts
@@ -1,4 +1,4 @@
-import type { FetchIdentityResponse, FetchScoreResponse, FetchStampsResponse, FetchUserDataResponse } from "@cubid/api"
+import type { FetchIdentityResponse, FetchScoreResponse, FetchStampsResponse, FetchUserDataResponse } from "@cubid/core"
 import type { Json } from "../../types/supabase.ts"
 import {
   CUBID_RECOMMENDED_STAMPS,
@@ -39,7 +39,7 @@ export function normalizeCubidIdentitySnapshot(input: CubidSnapshotNormalization
   return {
     cubidUserId: input.cubidUserId,
     primaryName: input.userData?.name?.trim() || null,
-    primaryEmail: input.stamps.email,
+    primaryEmail: input.stamps.email ?? null,
     primaryPhone: pickPrimaryPhone(input.stamps.allStamps),
     cubidScore: input.score?.cubidScore ?? null,
     availableStampTypes,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@cubid/api": "file:vendor/cubid/cubid-api-0.1.0.tgz",
+    "@cubid/core": "0.1.0",
     "@cubid/web2": "file:vendor/cubid/cubid-web2-0.1.0.tgz",
     "@cubid/web2-react": "file:vendor/cubid/cubid-web2-react-0.1.0.tgz",
     "@hookform/resolvers": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@cubid/api':
         specifier: file:vendor/cubid/cubid-api-0.1.0.tgz
         version: file:vendor/cubid/cubid-api-0.1.0.tgz
+      '@cubid/core':
+        specifier: 0.1.0
+        version: 0.1.0
       '@cubid/web2':
         specifier: file:vendor/cubid/cubid-web2-0.1.0.tgz
         version: file:vendor/cubid/cubid-web2-0.1.0.tgz
@@ -255,6 +258,8 @@ importers:
         specifier: ^3.0.7
         version: 3.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  packages/mcp-server: {}
+
 packages:
 
   '@actions/core@1.11.1':
@@ -414,6 +419,9 @@ packages:
   '@cubid/api@file:vendor/cubid/cubid-api-0.1.0.tgz':
     resolution: {integrity: sha512-FtzkdHlL2SfjrYyMmhLeZ1Sr5SL3RRwOsSkJJyrt3hdr5oqEvIkquqawG0hgmGMhZJQ4jfxPH9XdsNRweTYyWw==, tarball: file:vendor/cubid/cubid-api-0.1.0.tgz}
     version: 0.1.0
+
+  '@cubid/core@0.1.0':
+    resolution: {integrity: sha512-EJ0eM/DWhzUcqvHSTjDgmjSw1/QTEyW1cqocWlXcLsj+1WXojipr65YG1+zcyz555LXqyF3xwFFFJgZRq3Dqcw==}
 
   '@cubid/web2-react@file:vendor/cubid/cubid-web2-react-0.1.0.tgz':
     resolution: {integrity: sha512-ImP5mYICXBiKLhWSUsnLbB71hhKg2KLYfYCrnYmqTIHOJ0/KfB7DsL3xJADkS/tvuoISoJt66FrKZU3OuPhQEg==, tarball: file:vendor/cubid/cubid-web2-react-0.1.0.tgz}
@@ -6249,6 +6257,8 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@cubid/api@file:vendor/cubid/cubid-api-0.1.0.tgz': {}
+
+  '@cubid/core@0.1.0': {}
 
   '@cubid/web2-react@file:vendor/cubid/cubid-web2-react-0.1.0.tgz(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@cubid/api": "../../node_modules/@cubid/api/dist/index.mjs",
+    "@cubid/core": "jsr:@cubid/core@0.1.0",
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2.104.0",
     "viem": "npm:viem@2.48.1",
     "viem/chains": "npm:viem@2.48.1/chains",

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,10 +1,16 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@cubid/core@0.1.0": "0.1.0",
     "npm:@supabase/supabase-js@2": "2.104.0",
     "npm:@supabase/supabase-js@2.104.0": "2.104.0",
     "npm:viem@2.48.1": "2.48.1_zod@4.3.6",
     "npm:zod@4.3.6": "4.3.6"
+  },
+  "jsr": {
+    "@cubid/core@0.1.0": {
+      "integrity": "8ffee39868cc6f1563c86639017b1e8321859c641afd3dbfdb2ebec0df46d7ee"
+    }
   },
   "npm": {
     "@adraffy/ens-normalize@1.11.1": {
@@ -161,6 +167,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@cubid/core@0.1.0",
       "npm:@supabase/supabase-js@2.104.0",
       "npm:viem@2.48.1",
       "npm:zod@4.3.6"


### PR DESCRIPTION
## Summary
- Adds the next short roadmap tranche after Sessions 37-45 completed.
- Repairs the dev Supabase deploy failure by moving server/Edge CUBID imports to `@cubid/core@0.1.0`.
- Maps `@cubid/core` through JSR for Supabase Deno bundling and updates the related deployment docs.
- Keeps browser-only CUBID compatibility tarballs in place for existing Web2/React flows.

## Objective
Fix the post-merge `dev` Supabase Deploy failure from PR #39. The deploy applied migrations and deployed many functions, then failed while bundling `user-cubid-resolve-email` because the Edge runtime tried to resolve `node_modules/@cubid/api/dist/index.mjs`.

## Changes
- Added `@cubid/core@0.1.0` and switched server/Edge CUBID identity resolution/snapshot imports to that package.
- Updated `supabase/functions/deno.json` and `supabase/functions/deno.lock` so Edge Functions import `jsr:@cubid/core@0.1.0`.
- Updated Edge Function, Supabase deployment, and CUBID identity docs to make the new Edge import contract explicit.
- Added Sessions 46-52 to the roadmap, then completed Session 46 and added Session 46.1 for post-merge dev deploy confirmation.

## Validation
- `pnpm install --frozen-lockfile`
- `deno cache --config supabase/functions/deno.json supabase/functions/user-cubid-resolve-email/index.ts`
- `deno cache --config supabase/functions/deno.json supabase/functions/user-cubid-sync-profile/index.ts`
- `deno cache --config supabase/functions/deno.json supabase/functions/mcp-workflow-read/index.ts`
- `pnpm lint`
- `pnpm test` passing 74 files / 287 tests
- `pnpm typecheck`
- `pnpm build`
- Node 22.22.1 reruns of lint, test, typecheck, and build

## Reviewer Notes
Review the Session 46 repair commit first, then the roadmap checkpoint if desired. The key review area is the CUBID package split: Edge/server code should use `@cubid/core`, while browser compatibility helpers may still use the local `@cubid/api` tarball.

## Follow-ups
- After this merges, Session 46.1 should confirm the push-triggered `dev` Supabase Deploy run succeeds through all function deployments.
- This PR does not change CUBID product behavior, onboarding behavior, or MCP tool scope.
