### PR TITLE
[codex] wrap asset preference RPC grant migration

### DIFF
--- a/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-asset-grants-do-block.md
+++ b/agent-context/session-log/2026-07-22-codex-fix-dev-supabase-asset-grants-do-block.md
@@ -1,0 +1,10 @@
+# Session Log - codex/fix-dev-supabase-asset-grants-do-block
+
+## 2026-07-22T04:23:01.000Z - Wrap asset-preference RPC privileges in one statement
+
+- agent: Codex
+- branch: codex/fix-dev-supabase-asset-grants-do-block
+- head: repair commit
+- summary: Repaired the next post-merge dev Supabase Deploy failure by converting the asset-preference RPC REVOKE/GRANT migration into a single `DO $$ ... $$` statement. This keeps the grant immediately after the function migration while satisfying the remote deploy path's prepared-statement restriction.
+- validation: `git diff --check` passed. `supabase db push --dry-run --linked` passed and listed the asset-preference grant migration plus the remaining pending operational MVP migrations. The linked dry-run emitted the existing remote collation-version warning and a Supabase CLI update notice.
+- follow-ups: Open a repair PR to `dev`, confirm checks, merge when green, and verify the push-triggered dev Supabase Deploy succeeds.

--- a/supabase/migrations/20260721040510_grant_user_asset_preferences_rpc.sql
+++ b/supabase/migrations/20260721040510_grant_user_asset_preferences_rpc.sql
@@ -1,4 +1,8 @@
-REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM anon;
-REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM authenticated;
-GRANT EXECUTE ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) TO service_role;
+DO $$
+BEGIN
+  REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM PUBLIC;
+  REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM anon;
+  REVOKE ALL ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) FROM authenticated;
+  GRANT EXECUTE ON FUNCTION public.replace_user_asset_preferences_atomic(uuid, jsonb) TO service_role;
+END
+$$;


### PR DESCRIPTION
## Summary
- Repairs the latest `dev` Supabase Deploy failure in `20260721040510_grant_user_asset_preferences_rpc.sql`.
- Keeps the asset-preference RPC privilege change immediately after the function migration.
- Converts the multiple REVOKE/GRANT commands into one `DO $$ ... $$` statement for remote deploy compatibility.

## Objective
Restore the real post-merge `dev` Supabase Deploy path while preserving the safe privilege sequencing requested by Codex review on PR #93.

## Changes
- Wrapped the asset-preference RPC REVOKE/GRANT statements in a single DO block.
- Added a branch-scoped session-log entry.

## Validation
- `git diff --check`
- `supabase db push --dry-run --linked`

## Reviewer Notes
- Product behavior is unchanged.
- This is only a migration deploy-shape repair.

## Follow-ups
- Confirm PR dry-run/checks pass.
- Merge to `dev` and confirm the push-triggered Supabase Deploy succeeds.
