### PR TITLE
Encode Supabase deploy URL before psql marker setup

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -208,23 +208,6 @@ jobs:
               ;;
           esac
 
-          cleanup_target_marker() {
-            cleanup_status=$?
-            set +e
-            psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
-              -c "ALTER DATABASE postgres RESET app.settings.fundloop_target_environment;"
-            cleanup_result=$?
-            set -e
-            if [[ "${cleanup_result}" -ne 0 ]]; then
-              echo "::warning::Failed to reset Supabase deploy target marker after db push."
-            fi
-            return "${cleanup_status}"
-          }
-          trap cleanup_target_marker EXIT
-
-          psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
-            -c "ALTER DATABASE postgres SET app.settings.fundloop_target_environment = '${TARGET_ENVIRONMENT}';"
-
           encoded_db_url_file="${RUNNER_TEMP}/supabase-db-url"
           DB_URL="${supabase_db_url}" TARGET_ENVIRONMENT="${TARGET_ENVIRONMENT}" OUTPUT_FILE="${encoded_db_url_file}" node <<'NODE'
           const { writeFileSync } = require("node:fs")
@@ -244,6 +227,23 @@ jobs:
           NODE
           supabase_db_url="$(cat "${encoded_db_url_file}")"
           echo "::add-mask::${supabase_db_url}"
+
+          cleanup_target_marker() {
+            cleanup_status=$?
+            set +e
+            psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
+              -c "ALTER DATABASE postgres RESET app.settings.fundloop_target_environment;"
+            cleanup_result=$?
+            set -e
+            if [[ "${cleanup_result}" -ne 0 ]]; then
+              echo "::warning::Failed to reset Supabase deploy target marker after db push."
+            fi
+            return "${cleanup_status}"
+          }
+          trap cleanup_target_marker EXIT
+
+          psql "${supabase_db_url}" -v ON_ERROR_STOP=1 \
+            -c "ALTER DATABASE postgres SET app.settings.fundloop_target_environment = '${TARGET_ENVIRONMENT}';"
 
           export PGOPTIONS="-c app.settings.fundloop_target_environment=${TARGET_ENVIRONMENT}"
           supabase db push --yes --db-url "$supabase_db_url"

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -236,7 +236,7 @@ jobs:
             cleanup_result=$?
             set -e
             if [[ "${cleanup_result}" -ne 0 ]]; then
-              echo "::warning::Failed to reset Supabase deploy target marker after db push."
+              echo "::warning::Failed to reset Supabase deploy target marker during deploy step cleanup."
             fi
             return "${cleanup_status}"
           }

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-psql-url-encoding.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-psql-url-encoding.md
@@ -1,0 +1,27 @@
+### session v1: encode psql deploy URL before marker setup
+
+- Timestamp: 2026-08-04T21:21:19Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-psql-url-encoding
+- Head: d524804c24072ba16a07408a3a3dc88cfd3b6171
+
+Objective:
+- Repair the dev Supabase deploy failure after PR #105 exposed that `psql` received the raw session-pooler URL before the workflow URL encoder ran.
+
+Actions:
+- Confirmed PR #105 merged after green CI, Copilot review, Codex review, and resolved review threads.
+- Confirmed the push-triggered dev Supabase deploy failed before `supabase db push`.
+- Read the deploy log and identified `psql` interpreting part of the raw pooler secret as the host because the URL had not yet been encoded/masked.
+- Moved the existing URL encoding and masking block before all `psql` calls so both `ALTER DATABASE ... SET/RESET` and `supabase db push` use the same derived URL.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+- PR dry-run is pending.
+
+Reflections:
+- The deploy marker approach is still the right path, but any helper that touches the database must use the same encoded URL, not just the Supabase CLI call.
+
+Suggested next steps:
+- Validate, open a small repair PR, merge after full review gates, confirm the dev deploy applies the pending intake activation migration, then rerun hosted smoke.

--- a/agent-context/session-log/2026-08-04-codex-fix-dev-intake-psql-url-encoding.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-dev-intake-psql-url-encoding.md
@@ -3,7 +3,7 @@
 - Timestamp: 2026-08-04T21:21:19Z
 - Agent: Codex
 - Branch: codex/fix-dev-intake-psql-url-encoding
-- Head: d524804c24072ba16a07408a3a3dc88cfd3b6171
+- Head: 0eb253ed465dab094088edaaee6b2ec8665e7a91
 
 Objective:
 - Repair the dev Supabase deploy failure after PR #105 exposed that `psql` received the raw session-pooler URL before the workflow URL encoder ran.
@@ -25,3 +25,28 @@ Reflections:
 
 Suggested next steps:
 - Validate, open a small repair PR, merge after full review gates, confirm the dev deploy applies the pending intake activation migration, then rerun hosted smoke.
+
+### session v2: cleanup warning review fix
+
+- Timestamp: 2026-08-04T21:25:08Z
+- Agent: Codex
+- Branch: codex/fix-dev-intake-psql-url-encoding
+- Head: 0eb253ed465dab094088edaaee6b2ec8665e7a91
+
+Objective:
+- Address PR #106 review feedback before merging the psql URL encoding repair.
+
+Actions:
+- Updated the deploy-marker cleanup warning so it is accurate for any deploy-step early-exit path, not only failures after `supabase db push`.
+- Corrected the session v1 log head to the implementation commit.
+
+Validation:
+- `git diff --check` passed.
+- Python YAML parse for `.github/workflows/supabase-deploy.yml` passed.
+- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts` passed.
+
+Reflections:
+- The cleanup trap can run before, during, or after migration deployment; the message should describe cleanup scope rather than a specific phase.
+
+Suggested next steps:
+- Push, reply to and resolve the review thread, then continue CI/review gates.


### PR DESCRIPTION
## Summary
- Moves Supabase deploy URL encoding before all `psql` calls.
- Uses the same masked/derived database URL for target-marker setup, cleanup, and `supabase db push`.
- Records the follow-up deploy repair session.

## Objective
Repair the post-merge dev Supabase deploy failure from PR #105. The deploy failed before migrations because `psql` received the raw session-pooler URL and interpreted part of the secret as the host.

## Changes
- Computes and masks the encoded Supabase DB URL immediately after target selection.
- Runs `ALTER DATABASE ... SET/RESET` using the encoded URL.
- Leaves the pending intake activation migration from PR #105 in place; no additional migration is needed because the failed deploy did not reach `supabase db push`.

## Validation
- `git diff --check`
- Python YAML parse for `.github/workflows/supabase-deploy.yml`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts`

## Reviewer Notes
Review the workflow ordering only: URL encoding/masking must happen before `psql`, not only before `supabase db push`.

## Follow-ups
- After merge, confirm the dev Supabase deploy applies `20260804211000_apply_dev_intake_contract_reference_data.sql`.
- Verify active contract-mode intake route candidates in dev.
- Rerun hosted remote-safe smoke.
