### PR TITLE
Set Supabase deploy target marker before db push

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -209,8 +209,16 @@ jobs:
           esac
 
           cleanup_target_marker() {
+            cleanup_status=$?
+            set +e
             psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
               -c "ALTER DATABASE postgres RESET app.settings.fundloop_target_environment;"
+            cleanup_result=$?
+            set -e
+            if [[ "${cleanup_result}" -ne 0 ]]; then
+              echo "::warning::Failed to reset Supabase deploy target marker after db push."
+            fi
+            return "${cleanup_status}"
           }
           trap cleanup_target_marker EXIT
 

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           version: 2.90.0
 
+      - name: Install PostgreSQL client
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'deploy')
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+
       - name: Resolve Supabase target
         id: target
         shell: bash
@@ -201,6 +207,15 @@ jobs:
               exit 1
               ;;
           esac
+
+          cleanup_target_marker() {
+            psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
+              -c "ALTER DATABASE postgres RESET app.settings.fundloop_target_environment;"
+          }
+          trap cleanup_target_marker EXIT
+
+          psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
+            -c "ALTER DATABASE postgres SET app.settings.fundloop_target_environment = '${TARGET_ENVIRONMENT}';"
 
           encoded_db_url_file="${RUNNER_TEMP}/supabase-db-url"
           DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" OUTPUT_FILE="${encoded_db_url_file}" node <<'NODE'

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-guc.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-guc.md
@@ -3,7 +3,7 @@
 - Timestamp: 2026-08-04T21:08:30Z
 - Agent: Codex
 - Branch: codex/fix-dev-intake-contract-guc
-- Head: 5ec571e
+- Head: 7f2d8b78c70f9d5b5457efa61e18e92a1a141d77
 
 Objective:
 - Repair dev intake-contract activation after PR #103 proved Supabase session pooler/startup parameters still did not reach deploy migration execution.
@@ -31,3 +31,28 @@ Reflections:
 
 Suggested next steps:
 - Validate, open a small repair PR, merge after green checks, confirm dev rows become active, rerun hosted smoke, then clean merged branch residue.
+
+### session v2: deploy-marker review fixes
+
+- Timestamp: 2026-08-04T21:15:24Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-contract-guc
+- Head: 7f2d8b78c70f9d5b5457efa61e18e92a1a141d77
+
+Objective:
+- Address PR #105 review comments before merging the deploy-marker repair.
+
+Actions:
+- Updated the deploy marker cleanup trap so reset failures are warning-only and the original `supabase db push` exit status is preserved.
+- Corrected the session v1 log head from the parent merge commit to the actual implementation commit.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+
+Reflections:
+- Resetting the marker is useful hygiene, but it should not turn an otherwise successful deploy into a false failure.
+
+Suggested next steps:
+- Push the review fix, reply to and resolve review threads, then wait for PR checks.

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-guc.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-contract-guc.md
@@ -1,0 +1,33 @@
+### session v1: database-level deploy target marker
+
+- Timestamp: 2026-08-04T21:08:30Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-contract-guc
+- Head: 5ec571e
+
+Objective:
+- Repair dev intake-contract activation after PR #103 proved Supabase session pooler/startup parameters still did not reach deploy migration execution.
+
+Actions:
+- Confirmed PR #103 merged into `dev` and its push-triggered Supabase deploy succeeded.
+- Confirmed the retry migration ran as `unknown` and no-oped, leaving zero active contract-mode intake rows in dev.
+- Updated the Supabase Deploy workflow to install `psql` for deploy runs and set `app.settings.fundloop_target_environment` as a database-level GUC immediately before `supabase db push`.
+- Added cleanup logic that resets the database-level deploy marker after migration deployment.
+- Added a new forward migration so dev receives another approved deploy-path activation attempt.
+- Updated Supabase deployment docs to treat connection startup options as secondary and database-level GUC as the reliable deploy marker.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- Static grep confirmed the workflow contains database-level `ALTER DATABASE ... SET/RESET` marker handling and the new forward migration is present.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+- PR dry-run is pending.
+- Pending post-merge dev deploy confirmation.
+- Pending hosted remote-safe smoke rerun after the new migration lands on `dev`.
+
+Reflections:
+- PR #103 improved safety and made local replays sane, but the deploy log showed the session marker still arrived as `unknown`.
+- The reliable fix needs a setting visible to the new migration connection, not only startup parameters on the connection string.
+
+Suggested next steps:
+- Validate, open a small repair PR, merge after green checks, confirm dev rows become active, rerun hosted smoke, then clean merged branch residue.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -45,16 +45,19 @@ Pull requests use the same target resolution but run:
 supabase db push --yes --db-url "$SUPABASE_DB_URL" --dry-run
 ```
 
-The workflow appends a Postgres session setting to the migration connection URL and exports the same value through `PGOPTIONS`:
+The workflow sets a Postgres target marker before deploy migrations run:
 
 ```text
+ALTER DATABASE postgres SET app.settings.fundloop_target_environment = dev|main
 options=-c%20app.settings.fundloop_target_environment=dev|main
 PGOPTIONS=-c app.settings.fundloop_target_environment=dev|main
 ```
 
+The database-level setting is the reliable path for Supabase CLI deploy migrations because the session pooler may not propagate startup `options`/`PGOPTIONS` to the migration connection. The workflow resets the database-level marker after `supabase db push` completes. The startup `options` and `PGOPTIONS` values are retained as best-effort secondary paths.
+
 Forward migrations may use this setting for target-aware reference data that must differ between Preview/dev and Production. Migrations must fail safe: missing production configuration must not overwrite existing production values with local or placeholder data. Dev-only smoke fixtures may use deterministic non-production placeholders when the target is `dev` and the migration documents that behavior.
 
-Connection URL `options` values must be percent-encoded with `%20` for spaces. Do not rely on query-string `+` encoding for this parameter; the Supabase CLI migration connection may not propagate the setting to Postgres in that form.
+Connection URL `options` values must be percent-encoded with `%20` for spaces. Do not rely on query-string `+` encoding for this parameter. Also do not rely on connection startup parameters alone for migration-critical behavior through the session pooler.
 
 Workflow helpers must not print rewritten database URLs to logs. If a helper constructs a derived connection string, write it to a temporary file or shell variable, then mask the derived value with `::add-mask::` before passing it to `supabase db push`.
 

--- a/supabase/migrations/20260804211000_apply_dev_intake_contract_reference_data.sql
+++ b/supabase/migrations/20260804211000_apply_dev_intake_contract_reference_data.sql
@@ -1,0 +1,91 @@
+-- Apply dev intake-contract activation after switching deploy target markers
+-- from connection startup parameters to a database-level GUC set by the
+-- approved Supabase Deploy workflow.
+DO $$
+DECLARE
+  target_environment text := COALESCE(NULLIF(current_setting('app.settings.fundloop_target_environment', true), ''), 'unknown');
+BEGIN
+  IF target_environment = 'unknown' THEN
+    RAISE NOTICE 'Skipping dev intake-contract activation for marker-less local replay.';
+    RETURN;
+  END IF;
+
+  IF target_environment NOT IN ('dev', 'main') THEN
+    RAISE EXCEPTION
+      'Unsupported app.settings.fundloop_target_environment for intake activation migration: %',
+      target_environment;
+  END IF;
+
+  IF target_environment = 'main' THEN
+    RAISE NOTICE 'Skipping dev intake-contract activation for main target.';
+    RETURN;
+  END IF;
+
+  WITH configured_intake AS (
+    SELECT
+      chains.id AS chain_id,
+      chains.network_key,
+      'contract'::public.payment_collection_mode AS collection_mode,
+      CASE chains.network_key
+        WHEN 'ethereum' THEN COALESCE(
+          NULLIF(current_setting('app.settings.ethereum_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001E01'
+        )
+        WHEN 'base' THEN COALESCE(
+          NULLIF(current_setting('app.settings.base_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001B01'
+        )
+        WHEN 'celo' THEN COALESCE(
+          NULLIF(current_setting('app.settings.celo_intake_contract', true), ''),
+          '0x0000000000000000000000000000000000001C01'
+        )
+      END AS contract_address,
+      CASE chains.network_key
+        WHEN 'ethereum' THEN COALESCE(
+          NULLIF(current_setting('app.settings.ethereum_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002E01'
+        )
+        WHEN 'base' THEN COALESCE(
+          NULLIF(current_setting('app.settings.base_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002B01'
+        )
+        WHEN 'celo' THEN COALESCE(
+          NULLIF(current_setting('app.settings.celo_treasury_address', true), ''),
+          '0x0000000000000000000000000000000000002C01'
+        )
+      END AS treasury_address,
+      'fundloop-intake-v1'::text AS abi_version
+    FROM public.ref_chains chains
+    WHERE chains.network_key IN ('ethereum', 'base', 'celo')
+  ),
+  valid_intake AS (
+    SELECT *
+    FROM configured_intake
+    WHERE contract_address IS NOT NULL
+      AND treasury_address IS NOT NULL
+      AND contract_address <> '0x0000000000000000000000000000000000000000'
+      AND treasury_address <> '0x0000000000000000000000000000000000000000'
+  )
+  INSERT INTO public.chain_intake_contracts (
+    chain_id,
+    collection_mode,
+    contract_address,
+    treasury_address,
+    abi_version,
+    is_active
+  )
+  SELECT
+    chain_id,
+    collection_mode,
+    contract_address,
+    treasury_address,
+    abi_version,
+    true
+  FROM valid_intake
+  ON CONFLICT (chain_id, collection_mode) DO UPDATE
+  SET
+    contract_address = EXCLUDED.contract_address,
+    treasury_address = EXCLUDED.treasury_address,
+    abi_version = EXCLUDED.abi_version,
+    is_active = EXCLUDED.is_active;
+END $$;


### PR DESCRIPTION
## Summary
- Sets the Supabase deploy target marker as a database-level GUC before deploy-mode `supabase db push`.
- Adds a new forward migration to retry dev-only intake-contract activation after PR #103 proved startup/session markers still arrived as `unknown`.
- Keeps PR dry-runs non-mutating and documents the updated deploy-marker contract.

## Objective
Unblock hosted remote-safe MVP smoke by making target-aware migrations reliably see `app.settings.fundloop_target_environment=dev` during the approved post-merge deploy path.

## Changes
- Installs `postgresql-client` for deploy-mode Supabase workflow runs.
- Runs `ALTER DATABASE postgres SET app.settings.fundloop_target_environment = '<target>'` before deploy migrations and resets it afterward.
- Adds `20260804211000_apply_dev_intake_contract_reference_data.sql`, which no-ops locally, skips main, and activates deterministic non-production intake rows for dev.
- Updates Supabase deployment docs and session log.

## Validation
- `git diff --check`
- Python YAML parse for `.github/workflows/supabase-deploy.yml`
- Static grep confirmed deploy marker handling and the new migration are present.
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts`

## Reviewer Notes
The key change is intentionally limited to deploy mode. PR dry-runs stay non-mutating, so they validate syntax but cannot prove the database-level marker until the PR is merged to `dev`.

## Follow-ups
- After merge, confirm the dev Supabase deploy applies the new migration with `target_environment=dev`.
- Confirm remote dev has active contract-mode intake route candidates.
- Rerun hosted remote-safe Playwright smoke.
