### PR TITLE
Fix dev intake contract activation deploy marker

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -164,11 +164,20 @@ jobs:
           const url = new URL(process.env.DB_URL)
           const existingOptions = url.searchParams.get("options")
           const targetOption = `-c app.settings.fundloop_target_environment=${process.env.TARGET_ENVIRONMENT}`
-          url.searchParams.set("options", existingOptions ? `${existingOptions} ${targetOption}` : targetOption)
+          const query = []
+          url.searchParams.forEach((value, key) => {
+            if (key !== "options") {
+              query.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+            }
+          })
+          const mergedOptions = existingOptions ? `${existingOptions} ${targetOption}` : targetOption
+          query.push(`options=${encodeURIComponent(mergedOptions)}`)
+          url.search = `?${query.join("&")}`
           console.log(url.toString())
           NODE
           )"
 
+          export PGOPTIONS="-c app.settings.fundloop_target_environment=${TARGET_ENVIRONMENT}"
           supabase db push --yes --db-url "$supabase_db_url" --dry-run
 
       - name: Deploy database migrations
@@ -196,11 +205,20 @@ jobs:
           const url = new URL(process.env.DB_URL)
           const existingOptions = url.searchParams.get("options")
           const targetOption = `-c app.settings.fundloop_target_environment=${process.env.TARGET_ENVIRONMENT}`
-          url.searchParams.set("options", existingOptions ? `${existingOptions} ${targetOption}` : targetOption)
+          const query = []
+          url.searchParams.forEach((value, key) => {
+            if (key !== "options") {
+              query.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+            }
+          })
+          const mergedOptions = existingOptions ? `${existingOptions} ${targetOption}` : targetOption
+          query.push(`options=${encodeURIComponent(mergedOptions)}`)
+          url.search = `?${query.join("&")}`
           console.log(url.toString())
           NODE
           )"
 
+          export PGOPTIONS="-c app.settings.fundloop_target_environment=${TARGET_ENVIRONMENT}"
           supabase db push --yes --db-url "$supabase_db_url"
 
       - name: Install function bundle dependencies

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -159,8 +159,9 @@ jobs:
               ;;
           esac
 
-          supabase_db_url="$(
-            DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" node <<'NODE'
+          encoded_db_url_file="${RUNNER_TEMP}/supabase-db-url"
+          DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" OUTPUT_FILE="${encoded_db_url_file}" node <<'NODE'
+          const { writeFileSync } = require("node:fs")
           const url = new URL(process.env.DB_URL)
           const existingOptions = url.searchParams.get("options")
           const targetOption = `-c app.settings.fundloop_target_environment=${process.env.TARGET_ENVIRONMENT}`
@@ -173,9 +174,10 @@ jobs:
           const mergedOptions = existingOptions ? `${existingOptions} ${targetOption}` : targetOption
           query.push(`options=${encodeURIComponent(mergedOptions)}`)
           url.search = `?${query.join("&")}`
-          console.log(url.toString())
+          writeFileSync(process.env.OUTPUT_FILE, url.toString(), "utf8")
           NODE
-          )"
+          supabase_db_url="$(cat "${encoded_db_url_file}")"
+          echo "::add-mask::${supabase_db_url}"
 
           export PGOPTIONS="-c app.settings.fundloop_target_environment=${TARGET_ENVIRONMENT}"
           supabase db push --yes --db-url "$supabase_db_url" --dry-run
@@ -200,8 +202,9 @@ jobs:
               ;;
           esac
 
-          supabase_db_url="$(
-            DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" node <<'NODE'
+          encoded_db_url_file="${RUNNER_TEMP}/supabase-db-url"
+          DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" OUTPUT_FILE="${encoded_db_url_file}" node <<'NODE'
+          const { writeFileSync } = require("node:fs")
           const url = new URL(process.env.DB_URL)
           const existingOptions = url.searchParams.get("options")
           const targetOption = `-c app.settings.fundloop_target_environment=${process.env.TARGET_ENVIRONMENT}`
@@ -214,9 +217,10 @@ jobs:
           const mergedOptions = existingOptions ? `${existingOptions} ${targetOption}` : targetOption
           query.push(`options=${encodeURIComponent(mergedOptions)}`)
           url.search = `?${query.join("&")}`
-          console.log(url.toString())
+          writeFileSync(process.env.OUTPUT_FILE, url.toString(), "utf8")
           NODE
-          )"
+          supabase_db_url="$(cat "${encoded_db_url_file}")"
+          echo "::add-mask::${supabase_db_url}"
 
           export PGOPTIONS="-c app.settings.fundloop_target_environment=${TARGET_ENVIRONMENT}"
           supabase db push --yes --db-url "$supabase_db_url"

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-activation.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-activation.md
@@ -1,0 +1,33 @@
+### session v1: dev intake activation retry
+
+- Timestamp: 2026-08-04T05:27:19Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-contract-activation
+- Head: aca170c
+
+Objective:
+- Repair the post-merge dev Supabase intake-contract activation path after PR #95 deployed successfully but hosted remote-safe smoke still found zero active route candidates.
+
+Actions:
+- Confirmed the push-triggered dev Supabase deploy for PR #95 succeeded through migrations and Edge Function deployment.
+- Reran the remote-safe hosted smoke and reproduced the same fixture blocker: zero active contract-mode intake route candidates.
+- Read dev remote reference tables without mutation and confirmed `chain_intake_contracts` still contained inactive zero-address EVM placeholder rows.
+- Updated the Supabase Deploy workflow so Postgres `options` uses `%20` percent-encoded spaces rather than query-string `+` spaces, and added `PGOPTIONS` as a secondary session-setting path.
+- Added a forward retry migration that activates deterministic non-production intake/treasury placeholders only when the migration session explicitly reports `dev`, skips `main`, and raises on missing/unsupported target markers.
+- Updated the Supabase deployment docs with the reliable session-setting encoding rule.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- A local Node sanity check confirmed the workflow encoder emits `options=-c%20app.settings.fundloop_target_environment%3Ddev` and not query-string `+` spacing.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+- PR dry-run is pending.
+- Pending post-merge dev deploy confirmation.
+- Pending hosted remote-safe smoke rerun after the retry migration lands on `dev`.
+
+Reflections:
+- The previous workflow change was structurally valid and the migration was marked applied, but the runtime evidence shows the target environment setting did not reach the migration connection.
+- The retry migration should fail loudly if the workflow ever loses the target marker again, which is safer than silently recording a no-op migration.
+
+Suggested next steps:
+- Open a tiny repair PR to `dev`, confirm Supabase dry-run, merge after approval, confirm the dev deploy applies the retry migration, and rerun hosted MVP smoke.

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-activation.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-activation.md
@@ -31,3 +31,32 @@ Reflections:
 
 Suggested next steps:
 - Open a tiny repair PR to `dev`, confirm Supabase dry-run, merge after approval, confirm the dev deploy applies the retry migration, and rerun hosted MVP smoke.
+
+### session v2: PR review safety follow-up
+
+- Timestamp: 2026-08-04T13:53:32Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-contract-activation
+- Head: 6c0cf10
+
+Objective:
+- Address PR #103 review comments before merging the dev intake activation repair.
+
+Actions:
+- Removed the workflow helper pattern that printed the rewritten Supabase database URL to stdout.
+- Wrote the derived database URL to a temporary file instead and masked the derived value before passing it to `supabase db push`.
+- Changed the retry migration so marker-less local Supabase replays no-op cleanly, while unsupported explicit target markers still fail loudly.
+- Updated Supabase deploy docs with derived-URL masking guidance and local/no-op expectations for target-aware migrations.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- Static grep confirmed no `console.log(url.toString())` workflow URL logging remains.
+- A local Node sanity check confirmed the temporary-file URL encoder still emits `%20` options encoding and no `+` spacing.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+
+Reflections:
+- The PR dry-run proved the deploy marker path, but the reviews correctly caught two smaller safety/ergonomics issues before merge.
+
+Suggested next steps:
+- Push the review fix, reply to and resolve the PR #103 review threads, then wait for green checks.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -45,13 +45,16 @@ Pull requests use the same target resolution but run:
 supabase db push --yes --db-url "$SUPABASE_DB_URL" --dry-run
 ```
 
-The workflow appends a Postgres session setting to the migration connection URL:
+The workflow appends a Postgres session setting to the migration connection URL and exports the same value through `PGOPTIONS`:
 
 ```text
-options=-c app.settings.fundloop_target_environment=dev|main
+options=-c%20app.settings.fundloop_target_environment=dev|main
+PGOPTIONS=-c app.settings.fundloop_target_environment=dev|main
 ```
 
 Forward migrations may use this setting for target-aware reference data that must differ between Preview/dev and Production. Migrations must fail safe: missing production configuration must not overwrite existing production values with local or placeholder data. Dev-only smoke fixtures may use deterministic non-production placeholders when the target is `dev` and the migration documents that behavior.
+
+Connection URL `options` values must be percent-encoded with `%20` for spaces. Do not rely on query-string `+` encoding for this parameter; the Supabase CLI migration connection may not propagate the setting to Postgres in that form.
 
 Edge Functions are deployed by enumerating each local function directory under `supabase/functions/` except `_shared` and `_vendor`, then deploying the remaining function directories one by one:
 

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -56,6 +56,10 @@ Forward migrations may use this setting for target-aware reference data that mus
 
 Connection URL `options` values must be percent-encoded with `%20` for spaces. Do not rely on query-string `+` encoding for this parameter; the Supabase CLI migration connection may not propagate the setting to Postgres in that form.
 
+Workflow helpers must not print rewritten database URLs to logs. If a helper constructs a derived connection string, write it to a temporary file or shell variable, then mask the derived value with `::add-mask::` before passing it to `supabase db push`.
+
+Local `supabase db reset` and `supabase migration up` commands normally do not set `app.settings.fundloop_target_environment`. Target-aware migrations should treat a missing marker as local/no-op unless the migration is explicitly required for local schema correctness. Unsupported explicit marker values should still fail loudly.
+
 Edge Functions are deployed by enumerating each local function directory under `supabase/functions/` except `_shared` and `_vendor`, then deploying the remaining function directories one by one:
 
 ```bash

--- a/supabase/migrations/20260804054000_retry_dev_intake_contract_reference_data.sql
+++ b/supabase/migrations/20260804054000_retry_dev_intake_contract_reference_data.sql
@@ -1,14 +1,18 @@
 -- Retry the dev intake-contract activation after repairing deploy-time
 -- Postgres session-setting propagation. This migration is intentionally
--- target-aware and fails closed if the deploy workflow does not provide
--- app.settings.fundloop_target_environment.
+-- target-aware for remote deploys and a no-op for marker-less local replays.
 DO $$
 DECLARE
   target_environment text := COALESCE(NULLIF(current_setting('app.settings.fundloop_target_environment', true), ''), 'unknown');
 BEGIN
+  IF target_environment = 'unknown' THEN
+    RAISE NOTICE 'Skipping dev intake-contract placeholder activation for marker-less local replay.';
+    RETURN;
+  END IF;
+
   IF target_environment NOT IN ('dev', 'main') THEN
     RAISE EXCEPTION
-      'Missing or unsupported app.settings.fundloop_target_environment for intake reference-data migration: %',
+      'Unsupported app.settings.fundloop_target_environment for intake reference-data migration: %',
       target_environment;
   END IF;
 

--- a/supabase/migrations/20260804054000_retry_dev_intake_contract_reference_data.sql
+++ b/supabase/migrations/20260804054000_retry_dev_intake_contract_reference_data.sql
@@ -1,0 +1,87 @@
+-- Retry the dev intake-contract activation after repairing deploy-time
+-- Postgres session-setting propagation. This migration is intentionally
+-- target-aware and fails closed if the deploy workflow does not provide
+-- app.settings.fundloop_target_environment.
+DO $$
+DECLARE
+  target_environment text := COALESCE(NULLIF(current_setting('app.settings.fundloop_target_environment', true), ''), 'unknown');
+BEGIN
+  IF target_environment NOT IN ('dev', 'main') THEN
+    RAISE EXCEPTION
+      'Missing or unsupported app.settings.fundloop_target_environment for intake reference-data migration: %',
+      target_environment;
+  END IF;
+
+  IF target_environment = 'main' THEN
+    RAISE NOTICE 'Skipping dev intake-contract placeholder activation for main target.';
+    RETURN;
+  END IF;
+
+  WITH configured_intake AS (
+    SELECT
+      chains.id AS chain_id,
+      chains.network_key,
+      'contract'::public.payment_collection_mode AS collection_mode,
+      CASE chains.network_key
+        WHEN 'ethereum' THEN COALESCE(
+          NULLIF(current_setting('app.settings.ethereum_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001E01'
+        )
+        WHEN 'base' THEN COALESCE(
+          NULLIF(current_setting('app.settings.base_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001B01'
+        )
+        WHEN 'celo' THEN COALESCE(
+          NULLIF(current_setting('app.settings.celo_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001C01'
+        )
+      END AS contract_address,
+      CASE chains.network_key
+        WHEN 'ethereum' THEN COALESCE(
+          NULLIF(current_setting('app.settings.ethereum_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002E01'
+        )
+        WHEN 'base' THEN COALESCE(
+          NULLIF(current_setting('app.settings.base_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002B01'
+        )
+        WHEN 'celo' THEN COALESCE(
+          NULLIF(current_setting('app.settings.celo_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002C01'
+        )
+      END AS treasury_address,
+      'fundloop-intake-v1'::text AS abi_version
+    FROM public.ref_chains chains
+    WHERE chains.network_key IN ('ethereum', 'base', 'celo')
+  ),
+  valid_intake AS (
+    SELECT *
+    FROM configured_intake
+    WHERE contract_address IS NOT NULL
+      AND treasury_address IS NOT NULL
+      AND contract_address <> '0x0000000000000000000000000000000000000000'
+      AND treasury_address <> '0x0000000000000000000000000000000000000000'
+  )
+  INSERT INTO public.chain_intake_contracts (
+    chain_id,
+    collection_mode,
+    contract_address,
+    treasury_address,
+    abi_version,
+    is_active
+  )
+  SELECT
+    chain_id,
+    collection_mode,
+    contract_address,
+    treasury_address,
+    abi_version,
+    true
+  FROM valid_intake
+  ON CONFLICT (chain_id, collection_mode) DO UPDATE
+  SET
+    contract_address = EXCLUDED.contract_address,
+    treasury_address = EXCLUDED.treasury_address,
+    abi_version = EXCLUDED.abi_version,
+    is_active = EXCLUDED.is_active;
+END $$;


### PR DESCRIPTION
## Summary
- Repairs the Supabase Deploy migration connection marker used by target-aware migrations.
- Adds a forward retry migration to activate dev-only intake-contract reference rows through the approved deploy path.
- Documents the percent-encoded Postgres `options` contract and records the repair session.

## Objective
Unblock the hosted remote-safe MVP smoke after PR #95 merged and deployed successfully but dev still had zero active contract-mode intake route candidates.

## Changes
- Percent-encodes the database URL `options` parameter so spaces are emitted as `%20`, not query-string `+` spacing.
- Exports `PGOPTIONS` as a secondary target-marker path during `supabase db push` dry-runs and deploys.
- Adds `20260804054000_retry_dev_intake_contract_reference_data.sql`, which activates deterministic non-production EVM intake/treasury placeholders only for `dev`, skips `main`, and fails closed if the target marker is missing.
- Updates Supabase deployment docs and the branch session log.

## Validation
- `git diff --check`
- Python YAML parse for `.github/workflows/supabase-deploy.yml`
- Local Node URL encoder sanity check confirmed `%20` options encoding and no `+` spacing.
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts`

## Reviewer Notes
Review the workflow encoder first, then the retry migration. This PR intentionally does not mutate remote Supabase manually; it relies on PR dry-run and post-merge `dev` deploy.

## Follow-ups
- After merge, confirm the push-triggered dev Supabase deploy applies the retry migration.
- Rerun hosted remote-safe Playwright smoke against `https://fundloop-website.vercel.app`.
