### PR TITLE
Reload Supabase REST schema cache for smoke repair

### DIFF
--- a/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-schema-cache.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-remote-smoke-schema-cache.md
@@ -1,0 +1,30 @@
+### session v1: Remote smoke schema cache reload
+
+- Timestamp: 2026-08-04T22:13:04Z
+- Agent: Codex
+- Branch: codex/fix-remote-smoke-schema-cache
+- Head: b166953f0671035fb86898da1022cd17cca6ced2
+
+#### Objective
+
+Repair the hosted remote-safe smoke after the dev database migration restored `payment_methods.sort_order`, but Supabase/PostgREST continued rejecting the column through the REST API because its schema cache had not refreshed.
+
+#### Actions Taken
+
+- Added a tiny forward migration that sends `NOTIFY pgrst, 'reload schema'`.
+- Kept the repair on the approved Supabase deploy path instead of manually mutating the remote database.
+
+#### Validation Notes
+
+- Passed: `git diff --check`.
+- Passed: `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts`.
+- Pending: PR Supabase dry-run.
+- Pending: dev Supabase deploy and hosted remote-safe smoke rerun after merge.
+
+#### Reflections
+
+- For remote schema repairs that immediately need to be exercised through Supabase REST/PostgREST, include an explicit schema-cache reload notification.
+
+#### Suggested Next Steps
+
+- Merge through normal review gates, confirm the dev deploy applies this migration, then rerun the hosted remote-safe smoke.

--- a/supabase/migrations/20260804221300_reload_postgrest_schema_cache.sql
+++ b/supabase/migrations/20260804221300_reload_postgrest_schema_cache.sql
@@ -1,0 +1,4 @@
+-- Force Supabase/PostgREST to refresh its schema cache after the remote
+-- payment_methods.sort_order repair migration. Without this notification,
+-- REST inserts can still reject the repaired column until the cache expires.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- adds a forward migration that sends `NOTIFY pgrst, 'reload schema'`
- keeps the schema-cache repair on the approved Supabase deploy path
- records the repair in the branch session log

## Validation
- `git diff --check`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm test -- tests/e2e-env.test.ts`

## Follow-up after merge
- confirm dev Supabase Deploy applies `20260804221300_reload_postgrest_schema_cache.sql`
- rerun hosted remote-safe MVP smoke against https://fundloop-website.vercel.app
