### PR TITLE
[codex] repair dev Supabase migration deploy

### DIFF
--- a/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-default-reporting-migration.md
+++ b/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-default-reporting-migration.md
@@ -1,0 +1,10 @@
+# Session Log - codex/fix-dev-supabase-default-reporting-migration
+
+## 2026-07-22T03:49:09.000Z - Dev Supabase deploy migration repair
+
+- agent: Codex
+- branch: codex/fix-dev-supabase-default-reporting-migration
+- head: repair commit
+- summary: Repaired the post-merge dev Supabase Deploy failure from PR #90 by making the `publish_project_onboarding_draft_atomic` drop/grant signatures in `20260720173500_project_default_reporting_currency.sql` parser-friendly single statements. The function body and product behavior are unchanged.
+- validation: `git diff --check` passed. `supabase db push --dry-run --linked` passed and reported that the seven operational MVP migrations would be pushed without hitting the previous prepared-statement multi-command failure. The linked dry-run emitted the existing remote collation-version warning and a Supabase CLI update notice.
+- follow-ups: Open a repair PR to `dev`, confirm the Supabase Deploy PR dry-run passes, merge once green, and confirm the post-merge dev Supabase Deploy succeeds.

--- a/supabase/migrations/20260720173500_project_default_reporting_currency.sql
+++ b/supabase/migrations/20260720173500_project_default_reporting_currency.sql
@@ -8,21 +8,7 @@ ALTER TABLE public.projects
 ADD CONSTRAINT projects_default_reporting_currency_code_check
 CHECK (default_reporting_currency_code ~ '^[A-Z]{3,12}$');
 
-DROP FUNCTION IF EXISTS public.publish_project_onboarding_draft_atomic(
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  numeric,
-  integer,
-  integer,
-  integer[]
-);
+DROP FUNCTION IF EXISTS public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[]);
 
 CREATE OR REPLACE FUNCTION public.publish_project_onboarding_draft_atomic(
   p_name text,
@@ -148,19 +134,4 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.publish_project_onboarding_draft_atomic(
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  text,
-  numeric,
-  integer,
-  integer,
-  integer[],
-  text
-) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[], text) TO authenticated;


### PR DESCRIPTION
## Summary
- Repairs the `dev` Supabase Deploy failure that occurred after PR #90 merged.
- Makes the failing migration parser-friendly by collapsing the `DROP FUNCTION` and `GRANT` signatures for `publish_project_onboarding_draft_atomic` to single SQL statements.
- Leaves the function body and product behavior unchanged.

## Objective
Restore the `dev` Supabase migration/deploy path so the operational MVP migrations and Edge Functions can deploy normally after merge.

## Changes
- Updated `supabase/migrations/20260720173500_project_default_reporting_currency.sql` to avoid a prepared-statement multi-command parser failure in Supabase CLI remote deploy.
- Added a branch-scoped session-log entry for the repair.

## Validation
- `git diff --check`
- `supabase db push --dry-run --linked`

## Reviewer Notes
- This is intentionally not a product change.
- The local linked dry-run reached the expected “Would push these migrations” output instead of failing on the prior `DROP FUNCTION ... CREATE FUNCTION ... GRANT` parser bundle.

## Follow-ups
- Confirm PR Supabase dry-run is green.
- Merge to `dev` once checks are green.
- Confirm the push-triggered `dev` Supabase Deploy succeeds.
