### PR TITLE
[codex] Add rotating prosperity thesis

### DIFF
--- a/agent-context/session-log/2026-07-21-codex-landing-page-theory.md
+++ b/agent-context/session-log/2026-07-21-codex-landing-page-theory.md
@@ -1,0 +1,13 @@
+# Landing page theory branch log
+
+### session v1: rotating prosperity thesis
+
+- timestamp: 2026-07-21T14:21:42.000Z
+- agent: Codex
+- branch: codex/landing-page-theory
+- head: origin/dev at session start
+- objective: Add a progressively slowing rotating hero thesis and an editorial Theory of Change section to the localized public homepage.
+- actions: Added 19 localized hero prefixes with a fixed mutual-prosperity suffix, restored the networked-economy thesis above the supporting hero body, added reduced-motion and stable accessible-heading behavior, introduced the capitalism/basic-income/pluralism narrative section, and constrained the mobile hero grid so long phrases wrap without viewport clipping.
+- tests and validation: Focused rotating-title and i18n tests, lint, typecheck, production build, and desktop/mobile Playwright smoke passed before publish. Browser smoke confirmed live title rotation, Theory section placement, responsive wrapping, and zero console errors; ignored screenshots are under `output/playwright/landing-*.png`.
+- reflections: The active checkout did not contain the referenced “Is FundLoop for Normal Companies or Crypto?” heading, so the Theory section sits at the equivalent narrative boundary before “How the loop works.”
+- suggested next steps: Review the final phrase and manifesto copy in product context. The progressive delay resets to two seconds after every complete 19-prefix cycle.

--- a/app/[locale]/(public)/page.tsx
+++ b/app/[locale]/(public)/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Reveal } from "@/components/marketing/reveal"
 import { NetworkConstellation } from "@/components/marketing/network-constellation"
 import { JourneyConfidenceBand, type JourneyConfidenceItem } from "@/components/marketing/journey-confidence-band"
+import { RotatingHeroTitle } from "@/components/marketing/rotating-hero-title"
 import { ecosystemSites, resourceLinks } from "@/lib/public-site"
 import { useCases } from "@/lib/use-cases"
 
@@ -70,6 +71,7 @@ export default async function Home({ params }: PageProps) {
   const shellT = await getTranslations({ locale, namespace: "shell" })
   const loopSteps = t.raw("howItWorks.steps") as HomeStep[]
   const entryPaths = t.raw("entryPaths") as EntryPath[]
+  const heroPrefixes = t.raw("heroPrefixes") as string[]
   const exploreResourceLinks = resourceLinks.map((link) => ({
     ...link,
     label: shellT(`nav.resourceLinks.${link.id}.label`),
@@ -82,14 +84,15 @@ export default async function Home({ params }: PageProps) {
   return (
     <MarketingPage>
       <section className="relative min-h-[calc(100svh-5.5rem)]">
-        <div className="mx-auto grid min-h-[calc(100svh-5.5rem)] max-w-7xl items-end gap-12 px-6 pb-14 pt-10 sm:px-8 lg:grid-cols-[minmax(0,1.02fr)_minmax(22rem,0.98fr)] lg:px-12">
-          <Reveal className="max-w-3xl pb-4">
+        <div className="mx-auto grid min-h-[calc(100svh-5.5rem)] max-w-7xl grid-cols-[minmax(0,1fr)] items-end gap-12 px-6 pb-14 pt-10 sm:px-8 lg:grid-cols-[minmax(0,1.02fr)_minmax(22rem,0.98fr)] lg:px-12">
+          <Reveal className="min-w-0 max-w-3xl pb-4">
             <SectionEyebrow>{t("eyebrow")}</SectionEyebrow>
             <p className="mt-6 font-display text-[clamp(4rem,12vw,8.5rem)] leading-none tracking-[-0.07em]">FundLoop</p>
-            <h1 className="mt-6 max-w-2xl text-4xl font-semibold leading-[1.02] tracking-[-0.05em] sm:text-5xl lg:text-6xl">
-              {t("heroTitle")}
-            </h1>
-            <SectionBody className="mt-6 max-w-xl">{t("heroBody")}</SectionBody>
+            <RotatingHeroTitle prefixes={heroPrefixes} suffix={t("heroSuffix")} />
+            <SectionBody className="mt-6 max-w-xl font-medium text-[var(--marketing-ink)]">
+              {t("heroThesis")}
+            </SectionBody>
+            <SectionBody className="mt-3 max-w-xl">{t("heroBody")}</SectionBody>
             <div id="project-signup" className="mt-10 flex scroll-mt-28 flex-col gap-4 sm:flex-row">
               <Button
                 asChild
@@ -136,6 +139,38 @@ export default async function Home({ params }: PageProps) {
         secondaryHref="/founders"
         items={polishT.raw("items") as JourneyConfidenceItem[]}
       />
+
+      <MarketingSection className="border-b border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-20">
+          <Reveal className="lg:sticky lg:top-28 lg:self-start">
+            <SectionEyebrow>{t("theoryOfChange.eyebrow")}</SectionEyebrow>
+            <SectionTitle className="mt-4 max-w-lg text-5xl sm:text-6xl">
+              {t("theoryOfChange.title")}
+            </SectionTitle>
+            <SectionBody className="mt-5">{t("theoryOfChange.body")}</SectionBody>
+          </Reveal>
+
+          <div>
+            {["capitalism", "basicIncome", "pluralism"].map((idea, index) => (
+              <Reveal key={idea} delay={index * 90}>
+                <article className="grid gap-5 border-t border-[color:var(--marketing-line)] py-8 sm:grid-cols-[4rem_minmax(0,1fr)] sm:py-10">
+                  <p className="font-display text-3xl leading-none text-[var(--marketing-accent)]">
+                    {String(index + 1).padStart(2, "0")}
+                  </p>
+                  <div>
+                    <h2 className="max-w-2xl font-display text-3xl leading-[1.02] tracking-[-0.04em] sm:text-4xl">
+                      {t(`theoryOfChange.ideas.${idea}.title`)}
+                    </h2>
+                    <p className="mt-4 max-w-2xl text-base leading-7 text-[var(--marketing-muted-strong)]">
+                      {t(`theoryOfChange.ideas.${idea}.body`)}
+                    </p>
+                  </div>
+                </article>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
 
       <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
         <div className="grid gap-12 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">

--- a/components/marketing/rotating-hero-title.tsx
+++ b/components/marketing/rotating-hero-title.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+const INITIAL_PAUSE_MS = 2_000
+const PAUSE_INCREMENT_MS = 1_000
+const TRANSITION_MS = 260
+
+type RotatingHeroTitleProps = {
+  prefixes: readonly string[]
+  suffix: string
+}
+
+export function RotatingHeroTitle({ prefixes, suffix }: RotatingHeroTitleProps) {
+  const [prefixIndex, setPrefixIndex] = useState(0)
+  const [isChanging, setIsChanging] = useState(false)
+  const pauseStepRef = useRef(0)
+
+  useEffect(() => {
+    if (prefixes.length < 2 || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      return
+    }
+
+    const pauseTimer = window.setTimeout(
+      () => setIsChanging(true),
+      INITIAL_PAUSE_MS + pauseStepRef.current * PAUSE_INCREMENT_MS,
+    )
+
+    return () => window.clearTimeout(pauseTimer)
+  }, [prefixIndex, prefixes.length])
+
+  useEffect(() => {
+    if (!isChanging) {
+      return
+    }
+
+    const transitionTimer = window.setTimeout(() => {
+      setPrefixIndex((currentIndex) => {
+        const nextIndex = (currentIndex + 1) % prefixes.length
+        pauseStepRef.current = nextIndex === 0 ? 0 : pauseStepRef.current + 1
+        return nextIndex
+      })
+      setIsChanging(false)
+    }, TRANSITION_MS)
+
+    return () => window.clearTimeout(transitionTimer)
+  }, [isChanging, prefixes.length])
+
+  const currentPrefix = prefixes[prefixIndex] ?? ""
+  const accessibleTitle = `${prefixes[0] ?? ""} ${suffix}`.trim()
+
+  return (
+    <h1 className="mt-6 w-full min-w-0 max-w-3xl text-4xl font-semibold leading-[1.02] tracking-[-0.05em] sm:text-5xl lg:text-6xl">
+      <span className="sr-only">{accessibleTitle}</span>
+      <span aria-hidden="true" className="block min-w-0">
+        <span className="grid min-h-[2.04em] min-w-0 content-end sm:min-h-[2.04em]">
+          <span
+            className={`block text-[var(--marketing-accent)] transition-[opacity,transform,filter] duration-300 ease-out motion-reduce:transform-none motion-reduce:transition-none ${
+              isChanging ? "translate-y-3 opacity-0 blur-[2px]" : "translate-y-0 opacity-100 blur-0"
+            }`}
+          >
+            {currentPrefix}
+          </span>
+        </span>
+        <span className="block">{suffix}</span>
+      </span>
+    </h1>
+  )
+}

--- a/i18n/messages/en.ts
+++ b/i18n/messages/en.ts
@@ -1044,7 +1044,30 @@ export const enMessages = {
   },
   home: {
     eyebrow: "Mutual prosperity, made operational",
-    heroTitle: "A networked economy where projects feed the loop and people share in the upside.",
+    heroTitle: "A Network State for Mutual Prosperity",
+    heroSuffix: "for Mutual Prosperity",
+    heroPrefixes: [
+      "A Network State",
+      "A Collection of Apps",
+      "A Society of Likeminded",
+      "A Post-capitalistic Future",
+      "A Commons in Motion",
+      "A Coalition of Builders",
+      "A Culture of Contribution",
+      "A Circle of Belonging",
+      "A Federation of Communities",
+      "A Marketplace of Care",
+      "A Cooperative Economy",
+      "A Regenerative Society",
+      "A Pluralistic Commons",
+      "A Movement of Mutualists",
+      "A Network of Neighbours",
+      "A Union of Dreamers",
+      "A Civic Layer for Everyone",
+      "A Shared Prosperity Engine",
+      "An Economy of Enough",
+    ],
+    heroThesis: "A networked economy where projects feed the loop and people share in the upside.",
     heroBody:
       "FundLoop helps teams reward real contribution, grow with stronger proof-of-humanity signal, and route part of success back to the communities that make the whole system work.",
     ctas: {
@@ -1055,6 +1078,29 @@ export const enMessages = {
       projects: "Projects pledge 1%+ into the loop.",
       people: "People create signal through use.",
       value: "Value returns with more context.",
+    },
+    theoryOfChange: {
+      eyebrow: "Our theory of change",
+      title: "Prosperity needs more than one system.",
+      body:
+        "FundLoop starts from a simple belief: useful systems do not have to become total systems. We can keep what works, challenge what does not, and build practical complements together.",
+      ideas: {
+        capitalism: {
+          title: "Capitalism can create. It cannot be the whole answer.",
+          body:
+            "Is capitalism good? Yes. Is it enough? No. Extreme capitalism is not a future worth choosing—unless the Hunger Games looks like somewhere you would actually want to live. Markets can be productive, but they need credible complements that keep prosperity mutual.",
+        },
+        basicIncome: {
+          title: "Basic income can protect. It cannot be the whole answer either.",
+          body:
+            "A basic income is good. Radical sameness is not—unless Pluribus looks like the future you want. The goal is not to replace every incentive or flatten every difference. It is to add a dependable floor beneath an economy that still leaves room for ambition, contribution, and plurality.",
+        },
+        pluralism: {
+          title: "The state can help. It should not have to act alone.",
+          body:
+            "A state-governed basic income may be part of the answer, but relying on it alone is fragile. Companies that choose to help fund a basic income should be encouraged. Administration and distribution are hard; shared infrastructure makes both simpler. Will people flock to participating companies? Hopefully—but that remains to be seen. FundLoop exists to make the experiment possible.",
+        },
+      },
     },
     howItWorks: {
       eyebrow: "How the loop works",

--- a/i18n/messages/es.ts
+++ b/i18n/messages/es.ts
@@ -1029,6 +1029,30 @@ export const esMessages = {
   home: {
     eyebrow: "Prosperidad mutua, hecha operativa",
     heroTitle: "Una economía en red donde los proyectos alimentan el loop y las personas comparten el valor generado.",
+    heroSuffix: "para la prosperidad mutua",
+    heroPrefixes: [
+      "Un estado-red",
+      "Una colección de aplicaciones",
+      "Una sociedad de personas afines",
+      "Un futuro poscapitalista",
+      "Unos bienes comunes en movimiento",
+      "Una coalición de constructores",
+      "Una cultura de contribución",
+      "Un círculo de pertenencia",
+      "Una federación de comunidades",
+      "Un mercado del cuidado",
+      "Una economía cooperativa",
+      "Una sociedad regenerativa",
+      "Unos bienes comunes pluralistas",
+      "Un movimiento de mutualistas",
+      "Una red de vecinos",
+      "Una unión de soñadores",
+      "Una capa cívica para todos",
+      "Un motor de prosperidad compartida",
+      "Una economía de lo suficiente",
+    ],
+    heroThesis:
+      "Una economía en red donde los proyectos alimentan el loop y las personas comparten el valor generado.",
     heroBody:
       "FundLoop ayuda a los equipos a recompensar contribuciones reales, crecer con mejor señal de prueba de humanidad y redirigir parte del éxito hacia las comunidades que hacen posible el sistema.",
     ctas: {
@@ -1039,6 +1063,29 @@ export const esMessages = {
       projects: "Los proyectos destinan 1 % o más al loop.",
       people: "Las personas crean señal mediante el uso.",
       value: "El valor regresa con más contexto.",
+    },
+    theoryOfChange: {
+      eyebrow: "Nuestra teoría del cambio",
+      title: "La prosperidad necesita más de un sistema.",
+      body:
+        "FundLoop parte de una idea sencilla: un sistema útil no tiene por qué convertirse en un sistema total. Podemos conservar lo que funciona, cuestionar lo que no y construir juntos complementos prácticos.",
+      ideas: {
+        capitalism: {
+          title: "El capitalismo puede crear. No puede ser toda la respuesta.",
+          body:
+            "¿Es bueno el capitalismo? Sí. ¿Es suficiente? No. El capitalismo extremo no es un futuro que valga la pena elegir, salvo que Los juegos del hambre parezca un lugar donde realmente querrías vivir. Los mercados pueden ser productivos, pero necesitan complementos creíbles que mantengan la prosperidad como algo mutuo.",
+        },
+        basicIncome: {
+          title: "La renta básica puede proteger. Tampoco es toda la respuesta.",
+          body:
+            "Una renta básica es buena. La uniformidad radical no lo es, salvo que Pluribus parezca el futuro que deseas. El objetivo no es sustituir todos los incentivos ni borrar todas las diferencias, sino añadir un suelo fiable bajo una economía que aún deje espacio para la ambición, la contribución y la pluralidad.",
+        },
+        pluralism: {
+          title: "El Estado puede ayudar. No debería tener que actuar solo.",
+          body:
+            "Una renta básica administrada por el Estado puede formar parte de la respuesta, pero depender solo de ella es frágil. Las empresas que decidan ayudar a financiarla deberían ser promovidas. La administración y la distribución son difíciles; una infraestructura compartida simplifica ambas. ¿Acudirá la gente a esas empresas? Ojalá, pero está por verse. FundLoop existe para hacer posible el experimento.",
+        },
+      },
     },
     howItWorks: {
       eyebrow: "Cómo funciona el loop",

--- a/i18n/messages/fr.ts
+++ b/i18n/messages/fr.ts
@@ -1029,6 +1029,30 @@ export const frMessages = {
   home: {
     eyebrow: "Prospérité mutuelle, rendue opérationnelle",
     heroTitle: "Une économie en réseau où les projets alimentent la boucle et où les personnes partagent la valeur créée.",
+    heroSuffix: "pour une prospérité mutuelle",
+    heroPrefixes: [
+      "Un État-réseau",
+      "Une collection d’applications",
+      "Une société d’esprits proches",
+      "Un avenir post-capitaliste",
+      "Des communs en mouvement",
+      "Une coalition de bâtisseurs",
+      "Une culture de la contribution",
+      "Un cercle d’appartenance",
+      "Une fédération de communautés",
+      "Un marché du soin",
+      "Une économie coopérative",
+      "Une société régénérative",
+      "Des communs pluralistes",
+      "Un mouvement mutualiste",
+      "Un réseau de voisinage",
+      "Une union de rêveurs",
+      "Une couche civique pour tous",
+      "Un moteur de prospérité partagée",
+      "Une économie du suffisant",
+    ],
+    heroThesis:
+      "Une économie en réseau où les projets alimentent la boucle et où les personnes partagent la valeur créée.",
     heroBody:
       "FundLoop aide les équipes à récompenser de vraies contributions, à croître avec un meilleur signal de preuve d’humanité et à redistribuer une partie de leur succès aux communautés qui rendent le système possible.",
     ctas: {
@@ -1039,6 +1063,29 @@ export const frMessages = {
       projects: "Les projets consacrent 1 % ou plus à la boucle.",
       people: "Les personnes créent du signal par l’usage.",
       value: "La valeur revient avec plus de contexte.",
+    },
+    theoryOfChange: {
+      eyebrow: "Notre théorie du changement",
+      title: "La prospérité a besoin de plus d’un système.",
+      body:
+        "FundLoop part d’une conviction simple : un système utile ne doit pas devenir un système total. Nous pouvons garder ce qui fonctionne, remettre en cause le reste et construire ensemble des compléments concrets.",
+      ideas: {
+        capitalism: {
+          title: "Le capitalisme peut créer. Il ne peut pas être toute la réponse.",
+          body:
+            "Le capitalisme est-il bénéfique ? Oui. Est-il suffisant ? Non. Le capitalisme extrême n’est pas un avenir à choisir — sauf si Hunger Games ressemble au monde où vous voudriez vraiment vivre. Les marchés peuvent être productifs, mais ils ont besoin de compléments crédibles qui rendent la prospérité mutuelle.",
+        },
+        basicIncome: {
+          title: "Le revenu de base peut protéger. Il n’est pas toute la réponse non plus.",
+          body:
+            "Un revenu de base est bénéfique. Une uniformité radicale ne l’est pas — sauf si Pluribus ressemble à l’avenir que vous souhaitez. Il ne s’agit pas de remplacer toute incitation ni d’effacer toute différence, mais d’ajouter un socle fiable à une économie qui laisse place à l’ambition, à la contribution et à la pluralité.",
+        },
+        pluralism: {
+          title: "L’État peut aider. Il ne devrait pas agir seul.",
+          body:
+            "Un revenu de base administré par l’État peut faire partie de la réponse, mais en dépendre seul est fragile. Les entreprises qui choisissent de le financer devraient être encouragées. L’administration et la distribution sont difficiles ; une infrastructure partagée les simplifie. Les gens afflueront-ils vers ces entreprises ? Espérons-le — cela reste à voir. FundLoop existe pour rendre cette expérimentation possible.",
+        },
+      },
     },
     howItWorks: {
       eyebrow: "Comment fonctionne la boucle",

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -42,6 +42,10 @@ describe("i18n message loading", () => {
     const messages = getLocaleMessages("fr")
 
     expect(messages.home.heroTitle).toContain("économie")
+    expect(messages.home.heroPrefixes).toHaveLength(19)
+    expect(messages.home.heroPrefixes[0]).toBe("Un État-réseau")
+    expect(messages.home.heroThesis).toContain("économie en réseau")
+    expect(messages.home.theoryOfChange.ideas.pluralism.body).toContain("FundLoop")
     expect(messages.shell.nav.resources).toBe("Ressources")
     expect(messages.shell.nav.primary.founders).toBe("Fondateurs")
     expect(messages.shell.nav.resourceLinks.founders.label).toBe("Parcours fondateur")

--- a/tests/rotating-hero-title.test.tsx
+++ b/tests/rotating-hero-title.test.tsx
@@ -1,0 +1,33 @@
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { RotatingHeroTitle } from "@/components/marketing/rotating-hero-title"
+
+describe("RotatingHeroTitle", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("rotates after progressively longer pauses", () => {
+    vi.useFakeTimers()
+    render(<RotatingHeroTitle prefixes={["First idea", "Second idea", "Third idea"]} suffix="for everyone" />)
+
+    expect(screen.getByText("First idea")).toBeTruthy()
+
+    act(() => vi.advanceTimersByTime(2_000))
+    act(() => vi.advanceTimersByTime(260))
+    expect(screen.getByText("Second idea")).toBeTruthy()
+
+    act(() => vi.advanceTimersByTime(2_999))
+    expect(screen.getByText("Second idea")).toBeTruthy()
+
+    act(() => vi.advanceTimersByTime(1))
+    act(() => vi.advanceTimersByTime(260))
+    expect(screen.getByText("Third idea")).toBeTruthy()
+  })
+
+  it("keeps the first complete heading available to assistive technology", () => {
+    render(<RotatingHeroTitle prefixes={["A Network State", "A Cooperative Economy"]} suffix="for Mutual Prosperity" />)
+
+    expect(screen.getByRole("heading", { name: "A Network State for Mutual Prosperity" })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- Rotate 19 localized hero prefixes while keeping “for Mutual Prosperity” fixed.
- Restore the networked-economy thesis immediately above the existing hero support copy.
- Add a localized, editorial Theory of Change section covering capitalism, basic income, and plural institutional support.
- Preserve accessibility, reduced-motion behavior, and mobile wrapping.

## Objective

Make FundLoop’s landing-page economic thesis more expressive and explicit without weakening the existing founder and participant paths.

## Changes

- Added a client-side rotating hero-title component with progressive pauses beginning at two seconds and resetting after a full phrase cycle.
- Added English, French, and Spanish hero phrases, thesis copy, and Theory of Change content.
- Added focused timing, accessible-heading, and locale coverage.
- Constrained the mobile hero grid so long phrases wrap within the viewport.

## Validation

- `pnpm test tests/rotating-hero-title.test.tsx tests/i18n.test.ts`
- `pnpm check` — lint, 79 test files / 370 tests, typecheck, and production build passed.
- `git diff --check`
- Local browser smoke confirmed the rotating title and restored thesis render on `/en`; prior desktop/mobile smoke covered the new section and responsive wrapping with zero console errors.

Validation ran with local Node 24.15.0, so pnpm emitted the repository’s expected Node 22 engine warning.

## Reviewer Notes

Review the hero component and English message block first, then the French/Spanish equivalents and focused tests. The active page does not contain the previously referenced “Is FundLoop for Normal Companies or Crypto?” heading, so the Theory section is placed at the equivalent narrative boundary before “How the loop works.”

The unrelated operational-MVP branch work is intentionally excluded from this PR; this branch was created directly from `origin/dev`.

## Follow-ups

- Product-copy review can refine individual rotating phrases without changing the timing component.
- Revisit the progressive timing ceiling if analytics show later phrases are rarely seen.
