### PR TITLE
[codex] Define capped Cubid redistribution architecture (#134)

### DIFF
--- a/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
@@ -648,8 +648,9 @@ Goal invariants:
 - equal theoretical funded project share per eligible user;
 - initial project claim equals theoretical share multiplied by locked Cubid score
   divided by the versioned locked maximum score;
-- baseline is the largest single-project score-adjusted initial claim and final
-  allocation is capped at `3 ×` baseline;
+- baseline is the largest single-project score-adjusted initial claim; exact cap is
+  `3 ×` baseline and the canonical retained/final cap is that value floored to the
+  allocation minor unit;
 - before redistribution, aggregate initial is clamped to cap; if aggregate exceeds
   cap, every project/source initial lot is scaled by `cap / aggregate`, retained
   proportionally, and its exact difference becomes source-linked overlap overflow;
@@ -657,6 +658,9 @@ Goal invariants:
   clamped current totals are raised lowest-first through stable deterministic
   water-filling;
 - capped users and zero-baseline users receive no top-up;
+- cap-aware residual assignment skips any user/source whose next unit would cross
+  cap and keeps rejected exact fractions or minor units source-linked in the global
+  pool or returned/carryover residue;
 - top-ups and returned/carryover residue retain project, rail, asset, native, FX,
   and functional-USD provenance; and
 - redistribution is funded principal, not fee, revenue, treasury sweep, payable,
@@ -717,11 +721,12 @@ Scope:
 - calculate `initial claim = theoretical share × locked score / locked max score`
   and create source-linked score-discount shortfall lots;
 - aggregate user initial claims, define baseline as the largest single-project
-  initial claim, set cap to `3 ×` baseline, and clamp aggregate initial before
-  redistribution;
+  initial claim, set exact cap to `3 ×` baseline, floor it to the allocation minor
+  unit as the canonical cap, and clamp aggregate initial before redistribution;
 - when aggregate exceeds cap, apply one exact `cap / aggregate` factor to every
   project/source initial lot and move each difference into the pool as overlap-cap
-  overflow; start water-filling from `min(aggregate, cap)`;
+  overflow; start water-filling from the canonical retained target, namely floored
+  `min(aggregate, exact cap)` bounded by the floored minor-unit cap;
 - define the global pool as score-discount shortfalls plus overlap-cap overflow;
   capped and zero-baseline users receive no top-up;
 - use aggregate initial claim, baseline, then stable user ID for ties and assign
@@ -729,6 +734,9 @@ Scope:
 - apply cap scaling in exact decimals, allocate retained source residuals by
   fractional remainder then stable project/rail/asset/source-lot key, and derive
   each overflow lot as original minus retained so native and USD units conserve;
+  never let retained-lot or final-award rounding cross the floored cap, skip capped
+  residual candidates, and keep rejected fractions/units source-linked in the
+  pool or returned/carryover residue;
 - preserve project/rail/asset/native/FX/USD provenance for initial claims, top-ups,
   returned residue, and payout eligibility;
 - deterministic rerun and material-change comparison.
@@ -747,6 +755,13 @@ Validation:
 - four-project overlap fixture `[100,100,100,100]`: aggregate `$400`, baseline
   `$100`, cap `$300`, four retained `$75` source lots, four `$25` overflow lots,
   then water-fill only uncapped users; and
+- fractional cap fixture: four `$0.335` lots yield aggregate `$1.34`, baseline
+  `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, and four `$0.25`
+  retained lots; `$0.335` proportional overflow plus the cap-rejected `$0.005`
+  exact remainder stays source-linked as `$0.34` pool/residue and the user never
+  receives `$1.01`; and
+- arbitrary-overlap cap-aware randomized properties conserve exact decimals and
+  integer minor units independently, with no lost/double-assigned unit; and
 - old point-proportional results are explicitly superseded and intentional
   differences documented.
 

--- a/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
@@ -1,6 +1,7 @@
 # Preliminary issue tree: settlement-backed epoch treasury and auditable payouts
 
 Status: published and vetted; implementation proceeds through native blockers
+Last updated: 2026-08-09
 Repository: `FundLoop/fundloop-website`
 Project: [FundLoop Project](https://github.com/orgs/FundLoop/projects/1)
 Proposed priority: High
@@ -638,14 +639,31 @@ Depends on: Goal 2
 
 ### Objective
 
-Execute monthly valuation, fees, carryover, locking, deterministic allocation, and
-user-liability posting entirely from reconciled custody-backed inputs.
+Execute monthly valuation, fees, carryover, locking, deterministic Cubid-score
+discounting, global low-earner redistribution, and provisional award posting
+entirely from reconciled custody-backed inputs.
+
+Goal invariants:
+
+- equal theoretical funded project share per eligible user;
+- initial project claim equals theoretical share multiplied by locked Cubid score
+  divided by the versioned locked maximum score;
+- every shortfall enters one global epoch redistribution pool;
+- aggregate initial claims are raised lowest-current-total first through stable
+  deterministic water-filling;
+- baseline is the largest single-project score-adjusted initial claim and final
+  allocation is capped at `3 ×` baseline;
+- top-ups and returned/carryover residue retain project, rail, asset, native, FX,
+  and functional-USD provenance; and
+- redistribution is funded principal, not fee, revenue, treasury sweep, payable,
+  or production value flow.
 
 ### Task 3.1: Implement monthly FX, fee, expiry, and carryover accounting
 
 Expected surfaces:
 
-- FX observation/snapshot, fee assessment, expiry, and carryover migrations;
+- FX observation/snapshot, fee assessment, expiry, carryover, and
+  redistribution-source migrations;
 - `lib/monthly-cycles/`, `lib/accounting/`, scheduled Edge Functions, and operator
   review UI;
 - monthly valuation, fee journal, expiry, carryover, and variance tests.
@@ -658,7 +676,11 @@ Scope:
 - 1% default project fees with rail clamps, 2.5% base fee per rail, and treasury
   sweeps;
 - three-month expiry, reserved-claim protection, old-epoch harvest, and inventory
-  exchange for queued payouts.
+  exchange for queued payouts;
+- preserve every post-fee distributable source by project, rail, asset, native
+  quantity, FX snapshot, and functional USD; and
+- keep redistribution-pool principal and cap-exhausted residue source-linked and
+  outside fee, revenue, and payable classifications.
 
 Validation:
 
@@ -667,8 +689,8 @@ Validation:
 - depeg, missing-source, manual-rate, FX gain/loss, expiry, and conservation tests;
 - prior epoch closes only after successful harvest.
 
-Stop condition: fee-processed and carryover-complete assets are provably backed and
-ready to lock.
+Stop condition: fee-processed and carryover-complete assets are provably backed,
+provenance-complete, and ready to lock without calculating claims or moving value.
 
 ### Task 3.2: Lock settled pools and allocate by verified uniqueness
 
@@ -686,17 +708,30 @@ Scope:
 - lock only funding applications and journal-backed available epoch balances;
 - eliminate declared contribution amount as canonical pool input;
 - include approved project packages, fixed FX, fees, carryover, Cubid whitelist, and
-  uniqueness scores in the manifest;
-- proportional uniqueness weighting within existing project/source rules;
-- preserve rail/asset/project provenance and payout eligibility;
+  locked score/max evidence in the manifest;
+- divide each funded project pool equally across eligible users;
+- calculate `initial claim = theoretical share × locked score / locked max score`
+  and send the shortfall into one global epoch pool;
+- aggregate user initial claims, define baseline as the largest single-project
+  initial claim, and water-fill lowest current totals first under the `3 ×` cap;
+- use aggregate initial claim, baseline, then stable user ID for ties and assign
+  minor-unit rounding deterministically;
+- preserve project/rail/asset/native/FX/USD provenance for initial claims, top-ups,
+  returned residue, and payout eligibility;
 - deterministic rerun and material-change comparison.
 
 Validation:
 
 - no-receipt/no-allocation invariant;
-- asset/native/USD conservation and source attribution;
+- invalid score/max, cap, asset/native/USD conservation, privacy, and source
+  attribution;
 - repeat run equivalence;
-- old and new fixture comparison with intentional differences documented.
+- canonical A+B fixture: A `$300`, `5/10/15` of `20` gives `$25/$50/$75`
+  initial and `$150` pool; B `$1,000`, 100 users averaging `10/20` gives `$500`
+  initial and `$500` pool; because the three A users also use B, the combined
+  `$650` goes first to the 97 B-only lowest earners; and
+- old point-proportional results are explicitly superseded and intentional
+  differences documented.
 
 Stop condition: reviewed allocation is reproducible but payouts remain closed.
 
@@ -714,23 +749,33 @@ Expected surfaces:
 Scope:
 
 - one admin approves exact lock/result hashes;
-- post approved user award records and asset eligibility from approved results,
+- post approved provisional award-control records and asset eligibility from
+  approved results,
   without recognizing user ownership before payout is processed;
-- publish exact approved project totals/counts without user identifiers;
-- generate trial balance, custody, project funds, user payable, fee, FX, carryover,
-  allocation, provisional award, and exception artifacts under one root hash;
+- publish exact approved project totals/counts without user identifiers or
+  cross-project membership inference;
+- persist theoretical shares, score/max, initial claims, pool contributions,
+  top-ups, caps, final allocations, and source-linked residue;
+- generate trial balance, custody, project funds, fee, FX, carryover, initial claim,
+  redistribution pool, top-up, returned-residue, provisional award, and exception
+  artifacts under one root hash, without payable classification;
 - align payout thresholds and verify inventory/routes/paymaster before opening.
 
 Validation:
 
 - award-control balances equal approved allocations without creating user-owned
   liabilities before payout processing;
+- initial claims plus top-ups plus returned residue reconcile to funded sources and
+  pool contributions equal top-ups plus residue;
 - report totals reconcile to journal and artifacts reproduce;
 - role-scoped privacy tests;
 - payout window cannot open before every hard gate passes.
 
 Stop condition: the epoch is `payout_readying` or `payout_open` with a valid close
 package and no external payout yet required.
+
+Production allocation, award posting, provider calls, and real value flow remain
+fail-closed throughout Goal 3.
 
 ## Goal 4: Execute auditable multi-rail payouts
 

--- a/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
@@ -618,7 +618,8 @@ Scope:
 - frozen post-cutoff package and only approve/opt-out actions;
 - accepted-delivery-relative deadline and silence-as-approval;
 - project KYB/KYC/sanctions gates;
-- valid/whitelisted Cubid, uniqueness score, remediation, holds, pseudonyms, and
+- valid/whitelisted Cubid, locked Cubid score, versioned locked maximum score,
+  remediation, holds, pseudonyms, and
   greylist/blacklist email events;
 - exact preliminary project totals/counts without user identifiers.
 
@@ -652,11 +653,14 @@ Goal invariants:
   `3 ×` baseline and the canonical retained/final cap is that value floored to the
   allocation minor unit;
 - before redistribution, aggregate initial is clamped to cap; if aggregate exceeds
-  cap, every project/source initial lot is scaled by `cap / aggregate`, retained
+  cap, every project/source initial lot is scaled by `exact cap / aggregate`, retained
   proportionally, and its exact difference becomes source-linked overlap overflow;
 - one global pool equals score-discount shortfalls plus overlap-cap overflow, and
   clamped current totals are raised lowest-first through stable deterministic
   water-filling;
+- exact equal-current users rise together; aggregate initial and baseline do not
+  break ties, while indivisible minor units use only exact-target fractional
+  remainder then stable user ID with cap-aware skipping;
 - capped users and zero-baseline users receive no top-up;
 - cap-aware residual assignment skips any user/source whose next unit would cross
   cap and keeps rejected exact fractions or minor units source-linked in the global
@@ -723,17 +727,22 @@ Scope:
 - aggregate user initial claims, define baseline as the largest single-project
   initial claim, set exact cap to `3 ×` baseline, floor it to the allocation minor
   unit as the canonical cap, and clamp aggregate initial before redistribution;
-- when aggregate exceeds cap, apply one exact `cap / aggregate` factor to every
+- when aggregate exceeds exact cap, apply one `exact cap / aggregate` factor to every
   project/source initial lot and move each difference into the pool as overlap-cap
   overflow; start water-filling from the canonical retained target, namely floored
   `min(aggregate, exact cap)` bounded by the floored minor-unit cap;
 - define the global pool as score-discount shortfalls plus overlap-cap overflow;
   capped and zero-baseline users receive no top-up;
-- use aggregate initial claim, baseline, then stable user ID for ties and assign
-  minor-unit rounding deterministically;
-- apply cap scaling in exact decimals, allocate retained source residuals by
-  fractional remainder then stable project/rail/asset/source-lot key, and derive
-  each overflow lot as original minus retained so native and USD units conserve;
+- treat exact equal-current users equally until the next level/cap/exhaustion; for
+  indivisible minor units use only descending exact-target fractional remainder then
+  stable user ID with cap-aware skipping;
+- keep exact and canonical ledgers separate: every non-negative exact initial source
+  equals exact retained plus exact overflow; derive canonical initial source units
+  first by stable largest remainder to the funded canonical total; then assign
+  retained units to the floored target with `0 <= retained <= initial`, skipping
+  saturated/zero-capacity lots, and define canonical overflow as `initial - retained`;
+- track sub-minor residual and cross-source transfers separately with provenance,
+  never by subtracting rounded retained from exact retained;
   never let retained-lot or final-award rounding cross the floored cap, skip capped
   residual candidates, and keep rejected fractions/units source-linked in the
   pool or returned/carryover residue;
@@ -757,9 +766,15 @@ Validation:
   then water-fill only uncapped users; and
 - fractional cap fixture: four `$0.335` lots yield aggregate `$1.34`, baseline
   `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, and four `$0.25`
-  retained lots; `$0.335` proportional overflow plus the cap-rejected `$0.005`
-  exact remainder stays source-linked as `$0.34` pool/residue and the user never
+  retained lots; exact overflow is `$0.335`, canonical overflow is 34 cents, and
+  the `$0.005` exact-to-canonical residual stays separately source-linked; the user never
   receives `$1.01`; and
+- non-negative source fixture: two exact `$0.006` retained lots with a one-cent
+  target first receive canonical initial capacities; constrained retained rounding
+  yields no negative overflow and exact `$0.012` conservation remains separate; and
+- equal-current tie fixture: two exact `$0.005` top-up targets compete for one cent;
+  equal fractional remainder then stable user ID selects it, aggregate/baseline do
+  not participate, and permutation preserves the result hash; and
 - arbitrary-overlap cap-aware randomized properties conserve exact decimals and
   integer minor units independently, with no lost/double-assigned unit; and
 - old point-proportional results are explicitly superseded and intentional
@@ -786,8 +801,8 @@ Scope:
   without recognizing user ownership before payout is processed;
 - publish exact approved project totals/counts without user identifiers or
   cross-project membership inference;
-- persist theoretical shares, score/max, initial claims, aggregate/baseline/cap,
-  retention factors, retained source lots, score-discount contributions,
+- persist theoretical shares, score/max, initial claims, aggregate/exact/floored caps,
+  separate exact/canonical source ledgers, retention factors, retained source lots, score-discount contributions,
   overlap-cap overflow, pre-redistribution current, top-ups, final allocations, and
   source-linked residue;
 - generate trial balance, custody, project funds, fee, FX, carryover, initial claim,
@@ -799,9 +814,10 @@ Validation:
 
 - award-control balances equal approved allocations without creating user-owned
   liabilities before payout processing;
-- original initial lots equal retained lots plus overlap-cap overflow; retained
-  initials plus both pool-contribution classes reconcile to funded sources; both
-  pool-contribution classes equal top-ups plus residue;
+- non-negative exact initial lots equal exact retained plus exact overflow;
+  canonical initial units equal bounded canonical retained plus non-negative
+  canonical overflow; each ledger plus its pool-contribution classes reconciles
+  independently to funded sources, top-ups, and residue;
 - report totals reconcile to journal and artifacts reproduce;
 - role-scoped privacy tests;
 - payout window cannot open before every hard gate passes.

--- a/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
@@ -648,11 +648,15 @@ Goal invariants:
 - equal theoretical funded project share per eligible user;
 - initial project claim equals theoretical share multiplied by locked Cubid score
   divided by the versioned locked maximum score;
-- every shortfall enters one global epoch redistribution pool;
-- aggregate initial claims are raised lowest-current-total first through stable
-  deterministic water-filling;
 - baseline is the largest single-project score-adjusted initial claim and final
   allocation is capped at `3 ×` baseline;
+- before redistribution, aggregate initial is clamped to cap; if aggregate exceeds
+  cap, every project/source initial lot is scaled by `cap / aggregate`, retained
+  proportionally, and its exact difference becomes source-linked overlap overflow;
+- one global pool equals score-discount shortfalls plus overlap-cap overflow, and
+  clamped current totals are raised lowest-first through stable deterministic
+  water-filling;
+- capped users and zero-baseline users receive no top-up;
 - top-ups and returned/carryover residue retain project, rail, asset, native, FX,
   and functional-USD provenance; and
 - redistribution is funded principal, not fee, revenue, treasury sweep, payable,
@@ -711,11 +715,20 @@ Scope:
   locked score/max evidence in the manifest;
 - divide each funded project pool equally across eligible users;
 - calculate `initial claim = theoretical share × locked score / locked max score`
-  and send the shortfall into one global epoch pool;
+  and create source-linked score-discount shortfall lots;
 - aggregate user initial claims, define baseline as the largest single-project
-  initial claim, and water-fill lowest current totals first under the `3 ×` cap;
+  initial claim, set cap to `3 ×` baseline, and clamp aggregate initial before
+  redistribution;
+- when aggregate exceeds cap, apply one exact `cap / aggregate` factor to every
+  project/source initial lot and move each difference into the pool as overlap-cap
+  overflow; start water-filling from `min(aggregate, cap)`;
+- define the global pool as score-discount shortfalls plus overlap-cap overflow;
+  capped and zero-baseline users receive no top-up;
 - use aggregate initial claim, baseline, then stable user ID for ties and assign
   minor-unit rounding deterministically;
+- apply cap scaling in exact decimals, allocate retained source residuals by
+  fractional remainder then stable project/rail/asset/source-lot key, and derive
+  each overflow lot as original minus retained so native and USD units conserve;
 - preserve project/rail/asset/native/FX/USD provenance for initial claims, top-ups,
   returned residue, and payout eligibility;
 - deterministic rerun and material-change comparison.
@@ -723,13 +736,17 @@ Scope:
 Validation:
 
 - no-receipt/no-allocation invariant;
-- invalid score/max, cap, asset/native/USD conservation, privacy, and source
+- invalid score/max, pre-redistribution cap, zero-baseline, arbitrary-overlap,
+  input-permutation, asset/native/USD conservation, privacy, and source
   attribution;
 - repeat run equivalence;
 - canonical A+B fixture: A `$300`, `5/10/15` of `20` gives `$25/$50/$75`
-  initial and `$150` pool; B `$1,000`, 100 users averaging `10/20` gives `$500`
+  initial and `$150` pool; B `$1,000`, 100 users each exactly `10/20` gives `$500`
   initial and `$500` pool; because the three A users also use B, the combined
-  `$650` goes first to the 97 B-only lowest earners; and
+  `$650` goes first to the 97 B-only lowest earners;
+- four-project overlap fixture `[100,100,100,100]`: aggregate `$400`, baseline
+  `$100`, cap `$300`, four retained `$75` source lots, four `$25` overflow lots,
+  then water-fill only uncapped users; and
 - old point-proportional results are explicitly superseded and intentional
   differences documented.
 
@@ -754,8 +771,10 @@ Scope:
   without recognizing user ownership before payout is processed;
 - publish exact approved project totals/counts without user identifiers or
   cross-project membership inference;
-- persist theoretical shares, score/max, initial claims, pool contributions,
-  top-ups, caps, final allocations, and source-linked residue;
+- persist theoretical shares, score/max, initial claims, aggregate/baseline/cap,
+  retention factors, retained source lots, score-discount contributions,
+  overlap-cap overflow, pre-redistribution current, top-ups, final allocations, and
+  source-linked residue;
 - generate trial balance, custody, project funds, fee, FX, carryover, initial claim,
   redistribution pool, top-up, returned-residue, provisional award, and exception
   artifacts under one root hash, without payable classification;
@@ -765,8 +784,9 @@ Validation:
 
 - award-control balances equal approved allocations without creating user-owned
   liabilities before payout processing;
-- initial claims plus top-ups plus returned residue reconcile to funded sources and
-  pool contributions equal top-ups plus residue;
+- original initial lots equal retained lots plus overlap-cap overflow; retained
+  initials plus both pool-contribution classes reconcile to funded sources; both
+  pool-contribution classes equal top-ups plus residue;
 - report totals reconcile to journal and artifacts reproduce;
 - role-scoped privacy tests;
 - payout window cannot open before every hard gate passes.

--- a/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
@@ -313,12 +313,16 @@ occurs. Later policy edits never rewrite prior events.
 22. Each difference between theoretical share and score-adjusted initial claim
     enters one global epoch redistribution pool. The allocator aggregates each
     user's initial project claims, defines baseline as the largest single-project
-    initial claim, and defines cap as three times baseline. If aggregate initial
+    initial claim, defines exact cap as three times baseline, and floors it to the
+    allocation minor unit for the canonical executable cap. If aggregate initial
     exceeds cap, every project/source initial lot is proportionally retained by
     `cap / aggregate`; each exact difference enters the global pool as source-linked
-    overlap-cap overflow. Water-filling starts from the clamped current total and
+    overlap-cap overflow. Water-filling starts from the canonical floored and
+    cap-bounded retained current total and
     raises the lowest uncapped totals first. A capped or zero-baseline user receives
-    no top-up.
+    no top-up. Retained-lot and final-award rounding may never cross the floored cap;
+    descending-fraction residual assignment skips capped candidates and sends the
+    rejected fraction or unit, with source provenance, into pool/residue.
 23. Cubid is queried during reconciliation and again at lock. A prior validated
     snapshot may be used during an outage only within a configured short TTL;
     otherwise the user remains unresolved and cannot lock.
@@ -338,6 +342,13 @@ aggregate `$400`, baseline `$100`, cap `$300`, retention factor `0.75`, four ret
 `$75` lots, and four source-linked `$25` overflow lots. The user begins water-filling
 at cap and receives no top-up. These conservation and input-order properties apply
 to arbitrary overlap counts and to exact-decimal, minor-unit, and native-unit rows.
+
+Fractional cap fixture: four `$0.335` lots produce aggregate `$1.34`, baseline
+`$0.335`, exact cap `$1.005`, and canonical cent cap `$1.00`. Cap-aware retained-lot
+rounding emits four `$0.25` lots totaling `$1.00`, never `$1.01`; the rejected exact
+`$0.005` remainder joins `$0.335` of proportional differences as source-linked
+`$0.34` pool/residue. Exact-decimal and
+integer-cent conservation are proved independently without lost or duplicate units.
 
 ### 10. Legal ownership, payout, privacy, and consent intent
 
@@ -711,7 +722,8 @@ Process:
    score divided by locked maximum score; send every shortfall into one global
    epoch redistribution pool.
 3. Aggregate each user's initial claims, set baseline to the largest single-project
-   initial claim, and set the final cap to three times baseline.
+   initial claim, set exact cap to three times baseline, and floor that value to the
+   allocation minor unit for the canonical retained/final cap.
 4. Before redistribution, clamp aggregate initial to cap. Scale every project/source
    initial lot by `min(1, cap / aggregate)`, retain the scaled lot, and move its exact
    difference into the pool as source-linked overlap-cap overflow.
@@ -723,9 +735,13 @@ Process:
    every initial claim, top-up, and cap-exhausted returned/carryover residue.
 7. Apply exact-decimal cap scaling first. Allocate retained functional-USD and native
    residual units by descending fractional remainder then stable project/rail/asset/
-   source-lot key; derive overflow as original minus retained before user rounding.
+   source-lot key, skipping any assignment that would cross the canonical cap;
+   derive overflow as original minus retained before user rounding. A rejected exact
+   fraction or minor unit remains source-linked in pool/residue and may fund another
+   uncapped user.
 8. Prove conservation by project, rail, asset, native quantity, redistribution pool,
-   and functional USD for arbitrary overlap count and input order.
+   and functional USD for arbitrary overlap count and input order, separately for
+   exact decimals and integer minor-unit outputs, with no lost/double-assigned units.
 9. Produce immutable calculation inputs, outputs, version, and reproducibility hash.
 10. Do not classify redistribution as fee/revenue/payable, and do not open payouts or
    post final user award/accounting records until review

--- a/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
@@ -316,10 +316,11 @@ occurs. Later policy edits never rewrite prior events.
     initial claim, defines exact cap as three times baseline, and floors it to the
     allocation minor unit for the canonical executable cap. If aggregate initial
     exceeds cap, every project/source initial lot is proportionally retained by
-    `cap / aggregate`; each exact difference enters the global pool as source-linked
+    `exact cap / aggregate`; each exact difference enters the global pool as source-linked
     overlap-cap overflow. Water-filling starts from the canonical floored and
     cap-bounded retained current total and
-    raises the lowest uncapped totals first. A capped or zero-baseline user receives
+    raises equal-current uncapped users together until the next level, cap, or
+    exhaustion. Aggregate initial and baseline do not break equal-current ties. A capped or zero-baseline user receives
     no top-up. Retained-lot and final-award rounding may never cross the floored cap;
     descending-fraction residual assignment skips capped candidates and sends the
     rejected fraction or unit, with source provenance, into pool/residue.
@@ -334,7 +335,8 @@ Canonical allocation fixture: Project A contributes `$300`; scores `5/10/15` of 
 locked maximum `20` yield `$25/$50/$75` initial claims and `$150` of pool. Project B
 contributes `$1,000`; 100 users each exactly `10/20` yield `$500` of initial claims and
 `$500` of pool. The three A users also use B, so the combined `$650` is water-filled
-first to the 97 B-only users with the lowest aggregate initial claims. Stable ties,
+first to the 97 B-only users with the lowest aggregate initial claims. Equal-current
+continuous treatment and the sole fractional-remainder/stable-user-ID minor-unit rule,
 rounding, caps, and complete funded-source provenance must reproduce exactly.
 
 Adversarial overlap fixture: score-adjusted initial lots `[100,100,100,100]` produce
@@ -346,9 +348,20 @@ to arbitrary overlap counts and to exact-decimal, minor-unit, and native-unit ro
 Fractional cap fixture: four `$0.335` lots produce aggregate `$1.34`, baseline
 `$0.335`, exact cap `$1.005`, and canonical cent cap `$1.00`. Cap-aware retained-lot
 rounding emits four `$0.25` lots totaling `$1.00`, never `$1.01`; the rejected exact
-`$0.005` remainder joins `$0.335` of proportional differences as source-linked
-`$0.34` pool/residue. Exact-decimal and
+`$0.005` exact-to-canonical residual is source-linked but separate from `$0.335`
+exact overflow and 34 canonical overflow cents. Exact-decimal and
 integer-cent conservation are proved independently without lost or duplicate units.
+
+Non-negative source fixture: two exact `$0.006` retained lots with a one-cent
+canonical target first receive canonical initial capacities by stable largest
+remainder. Constrained retained rounding assigns the cent only to the source with
+capacity, so canonical overflow is never negative; exact `$0.012` conservation and
+sub-minor source provenance remain separate.
+
+Equal-current tie fixture: two uncapped users each have an exact `$0.005` top-up
+target and one canonical cent remains. Continuous water-filling treats them equally;
+equal fractional remainder then stable user ID selects the cent. Aggregate initial
+and baseline do not participate, and input permutation preserves the result hash.
 
 ### 10. Legal ownership, payout, privacy, and consent intent
 
@@ -725,20 +738,24 @@ Process:
    initial claim, set exact cap to three times baseline, and floor that value to the
    allocation minor unit for the canonical retained/final cap.
 4. Before redistribution, clamp aggregate initial to cap. Scale every project/source
-   initial lot by `min(1, cap / aggregate)`, retain the scaled lot, and move its exact
+   initial lot by `min(1, exact cap / aggregate)`, retain the scaled lot, and move its exact
    difference into the pool as source-linked overlap-cap overflow.
 5. Define the global pool as score-discount contributions plus overlap-cap overflow,
    then redistribute lowest-current-total first through deterministic water-filling;
-   ties use aggregate initial claim, baseline, then stable user ID.
+   exact equal-current users remain equal until a level/cap/exhaustion boundary.
+   For indivisible canonical units, use only descending exact-target fractional
+   remainder then stable user ID, with cap-aware skipping.
    A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
 6. Preserve project, rail, asset, native, FX, and functional-USD source lots for
    every initial claim, top-up, and cap-exhausted returned/carryover residue.
 7. Apply exact-decimal cap scaling first. Allocate retained functional-USD and native
-   residual units by descending fractional remainder then stable project/rail/asset/
-   source-lot key, skipping any assignment that would cross the canonical cap;
-   derive overflow as original minus retained before user rounding. A rejected exact
-   fraction or minor unit remains source-linked in pool/residue and may fund another
-   uncapped user.
+   values in a separate exact ledger where each non-negative initial source equals
+   exact retained plus exact overflow. Derive canonical initial units first against
+   the funded canonical total by descending fractional remainder then stable source
+   ID. Assign retained units to the floored target with the same ordering constrained
+   by `0 <= retained <= initial`, skipping saturated/zero-capacity lots and any cap
+   breach; canonical overflow is `initial - retained`. Track sub-minor residual and
+   cross-source transfers separately with provenance, never as exact overflow.
 8. Prove conservation by project, rail, asset, native quantity, redistribution pool,
    and functional USD for arbitrary overlap count and input order, separately for
    exact decimals and integer minor-unit outputs, with no lost/double-assigned units.

--- a/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
@@ -313,8 +313,12 @@ occurs. Later policy edits never rewrite prior events.
 22. Each difference between theoretical share and score-adjusted initial claim
     enters one global epoch redistribution pool. The allocator aggregates each
     user's initial project claims, defines baseline as the largest single-project
-    initial claim, and raises the lowest current totals first through deterministic
-    water-filling. Final allocation cannot exceed three times baseline.
+    initial claim, and defines cap as three times baseline. If aggregate initial
+    exceeds cap, every project/source initial lot is proportionally retained by
+    `cap / aggregate`; each exact difference enters the global pool as source-linked
+    overlap-cap overflow. Water-filling starts from the clamped current total and
+    raises the lowest uncapped totals first. A capped or zero-baseline user receives
+    no top-up.
 23. Cubid is queried during reconciliation and again at lock. A prior validated
     snapshot may be used during an outage only within a configured short TTL;
     otherwise the user remains unresolved and cannot lock.
@@ -324,10 +328,16 @@ occurs. Later policy edits never rewrite prior events.
 
 Canonical allocation fixture: Project A contributes `$300`; scores `5/10/15` of a
 locked maximum `20` yield `$25/$50/$75` initial claims and `$150` of pool. Project B
-contributes `$1,000`; 100 users averaging `10/20` yield `$500` of initial claims and
+contributes `$1,000`; 100 users each exactly `10/20` yield `$500` of initial claims and
 `$500` of pool. The three A users also use B, so the combined `$650` is water-filled
 first to the 97 B-only users with the lowest aggregate initial claims. Stable ties,
 rounding, caps, and complete funded-source provenance must reproduce exactly.
+
+Adversarial overlap fixture: score-adjusted initial lots `[100,100,100,100]` produce
+aggregate `$400`, baseline `$100`, cap `$300`, retention factor `0.75`, four retained
+`$75` lots, and four source-linked `$25` overflow lots. The user begins water-filling
+at cap and receives no top-up. These conservation and input-order properties apply
+to arbitrary overlap counts and to exact-decimal, minor-unit, and native-unit rows.
 
 ### 10. Legal ownership, payout, privacy, and consent intent
 
@@ -702,17 +712,25 @@ Process:
    epoch redistribution pool.
 3. Aggregate each user's initial claims, set baseline to the largest single-project
    initial claim, and set the final cap to three times baseline.
-4. Redistribute lowest-current-total first through deterministic water-filling;
+4. Before redistribution, clamp aggregate initial to cap. Scale every project/source
+   initial lot by `min(1, cap / aggregate)`, retain the scaled lot, and move its exact
+   difference into the pool as source-linked overlap-cap overflow.
+5. Define the global pool as score-discount contributions plus overlap-cap overflow,
+   then redistribute lowest-current-total first through deterministic water-filling;
    ties use aggregate initial claim, baseline, then stable user ID.
-5. Preserve project, rail, asset, native, FX, and functional-USD source lots for
+   A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
+6. Preserve project, rail, asset, native, FX, and functional-USD source lots for
    every initial claim, top-up, and cap-exhausted returned/carryover residue.
-6. Apply stable exact-decimal and minor-unit rounding, then prove conservation by
-   project, rail, asset, native quantity, redistribution pool, and functional USD.
-7. Produce immutable calculation inputs, outputs, version, and reproducibility hash.
-8. Do not classify redistribution as fee/revenue/payable, and do not open payouts or
+7. Apply exact-decimal cap scaling first. Allocate retained functional-USD and native
+   residual units by descending fractional remainder then stable project/rail/asset/
+   source-lot key; derive overflow as original minus retained before user rounding.
+8. Prove conservation by project, rail, asset, native quantity, redistribution pool,
+   and functional USD for arbitrary overlap count and input order.
+9. Produce immutable calculation inputs, outputs, version, and reproducibility hash.
+10. Do not classify redistribution as fee/revenue/payable, and do not open payouts or
    post final user award/accounting records until review
    completes.
-9. Keep production allocation fail-closed until the named accounting, privacy,
+11. Keep production allocation fail-closed until the named accounting, privacy,
    custody, legal, and launch approvals are effective.
 
 Exit gate:

--- a/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
@@ -1,7 +1,7 @@
 # Feature definition: settlement-backed epoch treasury and auditable payouts
 
 Status: brainstorm complete; published and vetted for implementation
-Last updated: 2026-08-08
+Last updated: 2026-08-09
 Issue kind: Feature
 Repository: `FundLoop/fundloop-website`
 Project: `FundLoop Project`
@@ -200,7 +200,9 @@ occurs. Later policy edits never rewrite prior events.
 3. Inventory is pooled by `epoch x rail x asset` across projects. Project
    participation establishes asset eligibility; individual project balances are
    not reserved for particular users.
-4. Every withdrawal preserves proportional project-source attribution.
+4. Every withdrawal preserves proportional project-source-lot attribution for the
+   already approved award. This payout provenance rule is unrelated to Cubid
+   allocation weighting.
 5. Availability shown in the UI is informational. Inventory is atomically reserved
    only when a valid payout request commits.
 6. Simultaneous requests are ordered by database commit order with a durable,
@@ -259,8 +261,10 @@ occurs. Later policy edits never rewrite prior events.
 3. Post-cutoff project actions are limited to approval or withdrawal from the
    current epoch.
 4. A user enters allocation only with a valid and whitelisted Cubid ID.
-5. A valid, whitelisted user receives an allocation proportional to the user's
-   Cubid uniqueness score under the versioned allocation algorithm.
+5. A valid, whitelisted user receives an equal theoretical share of each eligible
+   funded project pool, discounted by the user's locked Cubid score divided by the
+   versioned locked maximum score. The score is not divided by the sum of cohort
+   scores.
 6. Invalid Cubid IDs and whitelisting failures are excluded. Project admins see
    the affected project's validation and whitelisting failures without gaining
    cross-project identity visibility.
@@ -306,15 +310,24 @@ occurs. Later policy edits never rewrite prior events.
 21. Before lock, a blacklisted user is excluded. After lock, unpaid execution stops
     and the conditional award enters compliance hold pending an authorized resolution. It
     is not silently redistributed and completed payouts are not clawed back.
-22. Within the applicable allocation cohort, the locked Cubid uniqueness score is
-    used directly as a proportional weight: user score divided by the sum of
-    eligible scores, subject to the versioned project/source allocation rules.
+22. Each difference between theoretical share and score-adjusted initial claim
+    enters one global epoch redistribution pool. The allocator aggregates each
+    user's initial project claims, defines baseline as the largest single-project
+    initial claim, and raises the lowest current totals first through deterministic
+    water-filling. Final allocation cannot exceed three times baseline.
 23. Cubid is queried during reconciliation and again at lock. A prior validated
     snapshot may be used during an outage only within a configured short TTL;
     otherwise the user remains unresolved and cannot lock.
 24. Projects see only a project-scoped pseudonymous identifier, failure category,
     remediation state, and inclusion outcome for failed users. Raw Cubid evidence,
     another project's identifier, and cross-project membership remain private.
+
+Canonical allocation fixture: Project A contributes `$300`; scores `5/10/15` of a
+locked maximum `20` yield `$25/$50/$75` initial claims and `$150` of pool. Project B
+contributes `$1,000`; 100 users averaging `10/20` yield `$500` of initial claims and
+`$500` of pool. The three A users also use B, so the combined `$650` is water-filled
+first to the 97 B-only users with the lowest aggregate initial claims. Stable ties,
+rounding, caps, and complete funded-source provenance must reproduce exactly.
 
 ### 10. Legal ownership, payout, privacy, and consent intent
 
@@ -552,7 +565,8 @@ Process:
 10. Vet candidate users for valid, whitelisted Cubid IDs. Exclude invalid IDs and
     whitelisting failures, expose the relevant failure state to the submitting
     project and affected user, notify users who identify as or become greylisted or
-    blacklisted, and retain uniqueness scores for proportional allocation.
+    blacklisted, and retain the locked score and versioned maximum-score evidence
+    required for score discounting and redistribution.
     Recheck during reconciliation and at lock; use cached passing evidence only
     within the configured short outage TTL.
 11. Vet candidate amounts for clean provenance, final settlement, and preliminary
@@ -662,8 +676,9 @@ Process:
 
 1. Confirm the opt-out deadline has passed.
 2. Freeze included projects, settled/applied receipts, accepted user lists, Cubid
-   evidence, eligibility checks, native balances, fee results, fixed FX rates,
-   carryover results, and project-source dimensions.
+   score/max evidence, eligibility checks, native balances, fee results, fixed FX
+   rates, carryover results, eligible project-user counts, and project/rail/asset/
+   native/FX/USD source dimensions.
 3. Prove that the distributable pool is based only on reconciled epoch treasury
    assets after fees and carryover activity.
 4. Produce a deterministic lock manifest and input hash.
@@ -681,24 +696,34 @@ allocation results.
 
 Process:
 
-1. Run the versioned allocation algorithm against the locked manifest.
-2. Preserve per-user project-source attribution and eligible `rail x asset` union.
-3. Calculate user USD entitlements using the epoch's fixed monthly rates.
-4. Calculate native payout guides using the same originating-epoch rates.
-5. Prove conservation by project, rail, asset, and total functional USD.
-6. Produce immutable calculation inputs, outputs, version, and reproducibility hash.
-7. Do not open payouts or post final user award/accounting records until review
+1. Divide each funded project pool equally across that project's eligible users.
+2. Calculate each initial project claim as theoretical share multiplied by locked
+   score divided by locked maximum score; send every shortfall into one global
+   epoch redistribution pool.
+3. Aggregate each user's initial claims, set baseline to the largest single-project
+   initial claim, and set the final cap to three times baseline.
+4. Redistribute lowest-current-total first through deterministic water-filling;
+   ties use aggregate initial claim, baseline, then stable user ID.
+5. Preserve project, rail, asset, native, FX, and functional-USD source lots for
+   every initial claim, top-up, and cap-exhausted returned/carryover residue.
+6. Apply stable exact-decimal and minor-unit rounding, then prove conservation by
+   project, rail, asset, native quantity, redistribution pool, and functional USD.
+7. Produce immutable calculation inputs, outputs, version, and reproducibility hash.
+8. Do not classify redistribution as fee/revenue/payable, and do not open payouts or
+   post final user award/accounting records until review
    completes.
+9. Keep production allocation fail-closed until the named accounting, privacy,
+   custody, legal, and launch approvals are effective.
 
 Exit gate:
 
-- The allocation run is deterministic, balanced, reproducible, and free of hard
-  eligibility or funding failures.
+- The allocation run is deterministic, balanced, reproducible, privacy-safe, below
+  every `3 ×` cap, and free of hard eligibility or funding failures.
 
 ### Stage 8: `reviewing`
 
 Purpose: independently validate allocation integrity and reasonableness before
-creating spendable user claims.
+creating provisional award-control records.
 
 Process:
 
@@ -713,6 +738,9 @@ Process:
    - value harvested and transferred from previous epochs;
    - deduplicated net user count; and
    - minimum, mean, median, and maximum available payouts.
+   Operator-only evidence additionally shows theoretical shares, score factors,
+   initial claims, redistribution order, source-linked top-ups, caps, and residue;
+   project/public evidence cannot reveal cross-project membership.
 5. Review privacy thresholds before any public release.
 6. Require one authorized admin to approve the reviewed allocation package. The
    approval is bound to the exact locked manifest and allocation-result hashes.
@@ -725,13 +753,13 @@ Exit gates:
 
 ### Stage 9: `payout_readying`
 
-Purpose: convert approved allocation results into funded, externally executable
-user claims and prepare public/operator evidence.
+Purpose: post approved allocation results as funded provisional award-control
+records and prepare public/operator and later payout-readiness evidence.
 
 Process:
 
-1. Post the accountant-approved conditional-award or payout-accounting entries from
-   the approved allocation artifact.
+1. Post the approved conditional-award memorandum entries from the exact allocation
+   artifact without classifying redistribution or awards as a user payable.
 2. Publish the privacy-safe detailed outcome listing, including:
    - withdrawn projects;
    - included value and user count per project;
@@ -753,7 +781,8 @@ Process:
 
 Exit gates:
 
-- User liabilities reconcile to restricted assets.
+- Provisional award-control totals reconcile to funded sources; no user liability
+  or payable exists before the separately approved processed-payout event.
 - Payout thresholds, signer/paymaster controls, routes, and inventory are ready.
 - Close package exists and all hard gates pass.
 

--- a/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
+++ b/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
@@ -1,0 +1,46 @@
+### session v1: Cubid redistribution architecture rescope (#134-#137)
+
+- Timestamp: 2026-08-09T02:30:58-04:00
+- Agent: Codex
+- Branch: codex/134-cubid-redistribution-architecture
+- Head: 25233cf
+
+#### Objective
+
+Align the repository architecture with the approved Goal #134 allocation rescope
+without changing product code, schema, issue state, or production behavior.
+
+#### Actions Taken
+
+- Replaced the legacy point-proportional project entitlement and overlap-derived
+  remainder model with equal theoretical project shares discounted by locked Cubid
+  score divided by the versioned locked maximum score.
+- Defined one global epoch redistribution pool, aggregate initial claims,
+  largest-single-project baseline, deterministic lowest-current-total-first
+  water-filling, stable tie/rounding rules, and the `3 ×` final cap.
+- Defined immutable source-lot provenance for initial claims, top-ups, and
+  cap-exhausted returned/carryover residue across project, rail, asset, native, FX,
+  and functional USD.
+- Recorded that redistribution is funded principal rather than fee, revenue,
+  treasury sweep, payable, or new value.
+- Added the exact A+B fixture and propagated the formulas, conservation equations,
+  privacy boundary, provisional-award semantics, and production fail-closed gate
+  across the allocation, operational MVP, treasury, sprint, and issue-tree docs.
+- Explicitly superseded the current legacy calculator policy pending Task #136.
+
+#### Validation Notes
+
+- Passed scoped Markdown local-link resolution for all five edited architecture files.
+- Passed contradiction audit for legacy raw-entitlement, sum-of-scores,
+  score-proportional, and overlap-remainder formulas.
+- Passed executable A+B arithmetic/cent-rounding probe: `$650` distributed across
+  97 B-only users as ten `$6.71` and eighty-seven `$6.70` top-ups; total conserved
+  at `$1,300`.
+- Passed `pnpm lint` and `git diff --check`.
+- No dedicated Markdown/static-doc test command exists in the repository.
+
+#### Suggested Next Steps
+
+- Use these architecture contracts while vetting and implementing Tasks #135-#137.
+- Keep production allocation, award posting, and real value flow fail-closed until
+  the named professional, privacy, custody, and launch gates are satisfied.

--- a/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
+++ b/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
@@ -88,3 +88,44 @@ redistribution begins.
 
 - Commit this docs-only validation correction and retain the production fail-closed
   boundary for later Task #136 implementation.
+
+### session v3: Cap-aware minor-unit precision (#134/#136)
+
+- Timestamp: 2026-08-09T02:54:51-04:00
+- Agent: Codex
+- Branch: codex/134-cubid-redistribution-architecture
+- Head: 521f3f2
+
+#### Objective
+
+Close the final architecture precision gap where nearest rounding of an exact
+`3 × baseline` cap could award one minor unit above the allowed cap.
+
+#### Actions Taken
+
+- Defined the canonical executable cap as the exact cap floored to the allocation
+  minor unit and bounded both retained-lot and final-award targets by it.
+- Distinguished raw proportional retention from canonical retained lots and moved
+  cap-floor differences into source-linked global overflow.
+- Made descending-fraction residual assignment cap-aware for source lots and users;
+  capped candidates are skipped rather than receiving another unit.
+- Required rejected exact fractions and minor units to retain project, rail, asset,
+  native, FX, and USD provenance through pool use or returned/carryover residue.
+- Added the four-`$0.335` fixture and exact-decimal versus integer-minor-unit
+  conservation requirements throughout the Goal #134 and Task #136 architecture.
+
+#### Validation Notes
+
+- Passed the fractional fixture: 100 retained cents plus 34 source-linked overflow
+  cents conserve 134 cents under a 100-cent cap; the award never becomes 101 cents.
+- Passed the four-project overlap regression under its 30,000-cent cap.
+- Passed 2,000 deterministic randomized cap-aware overlap cases with minor-unit
+  conservation and source-order permutation equivalence.
+- Passed the canonical A+B `$650` redistribution regression.
+- Passed scoped Markdown local-link and precision-contradiction audits.
+- Passed `pnpm lint` under Node 22 and `git diff --check`.
+
+#### Suggested Next Steps
+
+- Use the cap-aware integer contract as the executable acceptance rule for Task
+  #136 while keeping production allocation and value flow fail-closed.

--- a/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
+++ b/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
@@ -44,3 +44,47 @@ without changing product code, schema, issue state, or production behavior.
 - Use these architecture contracts while vetting and implementing Tasks #135-#137.
 - Keep production allocation, award posting, and real value flow fail-closed until
   the named professional, privacy, custody, and launch gates are satisfied.
+
+### session v2: Pre-redistribution overlap cap correction (#134/#136)
+
+- Timestamp: 2026-08-09T02:43:42-04:00
+- Agent: Codex
+- Branch: codex/134-cubid-redistribution-architecture
+- Head: a8e7f71
+
+#### Objective
+
+Close the architecture validation gap for users whose aggregate score-adjusted
+initial claims already exceed the `3 ×` largest-project baseline before
+redistribution begins.
+
+#### Actions Taken
+
+- Defined `pre_redistribution_current = min(aggregate_initial, cap)` and excluded
+  users already at cap, including zero-baseline users, from top-ups.
+- Required an exact `cap / aggregate` factor across every project/source initial lot
+  when aggregate exceeds cap; retained lots keep the factor and each exact difference
+  enters the global pool as source-linked overlap-cap overflow.
+- Defined the global pool as score-discount shortfalls plus overlap-cap overflow and
+  extended returned/carryover provenance to both contribution classes.
+- Added exact-decimal, USD minor-unit, and native atomic-unit residual rules using
+  fractional remainder plus stable project/rail/asset/source-lot identity.
+- Added the four-project `[100,100,100,100]` fixture and arbitrary-overlap,
+  source-order permutation, zero-baseline, and conservation requirements.
+- Replaced every canonical B-fixture average with 100 users each exactly `10/20`.
+
+#### Validation Notes
+
+- Passed exact A+B fixture: ten B-only users receive `$6.71`, 87 receive `$6.70`,
+  the `$650` pool is exhausted, and `$1,300` is conserved.
+- Passed four-project fixture: four `$75` retained lots plus four `$25` overflow lots
+  conserve the `$400` aggregate under the `$300` cap.
+- Passed 1,000 deterministic randomized overlap cases with retained/overflow
+  minor-unit conservation and source-order permutation equivalence.
+- Passed scoped Markdown local-link and cap/fixture contradiction audits.
+- Passed `pnpm lint` and `git diff --check`.
+
+#### Suggested Next Steps
+
+- Commit this docs-only validation correction and retain the production fail-closed
+  boundary for later Task #136 implementation.

--- a/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
+++ b/agent-context/session-log/2026-08-09-codex-134-cubid-redistribution-architecture.md
@@ -129,3 +129,47 @@ Close the final architecture precision gap where nearest rounding of an exact
 
 - Use the cap-aware integer contract as the executable acceptance rule for Task
   #136 while keeping production allocation and value flow fail-closed.
+
+### session v4: Exact/canonical source and tie-rule review fixes (#149)
+
+- Timestamp: 2026-08-09T03:15:23-04:00
+- Agent: Codex
+- Branch: codex/134-cubid-redistribution-architecture
+- Head: cea9392
+
+#### Objective
+
+Address all five actionable PR #149 review threads without mutating thread state or
+weakening the allocation, privacy, accounting, or production gates.
+
+#### Actions Taken
+
+- Replaced allocation eligibility wording with approved locked package/cohort
+  membership and clarified that historical attribution points do not weight it.
+- Standardized treasury inputs on locked Cubid score plus versioned locked maximum,
+  and distinguished exact-cap scaling from the floored canonical rounding bound.
+- Split source accounting into an immutable non-negative exact ledger and a
+  canonical integer-minor-unit ledger with initial capacity assigned first.
+- Defined constrained retained largest-remainder assignment, non-negative canonical
+  overflow, and separately provenance-tracked sub-minor/cross-source residuals.
+- Removed aggregate/baseline tie breakers: continuous equal-current users remain
+  equal, while indivisible units use only fractional remainder then stable user ID.
+- Added two-`$0.006` non-negative-source and one-cent equal-current tie fixtures to
+  every canonical architecture mirror.
+
+#### Validation Notes
+
+- Passed the two-`$0.006` counterexample with canonical initial/retained `[1,0]`
+  cents and overflow `[0,0]`, while preserving the separate exact `$0.012` ledger.
+- Passed the `$0.005/$0.005` equal-current tie under reversed input order; stable
+  user ID alone receives the one cent.
+- Passed fractional-cap, four-project overlap, and canonical A+B regressions.
+- Passed 5,000 deterministic randomized constrained-rounding cases for per-source
+  non-negativity, capacity, conservation, cap safety, and permutation equivalence.
+- Passed scoped terminology/ledger/tie contradiction and Markdown local-link audits.
+- Passed `pnpm lint` under Node 22 and `git diff --check`.
+
+#### Suggested Next Steps
+
+- Use these exact/canonical contracts and the sole tie rule when Task #136 becomes
+  executable; keep production allocation and value flow fail-closed.

--- a/docs/engineering/allocation.md
+++ b/docs/engineering/allocation.md
@@ -20,10 +20,13 @@ USD-normalized Cubid-score discount followed by one global epoch redistribution:
 2. discount each theoretical share by the user's locked Cubid score divided by the
    locked maximum score;
 3. aggregate score-adjusted initial claims across projects;
-4. combine every project shortfall into one epoch redistribution pool;
-5. raise the lowest current user totals first through deterministic water-filling;
-6. stop each user at three times that user's largest single-project initial claim;
-7. return or carry forward any cap-exhausted residue to its originating funded
+4. clamp any aggregate initial claim above three times its largest single-project
+   claim and contribute the proportionally sourced overflow to the pool;
+5. combine every score-discount shortfall and overlap-cap overflow into one epoch
+   redistribution pool;
+6. raise the lowest current user totals first through deterministic water-filling;
+7. exclude users already at cap from top-ups; and
+8. return or carry forward any cap-exhausted residue to its originating funded
    sources.
 
 This model explicitly supersedes allocation based on a user's share of total
@@ -83,10 +86,10 @@ Each post-fee distributable source remains an immutable provenance lot containin
 - manifest position and stable source-lot key.
 
 The global redistribution pool is a calculated total over these lots, not an
-untracked fungible balance. Project shortfalls create source-linked pool lots.
-Top-ups consume those lots in a versioned stable order and record partial-lot
-splits. Unconsumed lots retain their original project, rail, asset, native, FX, and
-USD dimensions when returned or carried forward.
+untracked fungible balance. Score-discount shortfalls and overlap-cap overflow each
+create source-linked pool lots. Top-ups consume those lots in a versioned stable
+order and record partial-lot splits. Unconsumed lots retain their original project,
+rail, asset, native, FX, and USD dimensions when returned or carried forward.
 
 Redistribution principal is funded epoch value. It is never classified as a
 platform fee, platform revenue, treasury sweep, user payable, or newly created
@@ -142,20 +145,52 @@ final_cap(u) = 3 * baseline(u)
 
 The baseline is the largest single-project score-adjusted initial claim. It is not
 the aggregate initial claim, a raw point-proportional entitlement, or a value
-derived from project overlap.
+derived from project overlap. A user with a zero baseline has a zero cap.
 
-### 4. Global Epoch Redistribution Pool
+### 4. Pre-redistribution Cap Clamp
+
+The cap applies before redistribution as well as after it. For every user:
 
 ```text
-epoch_redistribution_pool = sum(project_pool_contribution(u,p))
+retention_factor(u) =
+  1                                      when aggregate_initial_claim(u) <= final_cap(u)
+  final_cap(u) / aggregate_initial_claim(u)  otherwise
+
+retained_initial_lot(u,p,source) =
+  initial_project_source_lot(u,p,source) * retention_factor(u)
+
+overlap_cap_overflow_lot(u,p,source) =
+  initial_project_source_lot(u,p,source) - retained_initial_lot(u,p,source)
+
+pre_redistribution_current(u) = sum(retained_initial_lot(u,p,source))
 ```
 
-All included project shortfalls enter this one pool. They do not remain restricted
-to users of the originating project, but their source provenance remains intact.
+Therefore `pre_redistribution_current = min(aggregate_initial_claim, final_cap)`.
+When aggregate initial value exceeds the cap, each project/source initial lot is
+scaled by the same exact factor. Each lot's exact difference becomes
+source-preserving overlap-cap overflow in the global pool. The clamp may not choose
+one project to absorb another project's overflow or erase rail, asset, native, FX,
+or USD provenance.
 
-### 5. Lowest-current-total-first Water-filling
+A user whose pre-redistribution current equals the cap is not a water-filling
+candidate. With non-negative initial lots, a zero baseline means every initial lot
+is zero; the user has cap zero, retains zero, and receives no redistribution top-up.
 
-Initialize each user's current total to `aggregate_initial_claim(u)`. Repeatedly:
+### 5. Global Epoch Redistribution Pool
+
+```text
+epoch_redistribution_pool =
+  sum(score_discount_pool_contribution(u,p,source))
+  + sum(overlap_cap_overflow_lot(u,p,source))
+```
+
+All included score-discount shortfalls and overlap-cap overflow enter this one pool.
+They do not remain restricted to users of the originating project, but their source
+provenance remains intact.
+
+### 6. Lowest-current-total-first Water-filling
+
+Initialize each user's current total to `pre_redistribution_current(u)`. Repeatedly:
 
 1. select uncapped users with the lowest current total;
 2. raise the tied lowest group together toward the next-lowest current total or a
@@ -173,9 +208,10 @@ Deterministic ordering is:
 
 Exact-decimal water-filling treats a tied group equally. Stable user ID is used
 only where indivisible minor units or an otherwise exact tie require assignment.
-No final allocation may exceed `3 * baseline`.
+No final allocation may exceed `3 * baseline`, and a user that begins at cap receives
+no top-up.
 
-### 6. Returned Or Carried-forward Residue
+### 7. Returned Or Carried-forward Residue
 
 If every eligible user reaches the cap before the pool is exhausted:
 
@@ -188,10 +224,19 @@ Residue is emitted as deterministic source-linked rows and returns or carries
 forward under the originating lot's project, rail, asset, native, FX, and USD
 provenance. It is not a user credit, fee, revenue, or payable.
 
-### 7. Rounding
+### 8. Rounding
 
-- preserve exact decimal theoretical shares, claims, pool lots, and water levels in
-  the artifact;
+- preserve exact decimal theoretical shares, initial lots, retention factors,
+  retained lots, overflow lots, pool lots, and water levels in the artifact;
+- calculate cap scaling before any minor-unit rounding;
+- for retained functional-USD source lots, floor each exact minor-unit amount and
+  assign the residual needed to reach the rounded retained-total target by
+  descending fractional remainder, then stable project/rail/asset/source-lot key;
+- derive each rounded overflow lot as original rounded source amount minus its
+  rounded retained amount, so retained plus overflow always equals the source;
+- apply the same largest-remainder and stable-key rule within each
+  rail/asset/custody group when an exact factor crosses atomic native units, and set
+  overflow native units to original minus retained units;
 - round canonical user awards in integer minor USD units only after water-filling;
 - assign user residual minor units by descending fractional remainder, then stable
   user ID;
@@ -199,6 +244,26 @@ provenance. It is not a user credit, fee, revenue, or payable.
 - assign source residuals through the versioned stable lot order; and
 - prove rounded user awards plus rounded returned residue equal the rounded funded
   pool, while native source quantities conserve exactly.
+
+### 9. Arbitrary-overlap Invariants
+
+For any number of overlapping project initial lots, including zero and one:
+
+```text
+sum(retained_initial_lot + overlap_cap_overflow_lot) =
+  aggregate_initial_claim
+
+pre_redistribution_current = min(aggregate_initial_claim, 3 * baseline)
+
+funded_epoch_pool =
+  sum(retained_initial_lot)
+  + sum(score_discount_pool_contribution)
+  + sum(overlap_cap_overflow_lot)
+```
+
+These identities must hold in exact decimals, rounded functional-USD minor units,
+and exact native atomic units. Permuting project/source input order cannot change
+retained totals, overflow totals, final allocations, or the result hash.
 
 ## Canonical A+B Fixture
 
@@ -213,7 +278,7 @@ A redistribution total       = $150
 ```
 
 Project B has `$1,000` and 100 eligible users. In the canonical deterministic
-fixture each B user is locked at `10/20`, so the `$10` theoretical share becomes a
+fixture the 100 B users are each exactly `10/20`, so the `$10` theoretical share becomes a
 `$5` initial claim.
 
 ```text
@@ -229,6 +294,25 @@ water-filling therefore sends the entire `$650` to the 97 B-only users before an
 A+B user. Exact top-up is `$650 / 97`; after cent rounding, 10 stable user IDs
 receive `$6.71` and 87 receive `$6.70`. No user reaches the `$15` cap, no A+B user
 receives a top-up, and no residue remains.
+
+## Four-project Overlap Cap Fixture
+
+One user has four score-adjusted project/source initial lots of `$100` each:
+
+```text
+aggregate initial claim      = $400
+baseline                     = $100
+cap                          = 3 * $100 = $300
+retention factor             = $300 / $400 = 0.75
+retained source lots         = $75, $75, $75, $75
+overlap-cap overflow lots    = $25, $25, $25, $25
+pre-redistribution current   = $300
+```
+
+The `$100` overflow joins the global pool with all four project/source identities
+intact. The user begins at cap and receives no top-up; water-filling proceeds only
+to other uncapped users. If no uncapped capacity remains, the four `$25` lots return
+or carry forward through their originating funded sources.
 
 ## Asset Fulfillment
 
@@ -246,7 +330,8 @@ The calculation artifact contains at least:
 - eligible project-user counts and theoretical shares;
 - locked score, locked maximum score, and score factor;
 - initial project claims and project pool contributions;
-- aggregate initial claims, baselines, and caps;
+- aggregate initial claims, baselines, caps, retention factors, retained initial
+  lots, and overlap-cap overflow lots;
 - ordered water-filling steps and redistribution top-ups;
 - final provisional allocations and cap status;
 - stable rounding decisions and asset/source fills;
@@ -267,12 +352,18 @@ Verification must prove:
 - every project dollar is settled, applied, journal-backed, fee-processed, and
   linked to immutable source provenance;
 - every user and score/max pair was eligible and locked;
-- equal theoretical shares, score-adjusted claims, and pool contributions recompute;
+- equal theoretical shares, score-adjusted claims, pre-redistribution cap clamps,
+  retained lots, and both pool-contribution classes recompute;
 - water-filling order, ties, caps, and rounding reproduce deterministically;
 - `final_allocation <= 3 * baseline` for every user;
-- funded pool equals initial claims plus pool contributions;
-- pool contributions equal top-ups plus returned/carryover residue;
-- final allocations equal initial claims plus top-ups;
+- every original initial lot equals its retained lot plus overlap-cap overflow;
+- funded pool equals retained initial lots plus score-discount contributions plus
+  overlap-cap overflow;
+- score-discount contributions plus overlap-cap overflow equal top-ups plus
+  returned/carryover residue;
+- final allocations equal pre-redistribution current plus top-ups;
+- capped and zero-baseline users receive no top-up;
+- arbitrary overlap count and input permutation properties hold;
 - native, FX, and functional-USD source conservation all hold;
 - project/public outputs cannot reveal cross-project membership; and
 - production allocation, payable posting, provider calls, and real value flow are

--- a/docs/engineering/allocation.md
+++ b/docs/engineering/allocation.md
@@ -172,13 +172,18 @@ canonical_retained_target(u) =
 ```
 
 The raw proportional target is `min(aggregate_initial_claim, exact_final_cap)`.
-The canonical retained target is the lesser of its floored minor-unit value and
-`minor_unit_cap`; retained-lot rounding may never produce a total above that target
-or cap. Allocate canonical retained source lots up to that target. The difference
-between every proportional retained lot and its canonical retained lot is
-`cap_floor_overflow`; total source-linked overlap overflow is proportional overlap
-overflow plus cap-floor overflow. Canonical pre-redistribution current is
-`sum(canonical_retained_initial_lot)`, never the higher raw target.
+The exact ledger is immutable: for every source,
+`exact_initial = exact_retained + exact_overflow`, every term is non-negative, and
+`exact_retained = exact_initial × retention_factor`. Canonical rounding never
+rewrites these exact terms.
+
+The canonical retained target is the lesser of the raw target floored to the
+allocation minor unit and `minor_unit_cap`. Canonical retained-lot assignment may
+never exceed that target or cap. Canonical pre-redistribution current is
+`sum(canonical_retained_minor_lot)`, never the higher raw target. The exact amount
+between raw and canonical targets is a separately recorded, source-provenance
+`sub_minor_residual`; it is not computed as exact retained minus a rounded lot and
+is not an exact overflow source lot.
 When aggregate initial value exceeds the cap, each project/source initial lot is
 scaled by the same exact factor. Each lot's exact difference becomes
 source-preserving overlap-cap overflow in the global pool. The clamp may not choose
@@ -212,15 +217,12 @@ Initialize each user's current total to `pre_redistribution_current(u)`. Repeate
 4. remove capped users and continue until the pool is exhausted or no user has cap
    capacity.
 
-Deterministic ordering is:
-
-1. lowest current total;
-2. lowest aggregate initial claim;
-3. lowest baseline; and
-4. stable user ID.
-
-Exact-decimal water-filling treats a tied group equally. Stable user ID is used
-only where indivisible minor units or an otherwise exact tie require assignment.
+Exact continuous water-filling treats every equal-current user equally until the
+next level, a cap, or pool exhaustion. Aggregate initial claim and baseline do not
+break an equal-current tie. Only after exact targets are fixed are indivisible
+canonical minor units assigned: descending fractional remainder of the exact user
+target, then stable user ID, with cap-aware skipping. An unassignable next unit
+continues to the next eligible user or remains source-linked residue.
 No final allocation may exceed `minor_unit_cap`, and a user that begins at cap receives
 no top-up.
 
@@ -241,21 +243,27 @@ provenance. It is not a user credit, fee, revenue, or payable.
 
 - preserve exact decimal theoretical shares, initial lots, retention factors,
   retained lots, overflow lots, pool lots, and water levels in the artifact;
+- maintain separate exact-decimal and canonical integer-minor-unit ledgers; never
+  substitute a rounded lot into an exact source identity;
+- derive canonical initial source units first: round the exact funded canonical
+  total under the versioned currency rule, floor each exact initial source lot, then
+  assign residual units by descending fractional remainder and stable
+  project/rail/asset/source-lot ID;
 - calculate cap scaling before any minor-unit rounding;
-- for retained functional-USD source lots, floor each exact minor-unit amount and
-  assign the residual needed to reach the rounded retained-total target by
-  descending fractional remainder, then stable project/rail/asset/source-lot key;
-  the target is floored and bounded by `minor_unit_cap`;
+- assign canonical retained units to the floored, cap-bounded retained target by
+  constrained largest remainder over exact retained lots: require
+  `0 <= retained_minor_lot <= initial_minor_lot`, skip saturated/zero-capacity lots,
+  and use stable project/rail/asset/source-lot ID after fractional remainder;
+- define `overflow_minor_lot = initial_minor_lot - retained_minor_lot`; it is always
+  non-negative, and canonical initial equals canonical retained plus canonical
+  overflow for every source;
 - make every retained-lot and final-award residual assignment cap-aware: skip a
   user/source assignment whenever its next unit would make the user's retained or
   final total exceed `minor_unit_cap`;
-- move every exact fractional remainder or candidate minor unit rejected by that
-  cap, with its original project/rail/asset/native/FX/USD provenance, into
-  cap-floor overflow; together with proportional overlap overflow it may fund
-  another eligible uncapped user and, if still
-  unassignable, becomes source-linked returned/carryover residue;
-- derive each rounded overflow lot as original rounded source amount minus its
-  rounded retained amount, so retained plus overflow always equals the source;
+- track sub-minor exact residual and deterministic cross-source residual transfers
+  separately with original project/rail/asset/native/FX/USD provenance. Residual
+  may combine into a canonical pool unit, fund another uncapped user, or become
+  returned/carryover residue; it never creates a negative exact or canonical lot;
 - apply the same largest-remainder and stable-key rule within each
   rail/asset/custody group when an exact factor crosses atomic native units, and set
   overflow native units to original minus retained units;
@@ -273,8 +281,14 @@ provenance. It is not a user credit, fee, revenue, or payable.
 For any number of overlapping project initial lots, including zero and one:
 
 ```text
-sum(canonical_retained_initial_lot + total_overlap_cap_overflow_lot) =
-  aggregate_initial_claim
+sum(canonical_retained_minor_lot + canonical_overflow_minor_lot) =
+  sum(canonical_initial_minor_lot)
+
+exact_initial_source_lot =
+  exact_retained_source_lot + exact_overflow_source_lot
+
+canonical_initial_minor_lot =
+  canonical_retained_minor_lot + canonical_overflow_minor_lot
 
 raw_proportional_retained_target = min(aggregate_initial_claim, 3 * baseline)
 
@@ -282,10 +296,15 @@ canonical_pre_redistribution_current =
   min(floor_to_allocation_minor_unit(raw_proportional_retained_target),
       floor_to_allocation_minor_unit(3 * baseline))
 
-funded_epoch_pool =
-  sum(canonical_retained_initial_lot)
-  + sum(score_discount_pool_contribution)
-  + sum(total_overlap_cap_overflow_lot)
+exact_funded_epoch_pool =
+  sum(exact_retained_source_lot)
+  + sum(exact_score_discount_pool_lot)
+  + sum(exact_overflow_source_lot)
+
+canonical_funded_epoch_minor_units =
+  sum(canonical_retained_minor_lot)
+  + sum(canonical_score_discount_minor_lot)
+  + sum(canonical_overflow_minor_lot)
 ```
 
 These identities must hold separately in exact decimals and integer functional-USD minor units,
@@ -296,14 +315,34 @@ retained totals, overflow totals, final allocations, or the result hash.
 
 Four source lots of `$0.335` produce aggregate initial `$1.34`, baseline `$0.335`,
 exact cap `$1.005`, and canonical cent cap `$1.00`. Raw proportional retention is
-`$0.25125` per source, totaling `$1.005`; cap-aware canonical retained-lot rounding emits four
+`$0.25125` per source, totaling `$1.005`, with `$0.08375` exact overflow per
+source and `$0.335` exact overflow total. Cap-aware canonical retained-lot rounding emits four
 `$0.25` retained lots totaling `$1.00`, never `$1.01`. The exact `$0.005` retained
-target remainder that cannot cross the cent cap becomes source-linked cap-floor
-overflow alongside `$0.335` of proportional source-lot differences. Thus exact and
-integer-cent overflow are both `$0.34`; if it cannot fund another uncapped user, it
-becomes source-linked residue. Exact-decimal conservation is `$1.00 + $0.34 = $1.34`,
-and the integer-cent ledger independently conserves 100 + 34 = 134 cents without losing or
-double-assigning a fraction or cent.
+target remainder is recorded separately with source provenance and joins the
+canonical pool/residue bridge. The exact ledger conserves
+`$1.005 + $0.335 = $1.34`; the canonical ledger independently conserves
+100 retained + 34 overflow = 134 cents. No source has negative overflow, and no
+fraction or cent is lost or assigned twice.
+
+### Non-negative Source-lot Counterexample
+
+Two exact retained source lots of `$0.006` have a one-cent canonical retained
+target. First derive canonical initial capacity from the exact funded total: stable
+largest remainder assigns one initial cent to the lower stable source ID and zero
+to the other. Constrained retained rounding assigns that one cent only to the
+one-cent-capacity source; canonical overflow is zero for both, never `-$0.004`.
+The exact ledger independently records `$0.006 = $0.006 + $0` for each source.
+The cross-source rounding transfer and remaining `$0.002` sub-minor residual stay
+source-provenanced outside exact overflow and reconcile the exact `$0.012` total to
+the canonical one-cent total.
+
+### One-cent Equal-current Tie Fixture
+
+Two uncapped users have the same exact current total, equal capacity, and exact
+top-up targets of `$0.005` each when one canonical cent remains. Continuous
+water-filling treats them equally. Their fractional remainders tie, so the lower
+stable user ID receives the cent; aggregate initial claim and baseline are ignored.
+Reversing user or source input order produces the same recipient and result hash.
 
 ## Canonical A+B Fixture
 
@@ -370,11 +409,12 @@ The calculation artifact contains at least:
 - eligible project-user counts and theoretical shares;
 - locked score, locked maximum score, and score factor;
 - initial project claims and project pool contributions;
-- aggregate initial claims, baselines, caps, retention factors, retained initial
-  lots, and overlap-cap overflow lots;
+- aggregate initial claims, exact and canonical caps, retention factors, separate
+  exact/canonical initial-retained-overflow source lots, and sub-minor residuals;
 - ordered water-filling steps and redistribution top-ups;
 - final provisional allocations and cap status;
-- stable rounding decisions and asset/source fills;
+- stable exact/canonical rounding decisions, constrained source capacities,
+  sub-minor residual transfers, and asset/source fills;
 - returned or carryover residue with complete provenance;
 - excluded users and typed reason codes;
 - conservation, privacy, and production-gate results; and
@@ -394,9 +434,12 @@ Verification must prove:
 - every user and score/max pair was eligible and locked;
 - equal theoretical shares, score-adjusted claims, pre-redistribution cap clamps,
   retained lots, and both pool-contribution classes recompute;
-- water-filling order, ties, caps, and rounding reproduce deterministically;
-- `final_allocation <= 3 * baseline` for every user;
-- every original initial lot equals its retained lot plus overlap-cap overflow;
+- continuous equal-current water-filling and the sole minor-unit tie rule reproduce
+  deterministically under user/source input permutation;
+- `final_allocation_minor <= floor_to_minor_unit(3 * baseline)` for every user;
+- every exact initial lot equals non-negative exact retained plus exact overflow;
+- every canonical initial lot equals bounded canonical retained plus non-negative
+  canonical overflow;
 - funded pool equals retained initial lots plus score-discount contributions plus
   overlap-cap overflow;
 - score-discount contributions plus overlap-cap overflow equal top-ups plus

--- a/docs/engineering/allocation.md
+++ b/docs/engineering/allocation.md
@@ -1,225 +1,292 @@
 # Allocation Architecture
 
-Last updated: 2026-07-20
+Last updated: 2026-08-09
 
 Related docs:
+
 - [Engineering Docs Index](./README.md)
 - [Operational MVP](./operational-mvp.md)
 - [Monthly Cycle Domain Model](./monthly-cycles.md)
+- [Settlement-backed Epoch Treasury](./settlement-backed-epoch-treasury.md)
 - [Outbound Payout Domain](./payouts.md)
 
 ## Summary
 
-FundLoop allocation converts confirmed monthly project contribution pools into user-visible bookkeeping credits. For the operational MVP, allocation is not a simple proportional payout. It is a deterministic, USD-normalized, capped equalization process followed by preference-based asset fulfillment.
+FundLoop allocation converts fee-processed, settled, journal-backed project value
+into provisional user awards. The approved Goal #134 model is a deterministic,
+USD-normalized Cubid-score discount followed by one global epoch redistribution:
 
-The allocator must be implemented as a pure calculation package first. It should accept a locked monthly manifest and price snapshot, produce deterministic outputs and hashes, and avoid live reads or writes. Database persistence, artifact storage, verification, and bookkeeping credits are separate workflow stages.
+1. divide each funded project pool equally among that project's eligible users;
+2. discount each theoretical share by the user's locked Cubid score divided by the
+   locked maximum score;
+3. aggregate score-adjusted initial claims across projects;
+4. combine every project shortfall into one epoch redistribution pool;
+5. raise the lowest current user totals first through deterministic water-filling;
+6. stop each user at three times that user's largest single-project initial claim;
+7. return or carry forward any cap-exhausted residue to its originating funded
+   sources.
 
-## Inputs
+This model explicitly supersedes allocation based on a user's share of total
+project points, the sum of eligible scores, or an overlap-derived remainder. A
+Cubid score is an individual factor against an equal theoretical project share; it
+is not a proportional weight against other users' scores.
 
-The allocator consumes only locked monthly-cycle inputs:
+The allocator remains a pure calculation package. It consumes one immutable lock
+manifest, produces deterministic artifacts and hashes, and performs no live reads,
+provider calls, posting, or value transfer.
 
-- confirmed available project contribution amounts for the cycle
-- project/currency/token pool identity and source amounts
-- system price snapshot for USD normalization
-- approved attribution datasets for the cycle
-- scoped CUBID identity references on attribution rows
-- CUBID-linked user eligibility snapshot captured at lock time
-- user asset preferences captured at lock time
-- deterministic project, user, asset, and cycle identifiers
+## Locked Inputs
 
-Unconfirmed commitments, unresolved receivables, draft attribution data, and post-lock identity/preference changes are not allocation inputs.
+The allocator consumes only immutable, versioned inputs:
 
-## Eligibility
+- approved project packages and eligible project-user cohorts;
+- fee-processed funding applications backed by reconciled custody and ledger
+  postings;
+- source lots identified by project, rail, asset, native amount, custody context,
+  FX snapshot, and functional USD;
+- one positive, versioned locked maximum Cubid score;
+- each eligible user's locked score, bounded from zero through that maximum;
+- project-scoped pseudonymous identity references and inclusion evidence;
+- the epoch FX snapshot and deterministic minor-unit rules;
+- user asset preferences and payout eligibility for later fulfillment only; and
+- stable project, user, source-lot, asset, and epoch identifiers.
 
-A user is eligible for a project/month allocation only when all of these are true:
+Declared contribution amounts, mutable activity points, unconfirmed receipts,
+unresolved receivables, draft cohorts, post-lock identity changes, and
+post-lock preference changes are not canonical allocation inputs. A project with
+no eligible users does not contribute value to the global pool; its funded sources
+follow the explicit return or carryover workflow.
 
-- the user is CUBID-linked at lock time
-- the user appears in an approved attribution dataset for the contributing project/month
-- the attribution row includes the scoped CUBID identity for that project/protocol context
-- the attribution row resolves to the FundLoop user identity included in the locked manifest
+## Eligibility And Privacy
 
-For the MVP, a protocol is equivalent to a FundLoop project. If a later version supports multiple protocols under one project, that must become an explicit input dimension and should not be inferred from project metadata.
+A user is eligible for a project only when the locked package proves a valid,
+whitelisted Cubid identity, approved project-scoped inclusion, and resolution to
+the FundLoop user represented in the manifest. Greylisted, blacklisted, invalid,
+expired, or unresolved evidence follows the versioned exclusion or hold rules.
 
-## Attribution Visibility And zkActivitySum Path
+Operators may inspect the complete audit graph. A project sees only its own
+project-scoped pseudonyms, inputs, and outcomes. Users see only their own
+project-source breakdown. Project and public read models must not expose raw Cubid
+evidence, cross-project membership, another project's pseudonym, or a join key that
+reveals the overlap used by redistribution. Public reporting remains aggregate and
+subject to the approved anti-correlation thresholds.
 
-The MVP intentionally preserves internal project-level transparency. Operators can inspect approved attribution rows, project contribution pools, and allocation outputs directly. Founders can inspect the attribution data they submit for their own managed projects. This is an explicit operational tradeoff so the first monthly bookkeeping cycle can be debugged and verified without depending on a privacy proof system.
+## Funded Source Model
 
-Even before zkActivitySum is implemented, MVP attribution submissions must include a scoped CUBID identity for each attributed user. When available, attribution rows may also include the resolved FundLoop user id for operator/debug usability. The scoped CUBID identity is required because it is the forward-compatible bridge to privacy-preserving attribution.
+Each post-fee distributable source remains an immutable provenance lot containing:
 
-zkActivitySum is the planned replacement for raw attribution visibility. In that future mode, projects submit app/project-scoped activity scores tied to scoped CUBID identities, and users or the system produce aggregate activity proofs without exposing the user's full cross-project activity graph.
+- `epochId` and `originProjectId`;
+- rail, asset, custody account, and external/funding reference;
+- exact native quantity and asset decimals;
+- locked FX snapshot and exact functional-USD value;
+- carryover origin and predecessor lot when applicable; and
+- manifest position and stable source-lot key.
 
-Future zkActivitySum ingest should be modeled as an interchangeable attribution source, not as a separate allocator. Allowed verifier backends are:
+The global redistribution pool is a calculated total over these lots, not an
+untracked fungible balance. Project shortfalls create source-linked pool lots.
+Top-ups consume those lots in a versioned stable order and record partial-lot
+splits. Unconsumed lots retain their original project, rail, asset, native, FX, and
+USD dimensions when returned or carried forward.
 
-- `tee`
-- `zk`
-
-The MVP does not choose between TEE and ZK. During attribution schema work, it is acceptable to reserve proof fields only if they fit naturally:
-
-- `proof_type`
-- `proof_artifact_uri`
-- `verifier_backend`
-- `verification_status`
-
-Public product copy should not claim zkActivitySum or privacy-preserving attribution is live until that implementation exists.
-
-## Pool Model
-
-Project contribution pools remain operationally separate by source asset or currency. The allocator also normalizes each pool to USD using the cycle price snapshot so users can be compared and equalized across projects and assets.
-
-Required pool fields:
-
-- `projectId`
-- `cycleKey`
-- `assetType`
-- `assetCode`
-- `sourceAmount`
-- `usdValue`
-- `priceSnapshotId` or equivalent deterministic price reference
-- `availableSourceAmount`
-
-Only confirmed available amounts are distributable. If an amount cannot be fulfilled into user credits because of preference or supply constraints, the unfulfilled value returns to the contributing project's future pool rather than becoming a user credit.
+Redistribution principal is funded epoch value. It is never classified as a
+platform fee, platform revenue, treasury sweep, user payable, or newly created
+value. Fee recognition and treasury sweeps occur before the distributable project
+pool is measured.
 
 ## Allocation Algorithm
 
-### 1. Raw Project Entitlements
+All equations use exact decimal functional USD until the rounding stage.
 
-For each project pool, compute each eligible user's raw project entitlement from approved attribution points:
+### 1. Equal Theoretical Project Share
 
-```text
-user_project_raw_usd =
-  project_pool_usd * user_project_points / total_eligible_project_points
-```
-
-Users without eligible approved attribution for a project receive no raw entitlement from that project.
-
-### 2. User Baseline
-
-For each user, compute the baseline as the largest single-project raw entitlement:
+For each funded project `p`:
 
 ```text
-user_baseline_usd = max(user_project_raw_usd values)
+theoretical_share(p) = funded_project_pool_usd(p) / eligible_user_count(p)
 ```
 
-This baseline protects the strongest protocol/project-specific earning a user would have received without cross-project equalization.
+Every eligible user in the same project receives the same theoretical share before
+the Cubid factor. Project activity points and the sum of cohort scores do not alter
+this share.
 
-Invariant:
+### 2. Score-adjusted Initial Project Claim
+
+For eligible user `u` in project `p`:
 
 ```text
-sum(user_baseline_usd) <= total_monthly_pool_usd
+score_factor(u,p) = locked_score(u,p) / locked_max_score
+initial_project_claim(u,p) = theoretical_share(p) * score_factor(u,p)
+project_pool_contribution(u,p) = theoretical_share(p) - initial_project_claim(u,p)
 ```
 
-The sum should be lower than the total pool when users overlap across projects, and equal only when every eligible user has attribution in exactly one project. If the baseline sum is greater than the total monthly pool, the allocator must fail with a deterministic invariant error rather than silently scaling or inventing a fallback rule.
+The maximum score must be positive and versioned. A score outside
+`0 <= locked_score <= locked_max_score` is a hard failure. The score-adjusted claim
+and its shortfall retain the funded source mix of the theoretical share.
 
-### 3. Remainder
-
-The equalization remainder is:
+For every project:
 
 ```text
-remainder_usd = total_monthly_pool_usd - sum(user_baseline_usd)
+funded_project_pool_usd =
+  sum(initial_project_claim) + sum(project_pool_contribution)
 ```
 
-If the remainder is zero, final USD allocations equal baselines and the allocator proceeds directly to rounding and asset fulfillment.
+### 3. Aggregate Initial Claim And Baseline
 
-### 4. Capped Equalization
-
-Distribute the remainder globally in USD to users with the lowest current allocations first. This is the MVP's basic-income equalization layer: users who would otherwise receive the least from poorer or smaller protocols receive top-ups before users with higher baselines.
-
-Each user's final allocation is capped at:
+For each user:
 
 ```text
-user_final_cap_usd = 3 * user_baseline_usd
+aggregate_initial_claim(u) = sum(initial_project_claim(u,p))
+baseline(u) = max(initial_project_claim(u,p))
+final_cap(u) = 3 * baseline(u)
 ```
 
-The cap is on final allocation, not only on the top-up. A user with a `100 USD` baseline can receive at most `300 USD` total for the cycle.
+The baseline is the largest single-project score-adjusted initial claim. It is not
+the aggregate initial claim, a raw point-proportional entitlement, or a value
+derived from project overlap.
 
-Tie-breaking must be deterministic. Recommended order:
+### 4. Global Epoch Redistribution Pool
 
-1. lowest current allocation
-2. lowest baseline
-3. stable user id sort
+```text
+epoch_redistribution_pool = sum(project_pool_contribution(u,p))
+```
 
-If every eligible user reaches their cap and some remainder still exists, the remainder is returned to project future pools through deterministic returned-pool rows.
+All included project shortfalls enter this one pool. They do not remain restricted
+to users of the originating project, but their source provenance remains intact.
 
-### 5. Rounding
+### 5. Lowest-current-total-first Water-filling
 
-Rounding happens after USD normalization and final USD allocation.
+Initialize each user's current total to `aggregate_initial_claim(u)`. Repeatedly:
 
-Rules:
+1. select uncapped users with the lowest current total;
+2. raise the tied lowest group together toward the next-lowest current total or a
+   member's cap, whichever comes first;
+3. consume no more than the remaining redistribution pool;
+4. remove capped users and continue until the pool is exhausted or no user has cap
+   capacity.
 
-- use integer minor USD units for canonical credited USD values
-- keep exact decimal intermediate values in the artifact
-- assign residuals deterministically by descending fractional remainder, then stable user id sort
-- reconcile rounded allocations plus returned amounts to the confirmed monthly pool USD
+Deterministic ordering is:
 
-Asset-specific source amounts may have different minor-unit rules. The asset fulfillment stage must apply those rules separately while preserving the canonical USD-equivalent reconciliation.
+1. lowest current total;
+2. lowest aggregate initial claim;
+3. lowest baseline; and
+4. stable user ID.
+
+Exact-decimal water-filling treats a tied group equally. Stable user ID is used
+only where indivisible minor units or an otherwise exact tie require assignment.
+No final allocation may exceed `3 * baseline`.
+
+### 6. Returned Or Carried-forward Residue
+
+If every eligible user reaches the cap before the pool is exhausted:
+
+```text
+epoch_redistribution_pool =
+  sum(redistribution_top_up) + sum(returned_or_carryover_residue)
+```
+
+Residue is emitted as deterministic source-linked rows and returns or carries
+forward under the originating lot's project, rail, asset, native, FX, and USD
+provenance. It is not a user credit, fee, revenue, or payable.
+
+### 7. Rounding
+
+- preserve exact decimal theoretical shares, claims, pool lots, and water levels in
+  the artifact;
+- round canonical user awards in integer minor USD units only after water-filling;
+- assign user residual minor units by descending fractional remainder, then stable
+  user ID;
+- split source-lot native quantities under the asset's exact atomic-unit rules;
+- assign source residuals through the versioned stable lot order; and
+- prove rounded user awards plus rounded returned residue equal the rounded funded
+  pool, while native source quantities conserve exactly.
+
+## Canonical A+B Fixture
+
+Project A has `$300`, three eligible users, locked scores `5`, `10`, and `15`, and a
+locked maximum score of `20`.
+
+```text
+theoretical share per A user = $300 / 3 = $100
+initial A claims             = $25, $50, $75
+A pool contributions         = $75, $50, $25
+A redistribution total       = $150
+```
+
+Project B has `$1,000` and 100 eligible users. In the canonical deterministic
+fixture each B user is locked at `10/20`, so the `$10` theoretical share becomes a
+`$5` initial claim.
+
+```text
+aggregate B initial claims   = 100 * $5 = $500
+B redistribution total       = $500
+combined epoch pool          = $150 + $500 = $650
+```
+
+The three A users are also B users. Their aggregate initial claims are `$30`, `$55`,
+and `$80`; their baselines are `$25`, `$50`, and `$75`. The other 97 B-only users
+each begin at `$5`, with a `$5` baseline and `$15` cap. Lowest-current-total-first
+water-filling therefore sends the entire `$650` to the 97 B-only users before any
+A+B user. Exact top-up is `$650 / 97`; after cent rounding, 10 stable user IDs
+receive `$6.71` and 87 receive `$6.70`. No user reaches the `$15` cap, no A+B user
+receives a top-up, and no residue remains.
 
 ## Asset Fulfillment
 
-After final USD-equivalent allocation, FundLoop fulfills each user's credit through accepted asset preferences.
+Asset preferences affect later source fulfillment only; they never change the USD
+allocation. Fulfillment consumes eligible source lots in the approved deterministic
+order, may split a user's award across accepted assets, and must retain the exact
+project/rail/asset/native/FX/USD source fills. Unfulfillable value follows the same
+source-linked return or carryover rules and is not presented as a user award.
 
-Rules:
+## Deterministic Outputs
 
-- choose the user's highest-priority accepted asset that is available
-- if that asset has insufficient supply, partially fill it and continue to the next accepted asset
-- continue until the user's allocation is fully filled or no accepted available asset remains
-- unfulfillable value returns to the contributing project's future pool
-- preferences affect asset fulfillment only; they do not change the user's USD-equivalent allocation
+The calculation artifact contains at least:
 
-Issue #70 stores these preferences in `user_asset_preferences` and updates them through the `user-asset-preferences-update` Edge Function command. The rank order is canonical and deterministic. A missing custom preference set means default fulfillment order is stablecoin, fiat, then project tokens. The table intentionally stores asset intent only, not payout destinations or transfer instructions.
+- funded project pools and immutable source lots;
+- eligible project-user counts and theoretical shares;
+- locked score, locked maximum score, and score factor;
+- initial project claims and project pool contributions;
+- aggregate initial claims, baselines, and caps;
+- ordered water-filling steps and redistribution top-ups;
+- final provisional allocations and cap status;
+- stable rounding decisions and asset/source fills;
+- returned or carryover residue with complete provenance;
+- excluded users and typed reason codes;
+- conservation, privacy, and production-gate results; and
+- canonical input, result, and root hashes.
 
-The output may contain multiple asset fills for one user result when fallback preferences are needed. The user-facing product may show those fills as one credited result with a breakdown.
-
-## Outputs
-
-Issue #76 introduced the pure allocator at `lib/monthly-cycles/mvp-distribution-calculator.ts`. It is intentionally runtime-agnostic and does not import the server-only monthly-cycle index. The calculation package command should call this module in the next persistence slice, then store the returned artifact and rows without recalculating the policy differently.
-
-The pure allocator returns a deterministic structure containing:
-
-- total monthly pool USD
-- source asset/currency pool summary
-- raw per-project user entitlements
-- user baselines
-- equalization top-ups
-- final capped USD allocations
-- rounding residual decisions
-- asset fill instructions
-- returned future-pool rows
-- excluded users and reason codes
-- warnings and invariant checks
-- stable hash input and result hash
-
-The calculation package command persists artifacts and rows from this output, but it must not recalculate with different rules.
+The current point-proportional calculator and its old raw-entitlement/remainder
+outputs are legacy compatibility surfaces. Task #136 must replace or version them;
+they cannot be the canonical Goal #134 result and must remain production-disabled.
 
 ## Verification Requirements
 
-Verification must check:
+Verification must prove:
 
-- locked manifest hash matches the calculation input
-- price snapshot reference is stable
-- all included contribution pools are confirmed and cycle-linked
-- all included attribution datasets are approved and cycle-linked
-- all included users were CUBID-linked at lock time
-- final allocation does not exceed `3x` baseline for any user
-- allocated USD plus returned future-pool USD reconciles to the confirmed monthly pool USD
-- asset fills respect accepted preference order and recorded availability constraints
-- returned future-pool amounts are not presented as user credits
-- artifact hashes exist and match persisted result rows
+- the exact locked manifest hash was consumed;
+- every project dollar is settled, applied, journal-backed, fee-processed, and
+  linked to immutable source provenance;
+- every user and score/max pair was eligible and locked;
+- equal theoretical shares, score-adjusted claims, and pool contributions recompute;
+- water-filling order, ties, caps, and rounding reproduce deterministically;
+- `final_allocation <= 3 * baseline` for every user;
+- funded pool equals initial claims plus pool contributions;
+- pool contributions equal top-ups plus returned/carryover residue;
+- final allocations equal initial claims plus top-ups;
+- native, FX, and functional-USD source conservation all hold;
+- project/public outputs cannot reveal cross-project membership; and
+- production allocation, payable posting, provider calls, and real value flow are
+  fail-closed.
 
-## User-Facing Reporting
+## Reporting Boundary
 
-User earnings surfaces should show:
+User reporting may show the user's provisional total and permitted project/source
+breakdown. Founder reporting may show only that founder's project cohort and
+aggregate source/pool results. Public reporting may show approved aggregate project
+and epoch totals only after privacy thresholds pass. Authorized operators may see
+the full provenance and overlap evidence.
 
-- credited asset amount or amounts
-- USD-equivalent total
-- contributing project/protocol breakdown
-- source-currency breakdown where relevant
-- clear `credited` and `not paid yet` language
-
-Founder and operator surfaces should additionally show:
-
-- project/cycle credited totals
-- returned future-pool totals
-- asset pool utilization
-- calculation artifact hash and verification state
-
-No surface should claim that a transfer or payout has occurred during the operational MVP.
+Allocation and approval are conditional internal records. They do not create user
+ownership, a general-ledger payable, an external transfer, or a production value
+flow. Production activation remains blocked on the named accounting, legal,
+privacy, custody, and payout gates.

--- a/docs/engineering/allocation.md
+++ b/docs/engineering/allocation.md
@@ -140,10 +140,13 @@ For each user:
 ```text
 aggregate_initial_claim(u) = sum(initial_project_claim(u,p))
 baseline(u) = max(initial_project_claim(u,p))
-final_cap(u) = 3 * baseline(u)
+exact_final_cap(u) = 3 * baseline(u)
+minor_unit_cap(u) = floor_to_allocation_minor_unit(exact_final_cap(u))
 ```
 
-The baseline is the largest single-project score-adjusted initial claim. It is not
+The baseline is the largest single-project score-adjusted initial claim. The
+canonical executable cap is `minor_unit_cap`, never a nearest-rounded or ceiling
+version of the exact cap. It is not
 the aggregate initial claim, a raw point-proportional entitlement, or a value
 derived from project overlap. A user with a zero baseline has a zero cap.
 
@@ -153,26 +156,36 @@ The cap applies before redistribution as well as after it. For every user:
 
 ```text
 retention_factor(u) =
-  1                                      when aggregate_initial_claim(u) <= final_cap(u)
-  final_cap(u) / aggregate_initial_claim(u)  otherwise
+  1                                        when aggregate_initial_claim(u) <= exact_final_cap(u)
+  exact_final_cap(u) / aggregate_initial_claim(u)  otherwise
 
-retained_initial_lot(u,p,source) =
+proportional_retained_initial_lot(u,p,source) =
   initial_project_source_lot(u,p,source) * retention_factor(u)
 
-overlap_cap_overflow_lot(u,p,source) =
-  initial_project_source_lot(u,p,source) - retained_initial_lot(u,p,source)
+proportional_overlap_overflow_lot(u,p,source) =
+  initial_project_source_lot(u,p,source)
+  - proportional_retained_initial_lot(u,p,source)
 
-pre_redistribution_current(u) = sum(retained_initial_lot(u,p,source))
+raw_retained_target(u) = sum(proportional_retained_initial_lot(u,p,source))
+canonical_retained_target(u) =
+  min(floor_to_allocation_minor_unit(raw_retained_target(u)), minor_unit_cap(u))
 ```
 
-Therefore `pre_redistribution_current = min(aggregate_initial_claim, final_cap)`.
+The raw proportional target is `min(aggregate_initial_claim, exact_final_cap)`.
+The canonical retained target is the lesser of its floored minor-unit value and
+`minor_unit_cap`; retained-lot rounding may never produce a total above that target
+or cap. Allocate canonical retained source lots up to that target. The difference
+between every proportional retained lot and its canonical retained lot is
+`cap_floor_overflow`; total source-linked overlap overflow is proportional overlap
+overflow plus cap-floor overflow. Canonical pre-redistribution current is
+`sum(canonical_retained_initial_lot)`, never the higher raw target.
 When aggregate initial value exceeds the cap, each project/source initial lot is
 scaled by the same exact factor. Each lot's exact difference becomes
 source-preserving overlap-cap overflow in the global pool. The clamp may not choose
 one project to absorb another project's overflow or erase rail, asset, native, FX,
 or USD provenance.
 
-A user whose pre-redistribution current equals the cap is not a water-filling
+A user whose canonical pre-redistribution current equals the minor-unit cap is not a water-filling
 candidate. With non-negative initial lots, a zero baseline means every initial lot
 is zero; the user has cap zero, retains zero, and receives no redistribution top-up.
 
@@ -181,7 +194,7 @@ is zero; the user has cap zero, retains zero, and receives no redistribution top
 ```text
 epoch_redistribution_pool =
   sum(score_discount_pool_contribution(u,p,source))
-  + sum(overlap_cap_overflow_lot(u,p,source))
+  + sum(total_overlap_cap_overflow_lot(u,p,source))
 ```
 
 All included score-discount shortfalls and overlap-cap overflow enter this one pool.
@@ -208,7 +221,7 @@ Deterministic ordering is:
 
 Exact-decimal water-filling treats a tied group equally. Stable user ID is used
 only where indivisible minor units or an otherwise exact tie require assignment.
-No final allocation may exceed `3 * baseline`, and a user that begins at cap receives
+No final allocation may exceed `minor_unit_cap`, and a user that begins at cap receives
 no top-up.
 
 ### 7. Returned Or Carried-forward Residue
@@ -232,6 +245,15 @@ provenance. It is not a user credit, fee, revenue, or payable.
 - for retained functional-USD source lots, floor each exact minor-unit amount and
   assign the residual needed to reach the rounded retained-total target by
   descending fractional remainder, then stable project/rail/asset/source-lot key;
+  the target is floored and bounded by `minor_unit_cap`;
+- make every retained-lot and final-award residual assignment cap-aware: skip a
+  user/source assignment whenever its next unit would make the user's retained or
+  final total exceed `minor_unit_cap`;
+- move every exact fractional remainder or candidate minor unit rejected by that
+  cap, with its original project/rail/asset/native/FX/USD provenance, into
+  cap-floor overflow; together with proportional overlap overflow it may fund
+  another eligible uncapped user and, if still
+  unassignable, becomes source-linked returned/carryover residue;
 - derive each rounded overflow lot as original rounded source amount minus its
   rounded retained amount, so retained plus overflow always equals the source;
 - apply the same largest-remainder and stable-key rule within each
@@ -239,31 +261,49 @@ provenance. It is not a user credit, fee, revenue, or payable.
   overflow native units to original minus retained units;
 - round canonical user awards in integer minor USD units only after water-filling;
 - assign user residual minor units by descending fractional remainder, then stable
-  user ID;
+  user ID, skipping capped candidates rather than crossing their cap;
 - split source-lot native quantities under the asset's exact atomic-unit rules;
 - assign source residuals through the versioned stable lot order; and
-- prove rounded user awards plus rounded returned residue equal the rounded funded
-  pool, while native source quantities conserve exactly.
+- prove exact source decimals conserve and, independently, integer minor-unit user
+  awards plus integer minor-unit pool/residue equal the integer minor-unit funded
+  pool. No fractional or integer unit may be lost or assigned twice.
 
 ### 9. Arbitrary-overlap Invariants
 
 For any number of overlapping project initial lots, including zero and one:
 
 ```text
-sum(retained_initial_lot + overlap_cap_overflow_lot) =
+sum(canonical_retained_initial_lot + total_overlap_cap_overflow_lot) =
   aggregate_initial_claim
 
-pre_redistribution_current = min(aggregate_initial_claim, 3 * baseline)
+raw_proportional_retained_target = min(aggregate_initial_claim, 3 * baseline)
+
+canonical_pre_redistribution_current =
+  min(floor_to_allocation_minor_unit(raw_proportional_retained_target),
+      floor_to_allocation_minor_unit(3 * baseline))
 
 funded_epoch_pool =
-  sum(retained_initial_lot)
+  sum(canonical_retained_initial_lot)
   + sum(score_discount_pool_contribution)
-  + sum(overlap_cap_overflow_lot)
+  + sum(total_overlap_cap_overflow_lot)
 ```
 
-These identities must hold in exact decimals, rounded functional-USD minor units,
+These identities must hold separately in exact decimals and integer functional-USD minor units,
 and exact native atomic units. Permuting project/source input order cannot change
 retained totals, overflow totals, final allocations, or the result hash.
+
+### Fractional Cap Fixture
+
+Four source lots of `$0.335` produce aggregate initial `$1.34`, baseline `$0.335`,
+exact cap `$1.005`, and canonical cent cap `$1.00`. Raw proportional retention is
+`$0.25125` per source, totaling `$1.005`; cap-aware canonical retained-lot rounding emits four
+`$0.25` retained lots totaling `$1.00`, never `$1.01`. The exact `$0.005` retained
+target remainder that cannot cross the cent cap becomes source-linked cap-floor
+overflow alongside `$0.335` of proportional source-lot differences. Thus exact and
+integer-cent overflow are both `$0.34`; if it cannot fund another uncapped user, it
+becomes source-linked residue. Exact-decimal conservation is `$1.00 + $0.34 = $1.34`,
+and the integer-cent ledger independently conserves 100 + 34 = 134 cents without losing or
+double-assigning a fraction or cent.
 
 ## Canonical A+B Fixture
 

--- a/docs/engineering/operational-mvp.md
+++ b/docs/engineering/operational-mvp.md
@@ -219,14 +219,14 @@ Definitions:
 
 - Monthly pool USD = system-price-normalized value of confirmed available project contribution pools.
 - Project pool USD = each project's confirmed available contribution amount normalized through the cycle price snapshot.
-- Eligible user = CUBID status `linked` or `verified` at lock time with approved attribution for the contributing project/month.
+- Eligible user = CUBID status `linked` or `verified` at lock time and membership in the approved locked project package/cohort for that month. Historical attribution rows may support cohort evidence, but attribution points do not weight eligibility or allocation.
 - Theoretical project share = the funded project pool divided equally across that project's eligible users.
 - Initial project claim = theoretical project share multiplied by locked Cubid score divided by the versioned locked maximum score.
 - Project pool contribution = theoretical project share minus the initial project claim; all contributions enter one global epoch redistribution pool.
 - Aggregate initial claim = the sum of one user's score-adjusted initial project claims.
 - User baseline = the largest single-project score-adjusted initial claim for that user.
 - Exact user cap = `3 ×` baseline; canonical minor-unit cap = floor of that exact cap to the allocation minor unit. Before redistribution, aggregate initial claim is clamped, and neither retained-lot nor final-award rounding may cross the canonical cap.
-- Raw proportional retained source lot = initial project/source lot multiplied by `min(1, exact cap / aggregate initial claim)`. Canonical retained lots sum to the floored minor-unit target; proportional source differences plus cap-floor differences form source-linked overlap-cap overflow.
+- Raw proportional retained source lot = exact initial project/source lot multiplied by `min(1, exact cap / aggregate initial claim)`; its non-negative exact difference is exact overflow. Canonical initial/retained/overflow units are derived independently, while the source-provenanced sub-minor residual bridges exact and canonical totals.
 - Global epoch redistribution pool = score-discount project pool contributions plus overlap-cap overflow.
 - Pre-redistribution current = the canonical retained target: floor `min(aggregate initial claim, exact cap)` to the allocation minor unit and bound it by the floored minor-unit cap. A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
 - User final allocation = pre-redistribution current plus the deterministic lowest-current-total-first water-filling top-up, never above the cap.
@@ -245,14 +245,17 @@ cross-project overlap.
 
 Rounding:
 
+- Maintain separate exact-decimal and canonical integer-minor-unit source ledgers. Every exact source satisfies non-negative `exact initial = exact retained + exact overflow`.
+- Derive canonical initial source units first against the funded canonical total using descending fractional remainder then stable project/rail/asset/source-lot ID.
 - Calculate exact-decimal cap scaling before rounding.
-- Floor the retained-total target to the allocation minor unit and bound it by the canonical floored cap. Round retained source lots by descending fractional remainder then stable project/rail/asset/source-lot key; skip any next-unit assignment that would cross the user's cap.
+- Floor the retained-total target to the allocation minor unit and bound it by the canonical floored cap. Assign canonical retained units by constrained largest remainder, requiring `0 <= retained minor lot <= initial minor lot` and skipping saturated or zero-capacity lots.
+- Define canonical overflow units only as `initial minor lot - retained minor lot`; they are never negative.
 - Move an exact fraction or candidate minor unit rejected by the cap into the global overflow pool as cap-floor overflow with its original project/rail/asset/native/FX/USD provenance; together with proportional overlap overflow it may fund another uncapped user and otherwise becomes source-linked returned/carryover residue.
-- Derive overflow as original minus retained so each source conserves.
+- Track sub-minor exact residual and deterministic cross-source residual transfers separately with source provenance; never calculate exact overflow from a rounded retained lot.
 - Apply the same stable largest-remainder rule within each rail/asset/custody group for native atomic units.
 - Round after USD normalization.
 - Store exact decimal calculation inputs and rounded credited amounts.
-- Assign award residual deterministically by descending unrounded remainder then stable user id, skipping capped users rather than producing a one-unit cap breach.
+- Exact equal-current users water-fill equally; aggregate initial and baseline do not break their tie. Assign an indivisible award unit only by descending fractional remainder of exact target then stable user ID, skipping capped users and continuing to another eligible user or source-linked residue.
 
 Outputs:
 
@@ -270,14 +273,16 @@ Outputs:
 Acceptance criteria:
 
 - Same locked manifest produces same result hash.
-- Every initial source lot equals retained initial plus overlap-cap overflow.
+- Every non-negative exact initial source lot equals exact retained plus exact overflow; independently, every canonical initial source unit equals bounded canonical retained plus non-negative canonical overflow.
 - Retained initial lots plus score-discount contributions plus overlap-cap overflow equal the funded pool.
 - Top-ups plus returned/carryover residue equal score-discount contributions plus overlap-cap overflow.
 - Final allocations plus returned/carryover residue equal total funded pool USD after deterministic rounding.
 - No retained-lot target or final allocation exceeds the floored minor-unit `3 ×` baseline cap.
 - The canonical A+B fixture uses 100 B users each exactly `10/20`, produces `$150 + $500 = $650` of redistribution, and sends it first to the 97 B-only lowest earners.
 - The four-project overlap fixture `[100,100,100,100]` clamps `$400` to a `$300` cap, retains `$75` per source, and contributes four `$25` overflow lots before water-filling.
-- The fractional fixture with four `$0.335` lots has aggregate `$1.34`, baseline `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, four `$0.25` retained lots, `$0.335 + $0.005 = $0.34` of source-linked overflow/pool value, and never a `$1.01` award.
+- The fractional fixture with four `$0.335` lots has aggregate `$1.34`, baseline `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, four `$0.25` retained lots, `$0.335` exact overflow, 34 canonical overflow cents, and a separately source-linked `$0.005` exact-to-canonical residual; it never awards `$1.01`.
+- The two-`$0.006` retained-lot/one-cent-target counterexample assigns canonical initial capacity first, retains the cent only on that source, produces no negative source overflow, and separately reconciles exact `$0.012` to one canonical cent.
+- The one-cent equal-current-user fixture gives two users exact `$0.005` top-up targets; fractional remainders tie, so stable user ID alone selects the cent and input permutation leaves the result hash unchanged.
 - Arbitrary overlap count and project/source input permutation properties conserve exact decimals, USD minor units, and native atomic units.
 - Cap-aware residual properties prove exact-decimal conservation separately from integer minor-unit conservation, with no lost or double-assigned fractions or units.
 - Ineligible users are excluded with reason codes.
@@ -294,7 +299,7 @@ Verification checks:
 - all included project cohorts and score/max snapshots are approved and locked
 - all included users are CUBID-linked at lock time
 - retained initial lots, both pool-contribution classes, top-ups, and source-linked returned/carryover residue conserve the monthly pool after rounding
-- no user allocation exceeds the `3 ×` baseline cap
+- no user allocation exceeds the floored canonical minor-unit `3 ×` baseline cap
 - users already at cap and zero-baseline users receive no top-up
 - asset fills respect accepted preference order and recorded availability
 - no negative credits

--- a/docs/engineering/operational-mvp.md
+++ b/docs/engineering/operational-mvp.md
@@ -225,7 +225,11 @@ Definitions:
 - Project pool contribution = theoretical project share minus the initial project claim; all contributions enter one global epoch redistribution pool.
 - Aggregate initial claim = the sum of one user's score-adjusted initial project claims.
 - User baseline = the largest single-project score-adjusted initial claim for that user.
-- User final allocation = aggregate initial claim plus the deterministic lowest-current-total-first water-filling top-up, capped at `3 ×` baseline.
+- User cap = `3 ×` baseline. Before redistribution, aggregate initial claim is clamped to the cap.
+- Retained initial source lot = initial project/source lot multiplied by `min(1, cap / aggregate initial claim)`; its exact difference is source-linked overlap-cap overflow.
+- Global epoch redistribution pool = score-discount project pool contributions plus overlap-cap overflow.
+- Pre-redistribution current = `min(aggregate initial claim, cap)`; a user already at cap, including a zero-baseline user at cap zero, receives no top-up.
+- User final allocation = pre-redistribution current plus the deterministic lowest-current-total-first water-filling top-up, never above the cap.
 - Asset fulfillment = selected asset credit fills based on the user's highest-priority accepted available assets.
 - Every initial claim, pool contribution, top-up, and returned/carryover residue retains project, rail, asset, native, FX, and USD provenance.
 
@@ -241,6 +245,9 @@ cross-project overlap.
 
 Rounding:
 
+- Calculate exact-decimal cap scaling before rounding.
+- Round retained source lots by descending fractional remainder then stable project/rail/asset/source-lot key; derive overflow as original minus retained so each source conserves.
+- Apply the same stable largest-remainder rule within each rail/asset/custody group for native atomic units.
 - Round after USD normalization.
 - Store exact decimal calculation inputs and rounded credited amounts.
 - Assign rounding residual deterministically to users by descending unrounded remainder, then stable user id sort.
@@ -249,7 +256,8 @@ Outputs:
 
 - per-user result rows
 - per-project/user theoretical-share, score-factor, and initial-claim rows
-- source-linked pool-contribution and redistribution-top-up rows
+- source-linked retained-initial, score-discount contribution, overlap-cap overflow,
+  and redistribution-top-up rows
 - selected asset fill rows
 - returned/carryover residue rows with originating source provenance
 - total pool USD
@@ -260,10 +268,14 @@ Outputs:
 Acceptance criteria:
 
 - Same locked manifest produces same result hash.
-- Initial claims plus pool contributions equal the funded pool; top-ups plus returned/carryover residue equal pool contributions.
+- Every initial source lot equals retained initial plus overlap-cap overflow.
+- Retained initial lots plus score-discount contributions plus overlap-cap overflow equal the funded pool.
+- Top-ups plus returned/carryover residue equal score-discount contributions plus overlap-cap overflow.
 - Final allocations plus returned/carryover residue equal total funded pool USD after deterministic rounding.
 - No user final allocation exceeds `3 ×` baseline.
-- The canonical A+B fixture produces `$150 + $500 = $650` of redistribution and sends it first to the 97 B-only lowest earners.
+- The canonical A+B fixture uses 100 B users each exactly `10/20`, produces `$150 + $500 = $650` of redistribution, and sends it first to the 97 B-only lowest earners.
+- The four-project overlap fixture `[100,100,100,100]` clamps `$400` to a `$300` cap, retains `$75` per source, and contributes four `$25` overflow lots before water-filling.
+- Arbitrary overlap count and project/source input permutation properties conserve exact decimals, USD minor units, and native atomic units.
 - Ineligible users are excluded with reason codes.
 - Calculation creates artifacts in Supabase Storage and result rows linked to `monthly_cycle_id`.
 
@@ -277,8 +289,9 @@ Verification checks:
 - all included projects have approved packages and reconciled, journal-backed funded sources
 - all included project cohorts and score/max snapshots are approved and locked
 - all included users are CUBID-linked at lock time
-- initial claims, pool contributions, top-ups, and source-linked returned/carryover residue conserve the monthly pool after rounding
+- retained initial lots, both pool-contribution classes, top-ups, and source-linked returned/carryover residue conserve the monthly pool after rounding
 - no user allocation exceeds the `3 ×` baseline cap
+- users already at cap and zero-baseline users receive no top-up
 - asset fills respect accepted preference order and recorded availability
 - no negative credits
 - artifact hashes exist
@@ -415,6 +428,8 @@ Minimum automated coverage:
 - lock manifest includes funded source provenance, approved project cohorts, locked CUBID score/max, and asset preference inputs
 - attribution fixtures include scoped CUBID identity references and resolved FundLoop user mappings
 - canonical A+B fixture produces deterministic score-adjusted claims and `$650` lowest-earner-first redistribution
+- four-project `[100,100,100,100]` fixture retains four `$75` lots, contributes four `$25` overflow lots, and excludes the capped user from top-ups
+- arbitrary overlap count, source-order permutation, zero-baseline, and exact-decimal/minor-unit/native conservation properties
 - rounding residual assignment is deterministic
 - asset fulfillment partial fills and source-linked returned/carryover residue are deterministic
 - verification catches total mismatch, missing artifact, ineligible user, and unapproved dataset

--- a/docs/engineering/operational-mvp.md
+++ b/docs/engineering/operational-mvp.md
@@ -1,6 +1,6 @@
 # FundLoop Operational MVP
 
-Last drafted: 2026-07-20
+Last updated: 2026-08-09
 
 Related docs:
 - [Engineering Docs Index](./README.md)
@@ -22,7 +22,7 @@ The MVP must support:
 - project attribution data submission
 - user signup with CUBID linkage and payout-asset priorities
 - monthly cycle lock
-- deterministic capped equalization allocation
+- deterministic Cubid-discount and capped low-earner redistribution
 - operator verification and approval
 - bookkeeping earnings credited to user accounts
 - no actual payout execution
@@ -200,16 +200,16 @@ Rules:
 
 - Lock uses the existing `monthly-cycle-lock` command boundary.
 - Lock reattaches month-bearing rows to the target cycle before reading.
-- Lock manifest includes cycle identity/bounds, project contribution submissions, confirmed or submitted payment/contribution records, approved attribution datasets with scoped CUBID identity references, eligible users and CUBID snapshot summaries, user asset preference summaries, counts, and checksums.
+- Lock manifest includes cycle identity/bounds, approved project packages, applied and reconciled funding sources, project/rail/asset/native/FX/USD provenance, approved project cohorts with scoped CUBID identity references, eligible users, locked score/max evidence, user asset preference summaries, counts, and checksums.
 - Lock blocks unresolved required inputs by default.
 - Operator override requires explicit reason and audit event.
 
 Acceptance criteria:
 
 - Lock creates deterministic `locked_manifest` and `locked_manifest_hash`.
-- Locked manifest contains all MVP inputs.
+- Locked manifest contains every funded source, eligible project-user count, and score/max input required to reproduce the approved model.
 - Repeated lock attempts fail safely once status is no longer `open`.
-- Calculation work starts from `locked_manifest.mvp_inputs`, including contribution submissions, approved attribution datasets/rows, eligible users, CUBID snapshots, and destination-free asset preference summaries, not from live mutable rows.
+- Calculation work starts from `locked_manifest.mvp_inputs`, including funded source lots, approved project cohorts, eligible users, CUBID score/max snapshots, and destination-free asset preference summaries, not from live mutable rows.
 
 ### 6. Deterministic Allocation Calculation
 
@@ -220,12 +220,24 @@ Definitions:
 - Monthly pool USD = system-price-normalized value of confirmed available project contribution pools.
 - Project pool USD = each project's confirmed available contribution amount normalized through the cycle price snapshot.
 - Eligible user = CUBID status `linked` or `verified` at lock time with approved attribution for the contributing project/month.
-- User raw project entitlement = project pool USD multiplied by the user's approved attribution share within that project.
-- User baseline = the largest single-project raw entitlement for that user.
-- Equalization remainder = monthly pool USD minus the sum of user baselines.
-- User final allocation = baseline plus capped equalization top-up, capped at `3x` the user's baseline.
+- Theoretical project share = the funded project pool divided equally across that project's eligible users.
+- Initial project claim = theoretical project share multiplied by locked Cubid score divided by the versioned locked maximum score.
+- Project pool contribution = theoretical project share minus the initial project claim; all contributions enter one global epoch redistribution pool.
+- Aggregate initial claim = the sum of one user's score-adjusted initial project claims.
+- User baseline = the largest single-project score-adjusted initial claim for that user.
+- User final allocation = aggregate initial claim plus the deterministic lowest-current-total-first water-filling top-up, capped at `3 ×` baseline.
 - Asset fulfillment = selected asset credit fills based on the user's highest-priority accepted available assets.
-- Source-currency/project breakdown is retained for reporting, while canonical credit value is USD equivalent.
+- Every initial claim, pool contribution, top-up, and returned/carryover residue retains project, rail, asset, native, FX, and USD provenance.
+
+This replaces the prior point-proportional share and overlap-derived remainder model.
+Scores are individual discounts against equal project shares, not weights divided by
+the sum of cohort scores. Redistribution principal is not a fee, revenue, treasury
+sweep, or payable.
+
+Until Goal #134's accounting, privacy, custody, and production gates are satisfied,
+this calculation is review-only in local/dev. Production allocation and award
+posting must remain fail-closed, and project/public outputs must not expose user-level
+cross-project overlap.
 
 Rounding:
 
@@ -236,9 +248,10 @@ Rounding:
 Outputs:
 
 - per-user result rows
-- per-project/user attribution rows
+- per-project/user theoretical-share, score-factor, and initial-claim rows
+- source-linked pool-contribution and redistribution-top-up rows
 - selected asset fill rows
-- returned future-pool rows for unfulfillable amounts
+- returned/carryover residue rows with originating source provenance
 - total pool USD
 - source-currency breakdown
 - calculation artifact hash
@@ -247,8 +260,10 @@ Outputs:
 Acceptance criteria:
 
 - Same locked manifest produces same result hash.
-- Allocated USD plus returned future-pool USD equals total monthly pool USD after deterministic rounding.
-- No user final allocation exceeds `3x` baseline.
+- Initial claims plus pool contributions equal the funded pool; top-ups plus returned/carryover residue equal pool contributions.
+- Final allocations plus returned/carryover residue equal total funded pool USD after deterministic rounding.
+- No user final allocation exceeds `3 ×` baseline.
+- The canonical A+B fixture produces `$150 + $500 = $650` of redistribution and sends it first to the 97 B-only lowest earners.
 - Ineligible users are excluded with reason codes.
 - Calculation creates artifacts in Supabase Storage and result rows linked to `monthly_cycle_id`.
 
@@ -259,11 +274,11 @@ Operators review calculated results before credits become visible as approved ea
 Verification checks:
 
 - manifest hash matches calculation package input
-- all included projects have approved contribution submissions
-- all included attribution datasets are approved
+- all included projects have approved packages and reconciled, journal-backed funded sources
+- all included project cohorts and score/max snapshots are approved and locked
 - all included users are CUBID-linked at lock time
-- allocated USD plus returned future-pool USD equals monthly pool USD after rounding
-- no user allocation exceeds the `3x` baseline cap
+- initial claims, pool contributions, top-ups, and source-linked returned/carryover residue conserve the monthly pool after rounding
+- no user allocation exceeds the `3 ×` baseline cap
 - asset fills respect accepted preference order and recorded availability
 - no negative credits
 - artifact hashes exist
@@ -301,7 +316,7 @@ Rules:
 - Credits are created from approved user results.
 - Credits are created through the typed `monthly-cycle-bookkeeping-credits-create` Edge Function command.
 - Credits store selected asset fill amount, canonical USD equivalent amount, and source-currency/project breakdown for reporting.
-- Returned future-pool amounts are recorded separately and are not user credits.
+- Returned/carryover residue is recorded by originating funded source and is not a user credit, fee, revenue, or payable.
 - Credit status starts as `credited`.
 - If existing `payout_intents` are used, they must be presented as bookkeeping/not-paid-yet records unless and until a later payout execution session changes status.
 - User-facing language distinguishes `credited`, `pending payout setup`, `not paid yet`, and `future settlement preference`.
@@ -310,7 +325,7 @@ Acceptance criteria:
 
 - `/workspace/earnings` shows credited earnings by cycle.
 - User can see source breakdown and USD equivalent.
-- Founder/operator views show total credited by cycle/project, returned future-pool amounts, and not-paid status without exposing private payout destinations.
+- Founder/operator views show permitted cycle/project totals, source-linked returned/carryover residue, and not-paid status without exposing private payout destinations or cross-project membership.
 - No UI claims that funds were transferred.
 
 Handoff contract from Goal #58 / issue #81 to Goal #59:
@@ -397,11 +412,11 @@ Minimum automated coverage:
 - contribution submission authorization, period validation, amount validation, and cycle status rejection
 - attribution submission user resolution, approval state, duplicate handling, and cycle linkage
 - user asset priority create/update/reorder/reject-all warning
-- lock manifest includes contribution, attribution, CUBID snapshot, and asset preference inputs
+- lock manifest includes funded source provenance, approved project cohorts, locked CUBID score/max, and asset preference inputs
 - attribution fixtures include scoped CUBID identity references and resolved FundLoop user mappings
-- calculation fixture produces deterministic known capped equalization allocations
+- canonical A+B fixture produces deterministic score-adjusted claims and `$650` lowest-earner-first redistribution
 - rounding residual assignment is deterministic
-- asset fulfillment partial fills and returned future-pool amounts are deterministic
+- asset fulfillment partial fills and source-linked returned/carryover residue are deterministic
 - verification catches total mismatch, missing artifact, ineligible user, and unapproved dataset
 - bookkeeping credit creation is idempotent
 - user earnings workspace renders credited/not-paid states
@@ -425,7 +440,7 @@ Operational MVP is complete only when:
 - a project can submit attribution data
 - a user can sign up, link CUBID, and set asset priorities
 - an operator can lock a cycle
-- the system calculates deterministic capped equalization allocations
+- the system calculates deterministic score-adjusted claims and capped low-earner redistribution
 - an operator can verify and approve results
 - users see credited bookkeeping earnings
 - no actual payout is executed
@@ -434,7 +449,7 @@ Operational MVP is complete only when:
 ## Assumptions And Defaults
 
 - User priorities are payout-asset preferences, not allocation-weight inputs.
-- MVP allocation uses raw project attribution as input, then applies capped global equalization.
+- MVP allocation uses approved project membership plus locked Cubid score/max evidence; mutable activity points and point-proportional cohort weights are superseded.
 - USD equivalent is the canonical bookkeeping credit value.
 - Source-currency amounts are stored and shown for transparency.
 - USD normalization comes from the cycle system price snapshot.

--- a/docs/engineering/operational-mvp.md
+++ b/docs/engineering/operational-mvp.md
@@ -225,10 +225,10 @@ Definitions:
 - Project pool contribution = theoretical project share minus the initial project claim; all contributions enter one global epoch redistribution pool.
 - Aggregate initial claim = the sum of one user's score-adjusted initial project claims.
 - User baseline = the largest single-project score-adjusted initial claim for that user.
-- User cap = `3 ×` baseline. Before redistribution, aggregate initial claim is clamped to the cap.
-- Retained initial source lot = initial project/source lot multiplied by `min(1, cap / aggregate initial claim)`; its exact difference is source-linked overlap-cap overflow.
+- Exact user cap = `3 ×` baseline; canonical minor-unit cap = floor of that exact cap to the allocation minor unit. Before redistribution, aggregate initial claim is clamped, and neither retained-lot nor final-award rounding may cross the canonical cap.
+- Raw proportional retained source lot = initial project/source lot multiplied by `min(1, exact cap / aggregate initial claim)`. Canonical retained lots sum to the floored minor-unit target; proportional source differences plus cap-floor differences form source-linked overlap-cap overflow.
 - Global epoch redistribution pool = score-discount project pool contributions plus overlap-cap overflow.
-- Pre-redistribution current = `min(aggregate initial claim, cap)`; a user already at cap, including a zero-baseline user at cap zero, receives no top-up.
+- Pre-redistribution current = the canonical retained target: floor `min(aggregate initial claim, exact cap)` to the allocation minor unit and bound it by the floored minor-unit cap. A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
 - User final allocation = pre-redistribution current plus the deterministic lowest-current-total-first water-filling top-up, never above the cap.
 - Asset fulfillment = selected asset credit fills based on the user's highest-priority accepted available assets.
 - Every initial claim, pool contribution, top-up, and returned/carryover residue retains project, rail, asset, native, FX, and USD provenance.
@@ -246,11 +246,13 @@ cross-project overlap.
 Rounding:
 
 - Calculate exact-decimal cap scaling before rounding.
-- Round retained source lots by descending fractional remainder then stable project/rail/asset/source-lot key; derive overflow as original minus retained so each source conserves.
+- Floor the retained-total target to the allocation minor unit and bound it by the canonical floored cap. Round retained source lots by descending fractional remainder then stable project/rail/asset/source-lot key; skip any next-unit assignment that would cross the user's cap.
+- Move an exact fraction or candidate minor unit rejected by the cap into the global overflow pool as cap-floor overflow with its original project/rail/asset/native/FX/USD provenance; together with proportional overlap overflow it may fund another uncapped user and otherwise becomes source-linked returned/carryover residue.
+- Derive overflow as original minus retained so each source conserves.
 - Apply the same stable largest-remainder rule within each rail/asset/custody group for native atomic units.
 - Round after USD normalization.
 - Store exact decimal calculation inputs and rounded credited amounts.
-- Assign rounding residual deterministically to users by descending unrounded remainder, then stable user id sort.
+- Assign award residual deterministically by descending unrounded remainder then stable user id, skipping capped users rather than producing a one-unit cap breach.
 
 Outputs:
 
@@ -272,10 +274,12 @@ Acceptance criteria:
 - Retained initial lots plus score-discount contributions plus overlap-cap overflow equal the funded pool.
 - Top-ups plus returned/carryover residue equal score-discount contributions plus overlap-cap overflow.
 - Final allocations plus returned/carryover residue equal total funded pool USD after deterministic rounding.
-- No user final allocation exceeds `3 ×` baseline.
+- No retained-lot target or final allocation exceeds the floored minor-unit `3 ×` baseline cap.
 - The canonical A+B fixture uses 100 B users each exactly `10/20`, produces `$150 + $500 = $650` of redistribution, and sends it first to the 97 B-only lowest earners.
 - The four-project overlap fixture `[100,100,100,100]` clamps `$400` to a `$300` cap, retains `$75` per source, and contributes four `$25` overflow lots before water-filling.
+- The fractional fixture with four `$0.335` lots has aggregate `$1.34`, baseline `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, four `$0.25` retained lots, `$0.335 + $0.005 = $0.34` of source-linked overflow/pool value, and never a `$1.01` award.
 - Arbitrary overlap count and project/source input permutation properties conserve exact decimals, USD minor units, and native atomic units.
+- Cap-aware residual properties prove exact-decimal conservation separately from integer minor-unit conservation, with no lost or double-assigned fractions or units.
 - Ineligible users are excluded with reason codes.
 - Calculation creates artifacts in Supabase Storage and result rows linked to `monthly_cycle_id`.
 

--- a/docs/engineering/settlement-backed-epoch-treasury.md
+++ b/docs/engineering/settlement-backed-epoch-treasury.md
@@ -477,11 +477,16 @@ short transaction.
   initial project claim is that share multiplied by `locked score / locked maximum
   score`; it is not weighted by the sum of cohort scores or mutable activity points.
 - Baseline is the largest single-project score-adjusted initial claim and cap is
-  `3 ×` baseline. Before redistribution, aggregate initial claim is clamped to that
-  cap. If aggregate exceeds cap, every project/source initial lot is scaled by
+  exact `3 ×` baseline. The canonical minor-unit cap is that exact value floored to
+  the allocation minor unit. Before redistribution, aggregate initial claim is clamped to that
+  cap, and retained-lot and final-award rounding may never exceed it. If aggregate exceeds cap, every project/source initial lot is scaled by
   `cap / aggregate`; each lot's exact difference enters the pool as overlap-cap
   overflow. A zero-baseline user has cap zero, and any user already at cap receives
   no top-up.
+- Descending-fraction residual assignment is cap-aware and skips any user/source
+  whose next unit would cross the canonical cap. Rejected exact fractions or minor
+  units retain original source provenance in the global overflow pool, may fund
+  another uncapped user, and otherwise become source-linked returned/carryover residue.
 - Every theoretical-share score discount and overlap-cap overflow enters one global
   epoch redistribution pool. Pre-redistribution current totals are raised
   lowest-first through deterministic water-filling with stable ties.
@@ -497,6 +502,13 @@ short transaction.
   `$400`, baseline `$100`, cap `$300`, four retained `$75` lots, and four source-linked
   `$25` overflow lots before water-filling. Arbitrary overlap counts must preserve
   the same exact-decimal, minor-unit, native-unit, and input-order invariants.
+- Fractional-cap evidence uses four `$0.335` lots: aggregate `$1.34`, baseline
+  `$0.335`, exact cap `$1.005`, and canonical cent cap `$1.00`. Four `$0.25`
+  retained lots total `$1.00`; `$0.335` proportional overflow plus the cap-rejected
+  `$0.005` exact remainder travels with source provenance as `$0.34` pool/residue,
+  and the award never becomes `$1.01`.
+  Exact decimals and integer minor-unit outputs conserve independently with no lost
+  or double-assigned value.
 - Redistribution principal and residue are funded epoch value, never platform fee,
   revenue, a treasury sweep, a user payable, or newly created value.
 - Allocation results remain versioned artifacts and projections. The immutable

--- a/docs/engineering/settlement-backed-epoch-treasury.md
+++ b/docs/engineering/settlement-backed-epoch-treasury.md
@@ -1,5 +1,6 @@
 # Settlement-backed epoch treasury and auditable payouts
 
+Last updated: 2026-08-09
 Status: implementation architecture for Feature #118; production accounting and
 legal activation remain gated by Task #121
 Decision source: `agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md`
@@ -467,14 +468,34 @@ short transaction.
 ### Identity and allocation
 
 - Extend attribution/user-input snapshots with project-scoped pseudonymous Cubid
-  identity, whitelist state, uniqueness score, evidence timestamp, expiry, and
-  greylist/blacklist state.
+  identity, whitelist state, locked uniqueness score, versioned locked maximum
+  score, evidence timestamp, expiry, and greylist/blacklist state.
 - The lock manifest includes only settled funding applications, approved project
   packages, fixed FX, fee assessments, carryover results, eligible identities, and
   source-preserving asset inventory.
+- Each funded project's theoretical share is equal across its eligible users. The
+  initial project claim is that share multiplied by `locked score / locked maximum
+  score`; it is not weighted by the sum of cohort scores or mutable activity points.
+- Every theoretical-share shortfall enters one global epoch redistribution pool.
+  Aggregate initial claims are raised lowest-current-total first through
+  deterministic water-filling, with stable ties and a final cap of three times the
+  user's largest single-project score-adjusted initial claim.
+- Pool source lots and top-up fills preserve project, rail, asset, native quantity,
+  FX snapshot, and functional-USD provenance. Cap-exhausted residue returns or
+  carries forward through those originating lots.
+- Canonical evidence uses Project A `$300` with scores `5/10/15` of `20`, producing
+  `$25/$50/$75` initial claims and `$150` of pool, plus Project B `$1,000` with 100
+  users at average `10/20`, producing `$500` initial claims and `$500` of pool. The
+  three A users also use B, so the combined `$650` goes first to the 97 B-only users
+  with the lowest aggregate initial claims.
+- Redistribution principal and residue are funded epoch value, never platform fee,
+  revenue, a treasury sweep, a user payable, or newly created value.
 - Allocation results remain versioned artifacts and projections. The immutable
   conditional-award memorandum is the canonical pre-processing award record; it is
   not a user-owned asset or general-ledger obligation.
+- Project/public read models must not expose user-level cross-project membership;
+  production calculation and posting remain fail-closed until the named privacy,
+  accounting, custody, and launch gates pass.
 
 ### Withdrawal and payout
 
@@ -841,7 +862,7 @@ boundary while the production value path remains disabled behind its named gate.
 | Base custody | Separate platform and epoch Safe accounts; new versioned intake or explicit reconciled split; old single-treasury deployment is never reinterpreted | Tasks #132 and #140 approve deployments | Base intake/payout activation |
 | Limited signer | $20 per payout, $500 per rolling 24-hour window, $5,000 per epoch; token/recipient allowlists, nonce, expiry, pause, and independent Safe enforcement | Task #140 selects Safe owner threshold, audited module deployment, paymaster budget, and alert thresholds | Automated Base payouts |
 | FX and depeg | Immutable monthly rate, primary/fallback/manual evidence, reasonability review, and ±0.3% stablecoin pause | Task #135 selects source hierarchy and recovery/reactivation runbook | Valuing and later stages |
-| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; score-proportional allocation; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
+| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; equal theoretical project share discounted by locked score/max, then capped lowest-earner-first global redistribution; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
 | Project review deadline | Midnight Pacific at the end of the next FundLoop business day after accepted reconciliation-email delivery | Tasks #128/#133 select provider event mapping and versioned holiday rows | Project-package lock |
 | Risk reserve | Reversals never silently reduce unrelated awards; losses and receivables are explicit | Tasks #121/#135 set reserve target, chargeback recovery, and bad-debt policy | Controlled production value |
 | Rounding and queues | Exact atomic native quantities, exact numeric USD, deterministic sequence, explicit dust, and no negative inventory | Task #139 sets per-asset dust and queued-request terminal policy | Payout opening |
@@ -917,9 +938,10 @@ partial indexes cover unresolved events and open work queues.
 
 ### `conditional_award.v1`
 
-- source allocation/epoch, user, locked USD amount, project attribution, eligible
-  rail/asset inventory, expiry, Cubid evidence, hold state, and immutable result
-  hash;
+- source allocation/epoch, user, theoretical project shares, locked score/max,
+  initial claims, aggregate initial claim, largest-single-project baseline, cap,
+  redistribution top-up, final locked USD amount, project/source fills, eligible
+  rail/asset inventory, expiry, Cubid evidence, hold state, and immutable result hash;
 - available, reserved, queued, processed, expired, and reversed memorandum amounts
   whose conservation equals the approved award; and
 - no ownership-transfer or general-ledger-payable semantics before the approved

--- a/docs/engineering/settlement-backed-epoch-treasury.md
+++ b/docs/engineering/settlement-backed-epoch-treasury.md
@@ -476,18 +476,27 @@ short transaction.
 - Each funded project's theoretical share is equal across its eligible users. The
   initial project claim is that share multiplied by `locked score / locked maximum
   score`; it is not weighted by the sum of cohort scores or mutable activity points.
-- Every theoretical-share shortfall enters one global epoch redistribution pool.
-  Aggregate initial claims are raised lowest-current-total first through
-  deterministic water-filling, with stable ties and a final cap of three times the
-  user's largest single-project score-adjusted initial claim.
+- Baseline is the largest single-project score-adjusted initial claim and cap is
+  `3 ×` baseline. Before redistribution, aggregate initial claim is clamped to that
+  cap. If aggregate exceeds cap, every project/source initial lot is scaled by
+  `cap / aggregate`; each lot's exact difference enters the pool as overlap-cap
+  overflow. A zero-baseline user has cap zero, and any user already at cap receives
+  no top-up.
+- Every theoretical-share score discount and overlap-cap overflow enters one global
+  epoch redistribution pool. Pre-redistribution current totals are raised
+  lowest-first through deterministic water-filling with stable ties.
 - Pool source lots and top-up fills preserve project, rail, asset, native quantity,
   FX snapshot, and functional-USD provenance. Cap-exhausted residue returns or
   carries forward through those originating lots.
 - Canonical evidence uses Project A `$300` with scores `5/10/15` of `20`, producing
   `$25/$50/$75` initial claims and `$150` of pool, plus Project B `$1,000` with 100
-  users at average `10/20`, producing `$500` initial claims and `$500` of pool. The
+  users each exactly `10/20`, producing `$500` initial claims and `$500` of pool. The
   three A users also use B, so the combined `$650` goes first to the 97 B-only users
   with the lowest aggregate initial claims.
+- Adversarial overlap evidence uses initial lots `[100,100,100,100]`: aggregate
+  `$400`, baseline `$100`, cap `$300`, four retained `$75` lots, and four source-linked
+  `$25` overflow lots before water-filling. Arbitrary overlap counts must preserve
+  the same exact-decimal, minor-unit, native-unit, and input-order invariants.
 - Redistribution principal and residue are funded epoch value, never platform fee,
   revenue, a treasury sweep, a user payable, or newly created value.
 - Allocation results remain versioned artifacts and projections. The immutable
@@ -862,7 +871,7 @@ boundary while the production value path remains disabled behind its named gate.
 | Base custody | Separate platform and epoch Safe accounts; new versioned intake or explicit reconciled split; old single-treasury deployment is never reinterpreted | Tasks #132 and #140 approve deployments | Base intake/payout activation |
 | Limited signer | $20 per payout, $500 per rolling 24-hour window, $5,000 per epoch; token/recipient allowlists, nonce, expiry, pause, and independent Safe enforcement | Task #140 selects Safe owner threshold, audited module deployment, paymaster budget, and alert thresholds | Automated Base payouts |
 | FX and depeg | Immutable monthly rate, primary/fallback/manual evidence, reasonability review, and ±0.3% stablecoin pause | Task #135 selects source hierarchy and recovery/reactivation runbook | Valuing and later stages |
-| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; equal theoretical project share discounted by locked score/max, then capped lowest-earner-first global redistribution; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
+| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; equal theoretical project share discounted by locked score/max; aggregate initials pre-clamped to `3 ×` largest-project baseline with source-linked overflow, then lowest-earner-first global redistribution; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
 | Project review deadline | Midnight Pacific at the end of the next FundLoop business day after accepted reconciliation-email delivery | Tasks #128/#133 select provider event mapping and versioned holiday rows | Project-package lock |
 | Risk reserve | Reversals never silently reduce unrelated awards; losses and receivables are explicit | Tasks #121/#135 set reserve target, chargeback recovery, and bad-debt policy | Controlled production value |
 | Rounding and queues | Exact atomic native quantities, exact numeric USD, deterministic sequence, explicit dust, and no negative inventory | Task #139 sets per-asset dust and queued-request terminal policy | Payout opening |
@@ -940,7 +949,8 @@ partial indexes cover unresolved events and open work queues.
 
 - source allocation/epoch, user, theoretical project shares, locked score/max,
   initial claims, aggregate initial claim, largest-single-project baseline, cap,
-  redistribution top-up, final locked USD amount, project/source fills, eligible
+  retention factor, retained initial lots, overlap-cap overflow, pre-redistribution
+  current, redistribution top-up, final locked USD amount, project/source fills, eligible
   rail/asset inventory, expiry, Cubid evidence, hold state, and immutable result hash;
 - available, reserved, queued, processed, expired, and reversed memorandum amounts
   whose conservation equals the approved award; and

--- a/docs/engineering/settlement-backed-epoch-treasury.md
+++ b/docs/engineering/settlement-backed-epoch-treasury.md
@@ -468,7 +468,7 @@ short transaction.
 ### Identity and allocation
 
 - Extend attribution/user-input snapshots with project-scoped pseudonymous Cubid
-  identity, whitelist state, locked uniqueness score, versioned locked maximum
+  identity, whitelist state, locked Cubid score, versioned locked maximum Cubid
   score, evidence timestamp, expiry, and greylist/blacklist state.
 - The lock manifest includes only settled funding applications, approved project
   packages, fixed FX, fee assessments, carryover results, eligible identities, and
@@ -479,20 +479,28 @@ short transaction.
 - Baseline is the largest single-project score-adjusted initial claim and cap is
   exact `3 ×` baseline. The canonical minor-unit cap is that exact value floored to
   the allocation minor unit. Before redistribution, aggregate initial claim is clamped to that
-  cap, and retained-lot and final-award rounding may never exceed it. If aggregate exceeds cap, every project/source initial lot is scaled by
-  `cap / aggregate`; each lot's exact difference enters the pool as overlap-cap
+  canonical rounding bound, and retained-lot and final-award rounding may never exceed it. If aggregate exceeds the exact cap, every project/source initial lot is scaled by
+  `exact cap / aggregate`; each lot's exact difference enters the pool as overlap-cap
   overflow. A zero-baseline user has cap zero, and any user already at cap receives
   no top-up.
 - Descending-fraction residual assignment is cap-aware and skips any user/source
-  whose next unit would cross the canonical cap. Rejected exact fractions or minor
-  units retain original source provenance in the global overflow pool, may fund
-  another uncapped user, and otherwise become source-linked returned/carryover residue.
+  whose next unit would cross the canonical cap. Sub-minor exact residuals and
+  rejected candidate canonical units retain original source provenance, may combine
+  in the global pool or fund another uncapped user, and otherwise become
+  source-linked returned/carryover residue.
 - Every theoretical-share score discount and overlap-cap overflow enters one global
-  epoch redistribution pool. Pre-redistribution current totals are raised
-  lowest-first through deterministic water-filling with stable ties.
+  epoch redistribution pool. Exact equal-current users are raised together until
+  the next level/cap/exhaustion. Aggregate initial and baseline do not break ties;
+  indivisible units use only exact-target fractional remainder then stable user ID.
 - Pool source lots and top-up fills preserve project, rail, asset, native quantity,
   FX snapshot, and functional-USD provenance. Cap-exhausted residue returns or
   carries forward through those originating lots.
+- Exact and canonical ledgers remain separate. Exact source lots always satisfy
+  non-negative `exact initial = exact retained + exact overflow`. Canonical initial
+  units are assigned first to the funded canonical total by stable largest
+  remainder; constrained retained assignment cannot exceed initial source capacity,
+  and canonical overflow is `initial - retained`. Sub-minor residual is tracked
+  separately with source provenance, never as negative exact overflow.
 - Canonical evidence uses Project A `$300` with scores `5/10/15` of `20`, producing
   `$25/$50/$75` initial claims and `$150` of pool, plus Project B `$1,000` with 100
   users each exactly `10/20`, producing `$500` initial claims and `$500` of pool. The
@@ -504,11 +512,18 @@ short transaction.
   the same exact-decimal, minor-unit, native-unit, and input-order invariants.
 - Fractional-cap evidence uses four `$0.335` lots: aggregate `$1.34`, baseline
   `$0.335`, exact cap `$1.005`, and canonical cent cap `$1.00`. Four `$0.25`
-  retained lots total `$1.00`; `$0.335` proportional overflow plus the cap-rejected
-  `$0.005` exact remainder travels with source provenance as `$0.34` pool/residue,
-  and the award never becomes `$1.01`.
+  retained lots total `$1.00`; exact overflow remains `$0.335`, canonical overflow
+  is 34 cents, and the `$0.005` exact-to-canonical residual is tracked separately
+  with source provenance. The award never becomes `$1.01`.
   Exact decimals and integer minor-unit outputs conserve independently with no lost
   or double-assigned value.
+- Non-negative-lot evidence uses two exact `$0.006` retained lots with a one-cent
+  canonical target: assign canonical initial capacity first, retain the cent only
+  there, keep both canonical overflow lots non-negative, and reconcile the exact
+  `$0.012` ledger separately.
+- Equal-current tie evidence uses two exact `$0.005` top-up targets and one cent:
+  stable user ID alone selects after equal fractional remainder; aggregate initial
+  and baseline never break the tie, and input permutation preserves the result hash.
 - Redistribution principal and residue are funded epoch value, never platform fee,
   revenue, a treasury sweep, a user payable, or newly created value.
 - Allocation results remain versioned artifacts and projections. The immutable


### PR DESCRIPTION
## Summary

- Reintroduce a funded global redistribution pool sourced from Cubid score discounts.
- Preserve the `3×` low-earner cap with deterministic overlap clamping and cap-aware minor-unit rounding.
- Align the allocation, operational MVP, treasury, sprint, and issue-tree architecture before Goal #134 implementation.

## Objective

Replace the prior point-proportional/overlap-derived remainder model with the approved allocation principle: each eligible project user starts from an equal theoretical funded share, receives a score-adjusted initial claim, and contributes the shortfall to a global pool that raises the lowest aggregate earners first.

## Changes

- Defined `initial claim = theoretical project share × locked Cubid score / locked maximum score`.
- Defined the cap baseline as the largest single-project score-adjusted claim and final allocation as no more than `3×` that baseline.
- Added deterministic pre-redistribution overlap clamping when aggregate initial claims already exceed the cap, preserving proportional project/rail/asset/native/FX/USD source lots.
- Defined floored canonical minor-unit caps and cap-aware residual assignment so rounding can never cross the exact cap; rejected fractions remain source-linked pool or returned residue.
- Added the canonical A+B fixture, four-project overlap fixture, and fractional `$0.335 × 4` fixture.
- Preserved privacy, provisional accounting, no-payable/no-revenue classification, and production/value-flow fail-closed boundaries.

## Validation

- Independent architecture validation PASS at `cea9392a712fe729ad09defc9b333236e089af75`.
- Exact A+B proof: `$650` reaches 97 B-only users first as 10 × `$6.71` and 87 × `$6.70`; total conservation `$1,300`.
- Four-project overlap: four `$100` initial claims retain four × `$75` and contribute four × `$25` overflow.
- Fractional cap: four × `$0.335` retain `$1.00`, contribute `$0.34`, and never round to `$1.01`.
- Independent 5,000-case randomized sub-cent overlap/permutation probe passed.
- 17 local Markdown links, contradiction audit, `pnpm lint`, ancestry, and `git diff --check` passed.

## Reviewer Notes

Review `docs/engineering/allocation.md` first; the other four documents mirror that canonical algorithm. Legacy raw-entitlement names remain only where clearly identified as compatibility schema surfaces.

## Follow-ups

- This PR contains architecture and planning documentation only; no allocator, schema, provider, payable, payout, or production behavior changes.
- Goal #134 and Tasks #135–#137 will be implemented only after Goal #130/#133 dependencies are satisfied and the corrected issue tree is independently vetted.
- Definitive accounting policy, production cutover, and real value flow remain deferred.

Related: #118, #134, #135, #136, #137
