### PR TITLE
[codex] split project onboarding RPC grant migration

### DIFF
--- a/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-function-grant-migration.md
+++ b/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-function-grant-migration.md
@@ -1,0 +1,10 @@
+# Session Log - codex/fix-dev-supabase-function-grant-migration
+
+## 2026-07-22T03:56:04.000Z - Split function grant from default-currency migration
+
+- agent: Codex
+- branch: codex/fix-dev-supabase-function-grant-migration
+- head: repair commit
+- summary: Followed up on the post-merge dev Supabase Deploy failure after the first repair showed the real deploy still bundled `DROP/CREATE/GRANT` around the dollar-quoted function body. Removed the old-function drop and moved the new function grant into a dedicated grant-only migration so `20260720173500_project_default_reporting_currency.sql` ends with the `CREATE OR REPLACE FUNCTION` statement.
+- validation: `git diff --check` passed. `supabase db push --dry-run --linked` passed and listed the seven operational MVP migrations plus the new grant-only migration. The linked dry-run emitted the existing remote collation-version warning and a Supabase CLI update notice.
+- follow-ups: Open a second repair PR to `dev`, confirm PR checks, merge when green, then verify the push-triggered dev Supabase Deploy succeeds.

--- a/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-function-grant-migration.md
+++ b/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-function-grant-migration.md
@@ -5,6 +5,6 @@
 - agent: Codex
 - branch: codex/fix-dev-supabase-function-grant-migration
 - head: repair commit
-- summary: Followed up on the post-merge dev Supabase Deploy failure after the first repair showed the real deploy still bundled `DROP/CREATE/GRANT` around the dollar-quoted function body. Removed the old-function drop and moved the new function grant into a dedicated grant-only migration so `20260720173500_project_default_reporting_currency.sql` ends with the `CREATE OR REPLACE FUNCTION` statement.
-- validation: `git diff --check` passed. `supabase db push --dry-run --linked` passed and listed the seven operational MVP migrations plus the new grant-only migration. The linked dry-run emitted the existing remote collation-version warning and a Supabase CLI update notice.
+- summary: Followed up on the post-merge dev Supabase Deploy failure after the first repair showed the real deploy still bundled `DROP/CREATE/GRANT` around the dollar-quoted function body. Moved the new function grant into a dedicated grant-only migration so `20260720173500_project_default_reporting_currency.sql` ends with the `CREATE OR REPLACE FUNCTION` statement, then added a dedicated single-statement migration to drop the legacy 13-argument RPC overload after Codex review flagged the schema/types drift risk.
+- validation: `git diff --check` passed. `supabase db push --dry-run --linked` passed and listed the seven operational MVP migrations plus the grant-only and legacy-drop migrations. The linked dry-run emitted the existing remote collation-version warning and a Supabase CLI update notice.
 - follow-ups: Open a second repair PR to `dev`, confirm PR checks, merge when green, then verify the push-triggered dev Supabase Deploy succeeds.

--- a/supabase/migrations/20260720173500_project_default_reporting_currency.sql
+++ b/supabase/migrations/20260720173500_project_default_reporting_currency.sql
@@ -8,8 +8,6 @@ ALTER TABLE public.projects
 ADD CONSTRAINT projects_default_reporting_currency_code_check
 CHECK (default_reporting_currency_code ~ '^[A-Z]{3,12}$');
 
-DROP FUNCTION IF EXISTS public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[]);
-
 CREATE OR REPLACE FUNCTION public.publish_project_onboarding_draft_atomic(
   p_name text,
   p_slug text,
@@ -133,5 +131,3 @@ BEGIN
   RETURN NEXT;
 END;
 $$;
-
-GRANT EXECUTE ON FUNCTION public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[], text) TO authenticated;

--- a/supabase/migrations/20260722035500_grant_project_onboarding_default_currency_rpc.sql
+++ b/supabase/migrations/20260722035500_grant_project_onboarding_default_currency_rpc.sql
@@ -1,0 +1,1 @@
+GRANT EXECUTE ON FUNCTION public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[], text) TO authenticated;

--- a/supabase/migrations/20260722035600_drop_legacy_project_onboarding_rpc.sql
+++ b/supabase/migrations/20260722035600_drop_legacy_project_onboarding_rpc.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS public.publish_project_onboarding_draft_atomic(text, text, text, text, text, text, text, text, text, numeric, integer, integer, integer[]);


### PR DESCRIPTION
## Summary
- Further repairs the `dev` Supabase Deploy failure around `20260720173500_project_default_reporting_currency.sql`.
- Makes the dollar-quoted `CREATE OR REPLACE FUNCTION` the final statement in that migration.
- Moves the new RPC grant into a dedicated follow-up migration.

## Objective
Restore the real post-merge `dev` Supabase Deploy path, not just the local dry-run path, for the operational MVP migrations.

## Changes
- Removed the old overload drop from the default-reporting-currency migration.
- Moved the authenticated execute grant for the new 14-argument `publish_project_onboarding_draft_atomic` overload into `20260722035500_grant_project_onboarding_default_currency_rpc.sql`.
- Added a branch-scoped session-log entry.

## Validation
- `git diff --check`
- `supabase db push --dry-run --linked`

## Reviewer Notes
- Product behavior is unchanged.
- The previous repair passed PR dry-run but the real push deploy still bundled `DROP + CREATE + GRANT`; this version avoids any trailing statement after the function body.

## Follow-ups
- Confirm PR dry-run/checks pass.
- Merge to `dev` and confirm the push-triggered Supabase Deploy succeeds.
