### PR TITLE
Enable hosted dev E2E login gate

### DIFF
--- a/agent-context/session-log/2026-08-04-codex-fix-hosted-e2e-env-gate.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-hosted-e2e-env-gate.md
@@ -3,7 +3,7 @@
 - Timestamp: 2026-08-04T22:30:12Z
 - Agent: Codex
 - Branch: codex/fix-hosted-e2e-env-gate
-- Head: 0959bf95943c75b9fef8def9b1871eb6f9d5bf1c
+- Head: d590431bea23529d28ae8003b85141f728933910
 
 #### Objective
 
@@ -15,6 +15,8 @@ Repair the hosted remote-safe smoke after deploy and schema-cache repairs succee
 - Preserved the production safety boundary by keeping the endpoint disabled when `FUNDLOOP_DEPLOYMENT_ENV=production`.
 - Removed the remaining remote fixture dependency on ordered mutation-return rows for `payment_methods`; the fixture now uses its explicit IDs directly.
 - Added config test coverage for the hosted Preview/dev gate.
+- Updated the gate after review to fail closed for unknown deployment env values such as `main` or `prod`.
+- Reused named fixture payment method ID constants in both insert payloads and later references.
 
 #### Validation Notes
 

--- a/agent-context/session-log/2026-08-04-codex-fix-hosted-e2e-env-gate.md
+++ b/agent-context/session-log/2026-08-04-codex-fix-hosted-e2e-env-gate.md
@@ -1,0 +1,32 @@
+### session v1: Hosted E2E auth gate and fixture return cleanup
+
+- Timestamp: 2026-08-04T22:30:12Z
+- Agent: Codex
+- Branch: codex/fix-hosted-e2e-env-gate
+- Head: 0959bf95943c75b9fef8def9b1871eb6f9d5bf1c
+
+#### Objective
+
+Repair the hosted remote-safe smoke after deploy and schema-cache repairs succeeded, but the test login endpoint returned 404 on the canonical non-production Vercel app.
+
+#### Actions Taken
+
+- Updated `isE2EAuthEnabled()` so hosted Preview/dev deployments can enable the E2E login endpoint with `FUNDLOOP_DEPLOYMENT_ENV=dev` even though Vercel runs the app with `NODE_ENV=production`.
+- Preserved the production safety boundary by keeping the endpoint disabled when `FUNDLOOP_DEPLOYMENT_ENV=production`.
+- Removed the remaining remote fixture dependency on ordered mutation-return rows for `payment_methods`; the fixture now uses its explicit IDs directly.
+- Added config test coverage for the hosted Preview/dev gate.
+
+#### Validation Notes
+
+- Passed: `git diff --check`.
+- Passed: `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/e2e-config.test.ts --pool=forks`.
+- Pending: hosted remote-safe smoke after the Vercel preview/deploy includes this gate fix.
+- Pending: PR checks and post-merge dev validation.
+
+#### Reflections
+
+- Runtime `NODE_ENV` is not a deployment-environment signal on Vercel. Safety gates that differ between Preview/dev and Production should use `FUNDLOOP_DEPLOYMENT_ENV`.
+
+#### Suggested Next Steps
+
+- Merge through normal review gates, confirm the Vercel dev deployment includes the gate change, then rerun the hosted remote-safe smoke.

--- a/lib/e2e/config.ts
+++ b/lib/e2e/config.ts
@@ -3,14 +3,16 @@ import "server-only"
 export const FUNDLOOP_E2E_ENABLED_ENV = "FUNDLOOP_E2E_ENABLED"
 export const FUNDLOOP_E2E_SECRET_ENV = "FUNDLOOP_E2E_SECRET"
 
+const E2E_ENABLED_DEPLOYMENT_ENVIRONMENTS = new Set(["dev", "development", "local", "preview", "staging", "test"])
+
 export function isE2EAuthEnabled(env: NodeJS.ProcessEnv = process.env) {
   const deploymentEnvironment = env.FUNDLOOP_DEPLOYMENT_ENV?.trim().toLowerCase()
-  const isProductionDeployment =
+  const isAllowedDeployment =
     deploymentEnvironment && deploymentEnvironment.length > 0
-      ? deploymentEnvironment === "production"
-      : env.NODE_ENV === "production"
+      ? E2E_ENABLED_DEPLOYMENT_ENVIRONMENTS.has(deploymentEnvironment)
+      : env.NODE_ENV !== "production"
 
-  return env[FUNDLOOP_E2E_ENABLED_ENV]?.trim() === "true" && !isProductionDeployment
+  return env[FUNDLOOP_E2E_ENABLED_ENV]?.trim() === "true" && Boolean(isAllowedDeployment)
 }
 
 export function getConfiguredE2ESecret(env: NodeJS.ProcessEnv = process.env) {

--- a/lib/e2e/config.ts
+++ b/lib/e2e/config.ts
@@ -4,7 +4,13 @@ export const FUNDLOOP_E2E_ENABLED_ENV = "FUNDLOOP_E2E_ENABLED"
 export const FUNDLOOP_E2E_SECRET_ENV = "FUNDLOOP_E2E_SECRET"
 
 export function isE2EAuthEnabled(env: NodeJS.ProcessEnv = process.env) {
-  return env[FUNDLOOP_E2E_ENABLED_ENV]?.trim() === "true" && env.NODE_ENV !== "production"
+  const deploymentEnvironment = env.FUNDLOOP_DEPLOYMENT_ENV?.trim().toLowerCase()
+  const isProductionDeployment =
+    deploymentEnvironment && deploymentEnvironment.length > 0
+      ? deploymentEnvironment === "production"
+      : env.NODE_ENV === "production"
+
+  return env[FUNDLOOP_E2E_ENABLED_ENV]?.trim() === "true" && !isProductionDeployment
 }
 
 export function getConfiguredE2ESecret(env: NodeJS.ProcessEnv = process.env) {

--- a/tests/e2e-config.test.ts
+++ b/tests/e2e-config.test.ts
@@ -28,6 +28,20 @@ describe("e2e config helpers", () => {
         NODE_ENV: "production",
       }),
     ).toBe(false)
+    expect(
+      isE2EAuthEnabled({
+        FUNDLOOP_DEPLOYMENT_ENV: "main",
+        FUNDLOOP_E2E_ENABLED: "true",
+        NODE_ENV: "production",
+      }),
+    ).toBe(false)
+    expect(
+      isE2EAuthEnabled({
+        FUNDLOOP_DEPLOYMENT_ENV: "prod",
+        FUNDLOOP_E2E_ENABLED: "true",
+        NODE_ENV: "production",
+      }),
+    ).toBe(false)
     expect(isE2EAuthEnabled({ FUNDLOOP_E2E_ENABLED: "true", NODE_ENV: "production" })).toBe(false)
     expect(isE2EAuthEnabled({ FUNDLOOP_E2E_ENABLED: "false", NODE_ENV: "development" })).toBe(false)
   })

--- a/tests/e2e-config.test.ts
+++ b/tests/e2e-config.test.ts
@@ -12,8 +12,22 @@ function buildRequest(secret: string | null) {
 }
 
 describe("e2e config helpers", () => {
-  it("enables the e2e auth bootstrap only outside production when explicitly flagged", () => {
+  it("enables the e2e auth bootstrap only outside production deployments when explicitly flagged", () => {
     expect(isE2EAuthEnabled({ FUNDLOOP_E2E_ENABLED: "true", NODE_ENV: "development" })).toBe(true)
+    expect(
+      isE2EAuthEnabled({
+        FUNDLOOP_DEPLOYMENT_ENV: "dev",
+        FUNDLOOP_E2E_ENABLED: "true",
+        NODE_ENV: "production",
+      }),
+    ).toBe(true)
+    expect(
+      isE2EAuthEnabled({
+        FUNDLOOP_DEPLOYMENT_ENV: "production",
+        FUNDLOOP_E2E_ENABLED: "true",
+        NODE_ENV: "production",
+      }),
+    ).toBe(false)
     expect(isE2EAuthEnabled({ FUNDLOOP_E2E_ENABLED: "true", NODE_ENV: "production" })).toBe(false)
     expect(isE2EAuthEnabled({ FUNDLOOP_E2E_ENABLED: "false", NODE_ENV: "development" })).toBe(false)
   })

--- a/tests/e2e/support/supabase-fixtures.ts
+++ b/tests/e2e/support/supabase-fixtures.ts
@@ -470,7 +470,7 @@ export async function createProjectPaymentsFixture(
     "Could not create the e2e project participant.",
   )
 
-  const paymentMethods = await ensureNoError(
+  await ensureMutation(
     supabase
       .from("payment_methods")
       .insert([
@@ -502,11 +502,10 @@ export async function createProjectPaymentsFixture(
           sort_order: 2,
           details: { source: "playwright_fixture" } satisfies Json,
         },
-      ])
-      .select("id")
-      .order("sort_order"),
+      ]),
     "Could not create the e2e crypto routes.",
   )
+  const paymentMethods = [{ id: idBase + 10 }, { id: idBase + 11 }]
 
   const payments = await createScenarioPayments(
     supabase,

--- a/tests/e2e/support/supabase-fixtures.ts
+++ b/tests/e2e/support/supabase-fixtures.ts
@@ -470,12 +470,15 @@ export async function createProjectPaymentsFixture(
     "Could not create the e2e project participant.",
   )
 
+  const primaryPaymentMethodId = idBase + 10
+  const secondaryPaymentMethodId = idBase + 11
+
   await ensureMutation(
     supabase
       .from("payment_methods")
       .insert([
         {
-          id: idBase + 10,
+          id: primaryPaymentMethodId,
           project_id: project.id,
           method_id: refs.cryptoContractMethodId,
           collection_mode: "contract",
@@ -489,7 +492,7 @@ export async function createProjectPaymentsFixture(
           details: { source: "playwright_fixture" } satisfies Json,
         },
         {
-          id: idBase + 11,
+          id: secondaryPaymentMethodId,
           project_id: project.id,
           method_id: refs.cryptoContractMethodId,
           collection_mode: "contract",
@@ -505,7 +508,7 @@ export async function createProjectPaymentsFixture(
       ]),
     "Could not create the e2e crypto routes.",
   )
-  const paymentMethods = [{ id: idBase + 10 }, { id: idBase + 11 }]
+  const paymentMethods = [{ id: primaryPaymentMethodId }, { id: secondaryPaymentMethodId }]
 
   const payments = await createScenarioPayments(
     supabase,


### PR DESCRIPTION
## Summary
- allows the internal E2E login endpoint on hosted Preview/dev by using `FUNDLOOP_DEPLOYMENT_ENV` instead of `NODE_ENV` as the production boundary
- keeps the endpoint disabled for `FUNDLOOP_DEPLOYMENT_ENV=production`
- removes the remaining payment-method fixture dependency on ordered mutation-return rows

## Validation
- `git diff --check`
- `pnpm dlx node@22.22.1 /opt/homebrew/bin/pnpm exec vitest run tests/e2e-config.test.ts --pool=forks`

## Follow-up after merge
- confirm Vercel dev deploy includes this gate fix
- rerun hosted remote-safe MVP smoke against https://fundloop-website.vercel.app
