### PR TITLE
Harden remote-safe payment smoke fixtures

### DIFF
--- a/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-fixture-ids.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-fixture-ids.md
@@ -1,0 +1,31 @@
+### session v1: Remote smoke fixture explicit IDs
+
+- Timestamp: 2026-08-04T21:55:33Z
+- Agent: Codex
+- Branch: codex/fix-remote-smoke-fixture-ids
+- Head: 5ca3051291248657cbb9d9ef8b7b6211459ae436
+
+#### Objective
+
+Repair the hosted remote-safe Playwright smoke after the dev Supabase deploy succeeded but fixture setup failed on a duplicate `organizations_pkey` caused by stale remote identity sequences.
+
+#### Actions Taken
+
+- Added a high-range deterministic fixture ID allocator derived from each Playwright run id.
+- Updated the remote-safe project payments fixture to assign explicit IDs for organizations, projects, project payment methods, payments, and onchain submissions.
+- Kept fixture cleanup scoped to the created project/user resources so repeated hosted smoke runs remain safe.
+- Added a forward, idempotent repair migration for `payment_methods.sort_order` after hosted smoke exposed Preview/dev schema drift against the app's project payment route ordering contract.
+
+#### Validation Notes
+
+- Pending: focused local test validation.
+- Pending: PR checks.
+- Pending: dev Supabase deploy and hosted remote-safe smoke rerun after merge.
+
+#### Reflections
+
+- Remote smoke fixtures should not depend on shared database sequences being perfectly aligned, especially after repeated seeded or partial fixture runs in Preview/dev.
+
+#### Suggested Next Steps
+
+- Open the fixture repair as a separate PR, merge after normal review gates, then rerun the hosted smoke against `https://fundloop-website.vercel.app`.

--- a/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-fixture-ids.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-fixture-ids.md
@@ -3,7 +3,7 @@
 - Timestamp: 2026-08-04T21:55:33Z
 - Agent: Codex
 - Branch: codex/fix-remote-smoke-fixture-ids
-- Head: 5ca3051291248657cbb9d9ef8b7b6211459ae436
+- Head: 488ab290884c4fff6ff403a923dad85f90d641f7
 
 #### Objective
 
@@ -15,10 +15,13 @@ Repair the hosted remote-safe Playwright smoke after the dev Supabase deploy suc
 - Updated the remote-safe project payments fixture to assign explicit IDs for organizations, projects, project payment methods, payments, and onchain submissions.
 - Kept fixture cleanup scoped to the created project/user resources so repeated hosted smoke runs remain safe.
 - Added a forward, idempotent repair migration for `payment_methods.sort_order` after hosted smoke exposed Preview/dev schema drift against the app's project payment route ordering contract.
+- Updated the repair migration after review to backfill missing route order values and advance stale identity sequences for payment smoke/setup tables.
+- Removed the remaining fixture assumption that PostgREST returns inserted payment rows in the same order as the request payload.
 
 #### Validation Notes
 
-- Pending: focused local test validation.
+- Passed: `git diff --check`.
+- Passed: `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts tests/project-crypto-routes.test.ts`.
 - Pending: PR checks.
 - Pending: dev Supabase deploy and hosted remote-safe smoke rerun after merge.
 

--- a/supabase/migrations/20260804215600_repair_payment_methods_sort_order.sql
+++ b/supabase/migrations/20260804215600_repair_payment_methods_sort_order.sql
@@ -1,0 +1,8 @@
+-- Repair Preview/dev databases that missed the project payment route ordering
+-- column even though the app now treats it as part of the payment_methods
+-- contract. This is intentionally idempotent for already-correct targets.
+ALTER TABLE public.payment_methods
+  ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_payment_methods_project_sort_order
+ON public.payment_methods (project_id, sort_order);

--- a/supabase/migrations/20260804215600_repair_payment_methods_sort_order.sql
+++ b/supabase/migrations/20260804215600_repair_payment_methods_sort_order.sql
@@ -4,5 +4,57 @@
 ALTER TABLE public.payment_methods
   ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 0;
 
+WITH ranked_methods AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY project_id
+      ORDER BY
+        COALESCE(is_default, false) DESC,
+        id ASC
+    ) AS next_sort_order
+  FROM public.payment_methods
+)
+UPDATE public.payment_methods AS payment_methods
+SET sort_order = ranked_methods.next_sort_order
+FROM ranked_methods
+WHERE ranked_methods.id = payment_methods.id
+  AND payment_methods.sort_order = 0;
+
 CREATE INDEX IF NOT EXISTS idx_payment_methods_project_sort_order
 ON public.payment_methods (project_id, sort_order);
+
+DO $$
+DECLARE
+  identity_column record;
+  next_identity_value bigint;
+  sequence_name text;
+BEGIN
+  FOR identity_column IN
+    SELECT *
+    FROM (
+      VALUES
+        ('public.organizations', 'id'),
+        ('public.projects', 'id'),
+        ('public.payment_methods', 'id'),
+        ('public.payments', 'id'),
+        ('public.onchain_payment_submissions', 'id')
+    ) AS identity_columns(table_name, column_name)
+  LOOP
+    sequence_name := pg_get_serial_sequence(identity_column.table_name, identity_column.column_name);
+
+    IF sequence_name IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    EXECUTE format(
+      'SELECT COALESCE(MAX(%I), 0) + 1 FROM %s',
+      identity_column.column_name,
+      identity_column.table_name
+    )
+    INTO next_identity_value;
+
+    EXECUTE 'SELECT setval($1::regclass, $2, false)'
+    USING sequence_name, GREATEST(next_identity_value, 1);
+  END LOOP;
+END $$;

--- a/tests/e2e/support/supabase-fixtures.ts
+++ b/tests/e2e/support/supabase-fixtures.ts
@@ -89,6 +89,12 @@ function uniqueHexHash(seed: string) {
   return `0x${createHash("sha256").update(seed).digest("hex")}`
 }
 
+function buildFixtureIdBase(runId: string) {
+  const hash = createHash("sha256").update(runId).digest().readUInt32BE(0)
+
+  return 1_900_000_000 + (hash % 100_000_000)
+}
+
 async function ensureNoError<T>(promise: PromiseLike<{ data: T | null; error: { message: string } | null }>, message: string) {
   const { data, error } = await promise
 
@@ -216,11 +222,12 @@ async function loadReferenceData(supabase: SupabaseClient<Database>): Promise<Re
   }
 }
 
-function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: PaymentStatusRefs) {
+function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: PaymentStatusRefs, paymentIdBase: number) {
   return [
     {
       key: "draftId",
       row: {
+        id: paymentIdBase,
         project_id: projectId,
         period_start: "2026-01-01",
         period_end: "2026-01-31",
@@ -235,6 +242,7 @@ function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: Pa
     {
       key: "pendingId",
       row: {
+        id: paymentIdBase + 1,
         project_id: projectId,
         period_start: "2026-02-01",
         period_end: "2026-02-28",
@@ -249,6 +257,7 @@ function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: Pa
     {
       key: "awaitingConfirmingId",
       row: {
+        id: paymentIdBase + 2,
         project_id: projectId,
         period_start: "2026-03-01",
         period_end: "2026-03-31",
@@ -263,6 +272,7 @@ function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: Pa
     {
       key: "awaitingSubmittedId",
       row: {
+        id: paymentIdBase + 3,
         project_id: projectId,
         period_start: "2026-04-01",
         period_end: "2026-04-30",
@@ -277,6 +287,7 @@ function buildPaymentSeed(projectId: number, routeMethodId: number, statuses: Pa
     {
       key: "failedId",
       row: {
+        id: paymentIdBase + 4,
         project_id: projectId,
         period_start: "2026-05-01",
         period_end: "2026-05-31",
@@ -296,8 +307,9 @@ async function createScenarioPayments(
   projectId: number,
   routeMethodId: number,
   statuses: PaymentStatusRefs,
+  paymentIdBase: number,
 ) {
-  const seed = buildPaymentSeed(projectId, routeMethodId, statuses)
+  const seed = buildPaymentSeed(projectId, routeMethodId, statuses, paymentIdBase)
   const inserted = await ensureNoError(
     supabase
       .from("payments")
@@ -316,6 +328,7 @@ async function createScenarioPayments(
 }
 
 function buildOnchainSubmissionRow(input: {
+  id: number
   route: RouteCandidate
   paymentId: number
   projectId: number
@@ -331,6 +344,7 @@ function buildOnchainSubmissionRow(input: {
   failureReason?: string
 }) {
   return {
+    id: input.id,
     payment_id: input.paymentId,
     project_id: input.projectId,
     payment_method_id: input.paymentMethodId,
@@ -366,6 +380,7 @@ export async function createProjectPaymentsFixture(
   const refs = await loadReferenceData(supabase)
   const [primaryRoute, secondaryRoute] = refs.routeCandidates
   const runId = buildRunId(input.scenario)
+  const idBase = buildFixtureIdBase(runId)
   const email = `${runId}@fundloop-e2e.test`
   const password = `FundLoop!${randomUUID().replace(/-/g, "").slice(0, 12)}`
   const user = await supabase.auth.admin.createUser({
@@ -402,6 +417,7 @@ export async function createProjectPaymentsFixture(
     supabase
       .from("organizations")
       .insert({
+        id: idBase + 1,
         name: `Playwright Org ${runId}`,
         description: "Generated for remote-safe Playwright coverage.",
         website: `https://${runId}.example.test`,
@@ -427,6 +443,7 @@ export async function createProjectPaymentsFixture(
     supabase
       .from("projects")
       .insert({
+        id: idBase + 2,
         name: `Playwright Project ${runId}`,
         slug: projectSlug,
         description: "Generated for wallet and payments Playwright coverage.",
@@ -459,6 +476,7 @@ export async function createProjectPaymentsFixture(
       .from("payment_methods")
       .insert([
         {
+          id: idBase + 10,
           project_id: project.id,
           method_id: refs.cryptoContractMethodId,
           collection_mode: "contract",
@@ -472,6 +490,7 @@ export async function createProjectPaymentsFixture(
           details: { source: "playwright_fixture" } satisfies Json,
         },
         {
+          id: idBase + 11,
           project_id: project.id,
           method_id: refs.cryptoContractMethodId,
           collection_mode: "contract",
@@ -490,12 +509,19 @@ export async function createProjectPaymentsFixture(
     "Could not create the e2e crypto routes.",
   )
 
-  const payments = await createScenarioPayments(supabase, project.id, refs.cryptoContractMethodId, refs.paymentStatuses)
+  const payments = await createScenarioPayments(
+    supabase,
+    project.id,
+    refs.cryptoContractMethodId,
+    refs.paymentStatuses,
+    idBase + 20,
+  )
   const walletAddress = uniqueHexHash(`${runId}-wallet`).slice(0, 42)
 
   await ensureMutation(
     supabase.from("onchain_payment_submissions").insert([
       buildOnchainSubmissionRow({
+        id: idBase + 30,
         route: primaryRoute,
         paymentId: payments.awaitingConfirmingId,
         projectId: project.id,
@@ -509,6 +535,7 @@ export async function createProjectPaymentsFixture(
         confirmationCount: 3,
       }),
       buildOnchainSubmissionRow({
+        id: idBase + 31,
         route: primaryRoute,
         paymentId: payments.awaitingSubmittedId,
         projectId: project.id,
@@ -522,6 +549,7 @@ export async function createProjectPaymentsFixture(
         confirmationCount: 0,
       }),
       buildOnchainSubmissionRow({
+        id: idBase + 32,
         route: secondaryRoute,
         paymentId: payments.failedId,
         projectId: project.id,

--- a/tests/e2e/support/supabase-fixtures.ts
+++ b/tests/e2e/support/supabase-fixtures.ts
@@ -310,20 +310,19 @@ async function createScenarioPayments(
   paymentIdBase: number,
 ) {
   const seed = buildPaymentSeed(projectId, routeMethodId, statuses, paymentIdBase)
-  const inserted = await ensureNoError(
+  await ensureMutation(
     supabase
       .from("payments")
-      .insert(seed.map((entry) => entry.row))
-      .select("id"),
+      .insert(seed.map((entry) => entry.row)),
     "Could not insert e2e payments.",
   )
 
   return {
-    draftId: inserted[0].id,
-    pendingId: inserted[1].id,
-    awaitingConfirmingId: inserted[2].id,
-    awaitingSubmittedId: inserted[3].id,
-    failedId: inserted[4].id,
+    draftId: paymentIdBase,
+    pendingId: paymentIdBase + 1,
+    awaitingConfirmingId: paymentIdBase + 2,
+    awaitingSubmittedId: paymentIdBase + 3,
+    failedId: paymentIdBase + 4,
   }
 }
 


### PR DESCRIPTION
## Summary
- assigns explicit high-range IDs for remote-safe payment smoke fixture rows so stale remote sequences do not collide
- adds an idempotent forward migration to restore `payment_methods.sort_order` where Preview/dev schema drift missed it
- records the smoke/schema repair in the branch session log

## Validation
- `git diff --check`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts tests/project-crypto-routes.test.ts`

## Follow-up after merge
- confirm dev Supabase Deploy applies `20260804215600_repair_payment_methods_sort_order.sql`
- rerun hosted remote-safe MVP smoke against https://fundloop-website.vercel.app
