### PR TITLE
[codex] correct allocation cap and monthly coordination story

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
-# FundLoop Website
+# FundLoop
 
-FundLoop connects projects and users in a revenue-sharing ecosystem. Projects pledge a portion of revenue back to the network, and active users can receive recurring community distributions.
+FundLoop is a monthly economic coordination platform. Projects pool a recurring share of revenue, verified people build participation and contribution signal, and FundLoop locks each month, calculates and verifies distributions, makes approved payments claimable, and publishes privacy-respecting reports about what happened and why.
 
-This repository contains the FundLoop website and app shell built with Next.js, React, TypeScript, Tailwind CSS, and Supabase.
+This repository contains the multilingual web app, Supabase workflow engine, payment and accounting control planes, and MCP interface. FundLoop is intentionally more than a website: the human and agent interfaces are expected to use the same typed Edge Function workflows, authorization rules, and audit history.
+
+The four primary audiences are:
+
+- people discovering projects, proving uniqueness through CUBID.me, participating, and managing earnings and payouts;
+- founders, developers, and project members managing revenue commitments, funding routes, monthly attribution, and project reporting;
+- researchers and the public following the practical design of post-capitalistic, decentralized coordination; and
+- internal operators and agents preparing epochs, reconciling money and data, publishing reports, and working through MCP.
+
+See the [target architecture](docs/engineering/target-state-architecture.md) and the [2026-08-11 capability review](docs/engineering/capability-review-2026-08-11.md) for the intended system and an evidence-based account of what is and is not currently usable.
 
 ## Stack
 

--- a/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/issue-tree.md
@@ -649,19 +649,18 @@ Goal invariants:
 - equal theoretical funded project share per eligible user;
 - initial project claim equals theoretical share multiplied by locked Cubid score
   divided by the versioned locked maximum score;
-- baseline is the largest single-project score-adjusted initial claim; exact cap is
-  `3 ×` baseline and the canonical retained/final cap is that value floored to the
-  allocation minor unit;
-- before redistribution, aggregate initial is clamped to cap; if aggregate exceeds
-  cap, every project/source initial lot is scaled by `exact cap / aggregate`, retained
-  proportionally, and its exact difference becomes source-linked overlap overflow;
-- one global pool equals score-discount shortfalls plus overlap-cap overflow, and
-  clamped current totals are raised lowest-first through stable deterministic
-  water-filling;
+- baseline is the largest single-project score-adjusted initial claim; an operator
+  selects a decimal multiple from `1.00` through `10.00` per epoch, with `3.00` used
+  only as the initial preview;
+- the floored baseline-times-multiple value is a redistribution top-up ceiling only;
+  aggregate initial claims remain intact even when already above that ceiling;
+- one global pool equals score-discount shortfalls plus exactly E−3 unclaimed awards
+  plus prior carry-in residue, and full initial totals are raised lowest-first through
+  stable deterministic water-filling only while top-up capacity remains;
 - exact equal-current users rise together; aggregate initial and baseline do not
   break ties, while indivisible minor units use only exact-target fractional
   remainder then stable user ID with cap-aware skipping;
-- capped users and zero-baseline users receive no top-up;
+- users with no remaining top-up capacity and zero-baseline users receive no top-up;
 - cap-aware residual assignment skips any user/source whose next unit would cross
   cap and keeps rejected exact fractions or minor units source-linked in the global
   pool or returned/carryover residue;
@@ -724,15 +723,13 @@ Scope:
 - divide each funded project pool equally across eligible users;
 - calculate `initial claim = theoretical share × locked score / locked max score`
   and create source-linked score-discount shortfall lots;
-- aggregate user initial claims, define baseline as the largest single-project
-  initial claim, set exact cap to `3 ×` baseline, floor it to the allocation minor
-  unit as the canonical cap, and clamp aggregate initial before redistribution;
-- when aggregate exceeds exact cap, apply one `exact cap / aggregate` factor to every
-  project/source initial lot and move each difference into the pool as overlap-cap
-  overflow; start water-filling from the canonical retained target, namely floored
-  `min(aggregate, exact cap)` bounded by the floored minor-unit cap;
-- define the global pool as score-discount shortfalls plus overlap-cap overflow;
-  capped and zero-baseline users receive no top-up;
+- aggregate all user initial claims without clipping, define baseline as the largest
+  single-project initial claim, and calculate a redistribution top-up ceiling from
+  the operator-selected immutable decimal multiple;
+- calculate top-up capacity as `max(ceiling - full initial total, 0)` and start
+  water-filling from the full initial total;
+- define the global pool as score-discount shortfalls plus exactly E−3 unclaimed
+  awards plus prior carry-in residue; users without top-up capacity receive no top-up;
 - treat exact equal-current users equally until the next level/cap/exhaustion; for
   indivisible minor units use only descending exact-target fractional remainder then
   stable user ID with cap-aware skipping;
@@ -753,7 +750,7 @@ Scope:
 Validation:
 
 - no-receipt/no-allocation invariant;
-- invalid score/max, pre-redistribution cap, zero-baseline, arbitrary-overlap,
+- invalid score/max, selected-cap validation, preserved-above-ceiling initial totals, zero-baseline,
   input-permutation, asset/native/USD conservation, privacy, and source
   attribution;
 - repeat run equivalence;
@@ -761,9 +758,9 @@ Validation:
   initial and `$150` pool; B `$1,000`, 100 users each exactly `10/20` gives `$500`
   initial and `$500` pool; because the three A users also use B, the combined
   `$650` goes first to the 97 B-only lowest earners;
-- four-project overlap fixture `[100,100,100,100]`: aggregate `$400`, baseline
-  `$100`, cap `$300`, four retained `$75` source lots, four `$25` overflow lots,
-  then water-fill only uncapped users; and
+- four-project fixture `[100,100,100,100]`: aggregate `$400`, baseline `$100`, and
+  selected `3.00` top-up ceiling `$300`; preserve the full `$400`, assign no top-up,
+  and contribute no ceiling-derived value to the pool; and
 - fractional cap fixture: four `$0.335` lots yield aggregate `$1.34`, baseline
   `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, and four `$0.25`
   retained lots; exact overflow is `$0.335`, canonical overflow is 34 cents, and
@@ -801,10 +798,10 @@ Scope:
   without recognizing user ownership before payout is processed;
 - publish exact approved project totals/counts without user identifiers or
   cross-project membership inference;
-- persist theoretical shares, score/max, initial claims, aggregate/exact/floored caps,
-  separate exact/canonical source ledgers, retention factors, retained source lots, score-discount contributions,
-  overlap-cap overflow, pre-redistribution current, top-ups, final allocations, and
-  source-linked residue;
+- persist theoretical shares, score/max, full initial claims, selected cap multiple,
+  redistribution top-up ceilings and capacity, separate exact/canonical source ledgers,
+  score-discount contributions, E−3 harvest, carry-in, top-ups, final allocations,
+  and source-linked carry-out residue;
 - generate trial balance, custody, project funds, fee, FX, carryover, initial claim,
   redistribution pool, top-up, returned-residue, provisional award, and exception
   artifacts under one root hash, without payable classification;

--- a/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
+++ b/agent-context/2026-08-08-epoch-treasury-accounting/sprint-definition.md
@@ -311,19 +311,15 @@ occurs. Later policy edits never rewrite prior events.
     and the conditional award enters compliance hold pending an authorized resolution. It
     is not silently redistributed and completed payouts are not clawed back.
 22. Each difference between theoretical share and score-adjusted initial claim
-    enters one global epoch redistribution pool. The allocator aggregates each
-    user's initial project claims, defines baseline as the largest single-project
-    initial claim, defines exact cap as three times baseline, and floors it to the
-    allocation minor unit for the canonical executable cap. If aggregate initial
-    exceeds cap, every project/source initial lot is proportionally retained by
-    `exact cap / aggregate`; each exact difference enters the global pool as source-linked
-    overlap-cap overflow. Water-filling starts from the canonical floored and
-    cap-bounded retained current total and
-    raises equal-current uncapped users together until the next level, cap, or
-    exhaustion. Aggregate initial and baseline do not break equal-current ties. A capped or zero-baseline user receives
-    no top-up. Retained-lot and final-award rounding may never cross the floored cap;
-    descending-fraction residual assignment skips capped candidates and sends the
-    rejected fraction or unit, with source provenance, into pool/residue.
+    enters one global epoch redistribution pool together with exactly E−3 unclaimed
+    awards and prior carry-in residue. The allocator preserves every initial project
+    claim, defines baseline as the largest single-project claim, and applies the
+    operator-selected `1.00`–`10.00` decimal multiple only to the redistribution
+    top-up ceiling. Top-up capacity is `max(ceiling - full initial total, 0)`.
+    Water-filling starts from full initial totals and raises equal-current users until
+    the next level, top-up ceiling, or exhaustion. A zero-baseline user or a user
+    already without capacity receives no top-up. Undistributed residue carries into
+    the next epoch with source provenance.
 23. Cubid is queried during reconciliation and again at lock. A prior validated
     snapshot may be used during an outage only within a configured short TTL;
     otherwise the user remains unresolved and cannot lock.
@@ -339,10 +335,10 @@ first to the 97 B-only users with the lowest aggregate initial claims. Equal-cur
 continuous treatment and the sole fractional-remainder/stable-user-ID minor-unit rule,
 rounding, caps, and complete funded-source provenance must reproduce exactly.
 
-Adversarial overlap fixture: score-adjusted initial lots `[100,100,100,100]` produce
-aggregate `$400`, baseline `$100`, cap `$300`, retention factor `0.75`, four retained
-`$75` lots, and four source-linked `$25` overflow lots. The user begins water-filling
-at cap and receives no top-up. These conservation and input-order properties apply
+Adversarial multi-project fixture: score-adjusted initial lots `[100,100,100,100]`
+produce aggregate `$400`, baseline `$100`, and a selected `3.00` redistribution
+top-up ceiling of `$300`. The full `$400` initial total remains intact and the user
+receives no top-up. These conservation and input-order properties apply
 to arbitrary overlap counts and to exact-decimal, minor-unit, and native-unit rows.
 
 Fractional cap fixture: four `$0.335` lots produce aggregate `$1.34`, baseline
@@ -734,28 +730,24 @@ Process:
 2. Calculate each initial project claim as theoretical share multiplied by locked
    score divided by locked maximum score; send every shortfall into one global
    epoch redistribution pool.
-3. Aggregate each user's initial claims, set baseline to the largest single-project
-   initial claim, set exact cap to three times baseline, and floor that value to the
-   allocation minor unit for the canonical retained/final cap.
-4. Before redistribution, clamp aggregate initial to cap. Scale every project/source
-   initial lot by `min(1, exact cap / aggregate)`, retain the scaled lot, and move its exact
-   difference into the pool as source-linked overlap-cap overflow.
-5. Define the global pool as score-discount contributions plus overlap-cap overflow,
-   then redistribute lowest-current-total first through deterministic water-filling;
+3. Aggregate each user's initial claims without clipping, set baseline to the largest
+   single-project initial claim, and floor `baseline × selected monthly multiple` to
+   the allocation minor unit for the redistribution top-up ceiling.
+4. Set top-up capacity to `max(0, ceiling - full initial total)`. A user above the
+   ceiling keeps every initial claim and receives no top-up.
+5. Define the global pool as score-discount contributions plus exactly E−3 unclaimed
+   awards plus prior carry-in residue, then redistribute lowest-current-total first;
    exact equal-current users remain equal until a level/cap/exhaustion boundary.
    For indivisible canonical units, use only descending exact-target fractional
    remainder then stable user ID, with cap-aware skipping.
-   A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
+   A user without remaining top-up capacity, including a zero-baseline user, receives no top-up.
 6. Preserve project, rail, asset, native, FX, and functional-USD source lots for
    every initial claim, top-up, and cap-exhausted returned/carryover residue.
-7. Apply exact-decimal cap scaling first. Allocate retained functional-USD and native
-   values in a separate exact ledger where each non-negative initial source equals
-   exact retained plus exact overflow. Derive canonical initial units first against
+7. Preserve exact-decimal initial claims first. Allocate functional-USD and native
+   values in a separate exact ledger, then derive canonical initial units against
    the funded canonical total by descending fractional remainder then stable source
-   ID. Assign retained units to the floored target with the same ordering constrained
-   by `0 <= retained <= initial`, skipping saturated/zero-capacity lots and any cap
-   breach; canonical overflow is `initial - retained`. Track sub-minor residual and
-   cross-source transfers separately with provenance, never as exact overflow.
+   ID. Apply the ceiling only while assigning top-ups. Track sub-minor residual and
+   cross-source transfers separately with provenance and carry undistributed residue.
 8. Prove conservation by project, rail, asset, native quantity, redistribution pool,
    and functional USD for arbitrary overlap count and input order, separately for
    exact decimals and integer minor-unit outputs, with no lost/double-assigned units.

--- a/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
+++ b/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
@@ -105,3 +105,58 @@ and E−3 unclaimed awards become a redistribution source.
 
 - Review the policy commit before the implementation commit so schema and runtime
   fields can be checked against the equations and conservation rules directly.
+
+### session v3: Implement allocation v2 and harvested redistribution
+
+- Timestamp: 2026-08-11T17:41:00-04:00
+- Agent: Codex
+- Branch: codex/public-monthly-coordination-story
+- Head: ab0c32d
+
+#### Objective
+
+Implement the documented v2 policy through deterministic calculation, forward-only
+schema, operator selection, independent close, withdrawal preparation, and monthly
+reporting while keeping production value flow disabled.
+
+#### Actions Taken
+
+- Added the deterministic v2 calculator with immutable source capacities, full
+  initial claims, top-up-only ceilings, lowest-current-total-first water filling,
+  and source-linked carry-out residue.
+- Added read-only `1.00`–`10.00` previews, a `3.00` initial scenario, selected-preview
+  locking, v2 calculation, and independent v2 close reruns.
+- Added a forward-only migration for E−3 harvested and carry-forward pool sources,
+  claim/harvest serialization, released-claim handling, newest-lot-first partial
+  harvest, duplicate guards, conservation constraints, and v2 withdrawal inventory.
+- Added selected cap and aggregate harvest fields to operator, project, private-user,
+  and privacy-thresholded public reports and bound them into report/root artifacts.
+- Regenerated local Supabase types and added focused calculator, contract, migration,
+  UI, reporting, and multilingual regression coverage.
+
+#### Validation Notes
+
+- Applied the full migration chain and seed from a fresh disposable local Supabase
+  volume with Vector excluded, then passed schema lint at error level.
+- Passed Node 22 `CI=1 pnpm check`: lint, 171 test files / 773 tests, typecheck, and a
+  165-page production build.
+- After the final canonical-capacity correction, passed 22 focused v2 tests,
+  typecheck, schema lint, and `git diff --check`.
+- The repository-wide `supabase test db` command remains non-TAP and fails in two
+  older fixtures before v2 coverage: one lacks an active payout route and one
+  violates the project-payment rail-claim integrity guard.
+
+#### Reflections
+
+- Harvested and carried sources already have authoritative canonical minor amounts;
+  largest-remainder assignment must apply only to current project sources so a cent
+  cannot move into or out of an obligation or predecessor residue lot.
+- Harvest must lock obligations before balance revalidation so a claim and harvest
+  cannot consume the same value concurrently.
+
+#### Suggested Next Steps
+
+- Add a fixture-backed four-epoch SQL scenario once the repository DB harness is
+  converted to a reliable TAP gate.
+- Keep production activation, remote Supabase mutation, push, and PR work in
+  separately authorized sessions.

--- a/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
+++ b/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
@@ -62,3 +62,46 @@ or production capability.
   function before claiming shared-dev parity.
 - Run one hosted founder/user/operator acceptance flow and complete deterministic
   report generation plus three-month claim lifecycle proof.
+
+### session v2: Correct allocation policy documentation
+
+- Timestamp: 2026-08-11T17:35:00-04:00
+- Agent: Codex
+- Branch: codex/public-monthly-coordination-story
+- Head: 1d5b0ad
+
+#### Objective
+
+Correct the durable allocation contract so the selected monthly multiple limits
+redistribution top-ups only, while full score-adjusted initial claims remain intact
+and E−3 unclaimed awards become a redistribution source.
+
+#### Actions Taken
+
+- Replaced the current allocation specification with
+  `settled_cubid_redistribution_v2` terminology, equations, conservation rules,
+  immutable cap-selection inputs, and audience-specific reporting requirements.
+- Corrected the operational MVP and settlement-backed treasury documents to remove
+  initial-claim clipping and ceiling-derived pool value.
+- Updated the epoch accounting sprint definition and issue tree to define the pool
+  as score discounts, exactly E−3 harvested awards, and prior carry-in residue.
+- Documented three complete payout months, newest-lot-first partial harvest, released
+  claim handling, deterministic residue carry-forward, and the production boundary.
+
+#### Validation Notes
+
+- Confirmed the active engineering and issue-tree documents no longer describe
+  initial-claim clipping or overlap-cap overflow as current policy.
+- Passed `git diff --check` for the documentation package.
+
+#### Reflections
+
+- “Redistribution top-up ceiling” is materially different from “final cap”: a final
+  award may exceed the ceiling when the preserved initial total already exceeds it.
+- The selected multiple and aggregate E−3 harvest belong in every monthly report
+  scope and root hash, not only in an operator-side calculation note.
+
+#### Suggested Next Steps
+
+- Review the policy commit before the implementation commit so schema and runtime
+  fields can be checked against the equations and conservation rules directly.

--- a/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
+++ b/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
@@ -160,3 +160,40 @@ reporting while keeping production value flow disabled.
   converted to a reliable TAP gate.
 - Keep production activation, remote Supabase mutation, push, and PR work in
   separately authorized sessions.
+
+### session v4: Codex review withdrawal availability fix
+
+- Timestamp: 2026-08-11T18:15:00-04:00
+- Agent: Codex
+- Branch: codex/public-monthly-coordination-story
+- Head: 2214068
+
+#### Objective
+
+Address the Codex P2 finding on PR #185 so harvested obligation value cannot shadow
+newer valid withdrawal obligations.
+
+#### Actions Taken
+
+- Replaced the obligation-state refresh calculation to compare active claims against
+  `total_minor - harvested_minor`.
+- Replaced the v3 withdrawal availability and oldest-first allocation queries so
+  both subtract harvested value and skip obligations with no remaining balance.
+- Added migration regression assertions for state refresh, aggregate availability,
+  and oldest-first unclaimed-minor calculation.
+
+#### Validation Notes
+
+- Focused migration tests, local schema replay/lint, and post-fix CI are required
+  before resolving the review thread.
+
+#### Reflections
+
+- A final insertion guard prevents double spending but is not sufficient UX or
+  ordering behavior: harvested obligations must also disappear from every upstream
+  availability and selection calculation.
+
+#### Suggested Next Steps
+
+- Reply to and resolve the original Codex thread after the fix is pushed, then merge
+  only after the final head is green.

--- a/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
+++ b/agent-context/session-log/2026-08-11-codex-public-monthly-coordination-story.md
@@ -1,0 +1,64 @@
+### session v1: Public monthly coordination story and capability review
+
+- Timestamp: 2026-08-11T15:49:00-04:00
+- Agent: Codex
+- Branch: codex/public-monthly-coordination-story
+- Head: 2b87b9c
+
+#### Objective
+
+Make FundLoop's unauthenticated home and durable documentation accurately describe
+the monthly economic coordination target, then compare that target with the current
+`dev` branch and Supabase Dev environment without overstating local, sandbox, hosted,
+or production capability.
+
+#### Actions Taken
+
+- Rebuilt the public home around one dominant monthly-epoch visual and a seven-step
+  revenue-to-claim story rather than the prior generic network-state/use-case page.
+- Added clear paths for regular users, project teams, researchers/public readers,
+  and internal operators/agents, plus explicit private-by-default and opt-in
+  publication language.
+- Added complete English, French, and Spanish copy for the new home hierarchy and
+  strengthened home metadata around revenue pooling, verification, participation,
+  and monthly distribution.
+- Updated the repository and target/current architecture docs to define FundLoop as
+  a multilingual app shell plus Supabase workflow engine and MCP interface.
+- Added an evidence-classed capability review comparing `origin/dev` at `2b87b9c`
+  with Supabase Dev project `kyxtqnfnksvcaugxwzuj`.
+- Verified that app CI is green while the matching Supabase deploy is blocked at
+  `20260809020000_neutral_ledger_foundations.sql` with SQLSTATE `42601`.
+- Compared 62 local Edge Function directories with 38 active remote functions and
+  documented the missing settlement, ledger, multi-rail, payout, and cutover paths.
+
+#### Validation Notes
+
+- Passed `PATH=/opt/homebrew/opt/node@22/bin:$PATH CI=1 pnpm check`:
+  lint, 169 test files / 757 tests, typecheck, and a 165-page production build.
+- Passed focused i18n validation before adding the final seven-stage/four-audience
+  regression assertion; that assertion was re-run separately afterward.
+- Passed `git diff --check` before the final session-log update.
+- Browser-reviewed `/en` at 1440x900 and 390x844 with the real Next.js dev server.
+  The hero fits the desktop and mobile first viewport, reduced-motion-safe loop
+  animation remains legible, and mobile has no horizontal overflow.
+- The local browser used a non-secret placeholder Supabase configuration solely to
+  let the unauthenticated shell render; no remote Supabase mutation occurred.
+
+#### Reflections
+
+- The frontend skill pushed the page toward one memorable economic-loop visual,
+  cardless stage and audience layouts, sparse copy, and motion that communicates
+  cadence rather than decoration.
+- The largest delivery risk is no longer absence of workflow code; it is the split
+  between CI-green app code and a stale Supabase Dev backend.
+- Public reporting remains a metadata/read-model scaffold until generation,
+  publication, retention, and hosted audience-specific verification are complete.
+
+#### Suggested Next Steps
+
+- Review and publish this branch through the normal PR-to-`dev` flow.
+- Repair the prepared-statement migration failure, replay Supabase Dev migrations,
+  deploy the missing current functions, and quarantine the retired remote payout
+  function before claiming shared-dev parity.
+- Run one hosted founder/user/operator acceptance flow and complete deterministic
+  report generation plus three-month claim lifecycle proof.

--- a/app/[locale]/(app)/admin/cycles/[cycleKey]/prep/page.tsx
+++ b/app/[locale]/(app)/admin/cycles/[cycleKey]/prep/page.tsx
@@ -36,8 +36,8 @@ function formatCurrency(locale: string, value: number) {
   }).format(value)
 }
 
-function sumIntegerValues(left: string | number | null, right: string | number | null) {
-  return (BigInt(String(left ?? 0)) + BigInt(String(right ?? 0))).toString()
+function sumIntegerValues(...values: Array<string | number | null>) {
+  return values.reduce<bigint>((sum,value)=>sum+BigInt(String(value ?? 0)),BigInt(0)).toString()
 }
 
 function severityIcon(severity: MonthlyCyclePrepSeverity) {
@@ -246,7 +246,7 @@ export default async function AdminCyclePrepPage({ params }: PageProps) {
             <p className="text-[0.72rem] font-semibold uppercase tracking-[0.28em] text-[var(--interactive-primary)]">Settled Cubid redistribution</p>
             <h2 className="mt-2 text-2xl font-semibold text-[var(--text-strong)]">Immutable allocation review</h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-[var(--text-muted)]">
-              Equal project shares are discounted by locked Cubid scores. Score shortfalls and overlap-cap overflow fund lowest-current-total-first top-ups under the preserved 3× cap. Results remain provisional: no payable, payout, provider call, or value movement is created here.
+              Equal project shares are discounted by locked Cubid scores. Score discounts, E−3 harvests, and carry-in residue fund lowest-current-total-first top-ups. The selected monthly multiple sets each redistribution top-up ceiling only; every initial claim remains intact.
             </p>
           </div>
           <Badge variant="outline">Production disabled</Badge>
@@ -256,9 +256,12 @@ export default async function AdminCyclePrepPage({ params }: PageProps) {
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {[
               ["State",fundedAllocation.allocation.status ?? "locked"],
-              ["Funded minor",fundedAllocation.allocation.funded_minor ?? "0"],
-              ["Redistribution pool",sumIntegerValues(fundedAllocation.allocation.score_pool_minor,fundedAllocation.allocation.overlap_pool_minor)],
-              ["Top-up / residue",`${fundedAllocation.allocation.top_up_minor ?? "0"} / ${fundedAllocation.allocation.returned_residue_minor ?? "0"}`],
+              ["Selected multiple",`${fundedAllocation.allocation.cap_multiple ?? "pending"}×`],
+              ["Current funded",fundedAllocation.allocation.current_funded_minor ?? "0"],
+              ["E−3 harvested",fundedAllocation.allocation.harvested_unclaimed_minor ?? "0"],
+              ["Carry-in",fundedAllocation.allocation.carry_in_minor ?? "0"],
+              ["Redistribution pool",sumIntegerValues(fundedAllocation.allocation.score_pool_minor,fundedAllocation.allocation.harvested_unclaimed_minor,fundedAllocation.allocation.carry_in_minor)],
+              ["Top-up / carry-out",`${fundedAllocation.allocation.top_up_minor ?? "0"} / ${fundedAllocation.allocation.carry_out_residue_minor ?? "0"}`],
               ["Final allocation",fundedAllocation.allocation.final_allocation_minor ?? "0"],
               ["Users",String(fundedAllocation.allocation.user_count ?? 0)],
               ["Manifest",fundedAllocation.allocation.manifest_hash?.slice(0,12) ?? "pending"],
@@ -296,6 +299,8 @@ export default async function AdminCyclePrepPage({ params }: PageProps) {
             ["Stage",epochClose.status ?? "payout_readying"],["Funded minor",String(epochClose.funded_minor ?? 0)],
             ["Final / residue",`${epochClose.final_allocation_minor ?? 0} / ${epochClose.returned_residue_minor ?? 0}`],
             ["Pool / top-up",`${epochClose.redistribution_pool_minor ?? 0} / ${epochClose.top_up_minor ?? 0}`],
+            ["Selected cap",epochClose.cap_multiple == null ? "pending" : `${Number(epochClose.cap_multiple).toFixed(2)}×`],
+            ["E−3 harvested",String(epochClose.harvested_unclaimed_minor ?? 0)],
             ["Conditional users",String(epochClose.user_count ?? 0)],["Artifacts",String(epochClose.artifact_count ?? 0)],
             ["Result",epochClose.result_hash?.slice(0,12) ?? "pending"],["Root",epochClose.root_hash?.slice(0,12) ?? "pending"],
           ].map(([label,value])=><div key={label} className="rounded-xl border border-[color:var(--surface-border)] p-3"><p className="text-xs uppercase tracking-[0.14em] text-[var(--text-soft)]">{label}</p><p className="mt-1 break-all font-mono font-semibold">{value}</p></div>)}

--- a/app/[locale]/(app)/founder/projects/[slug]/reporting/page.tsx
+++ b/app/[locale]/(app)/founder/projects/[slug]/reporting/page.tsx
@@ -70,6 +70,7 @@ export default async function FounderProjectReportingPage({ params }: PageProps)
         values={[
           {label:"Funded minor",value:epochClose.fundedMinor},{label:"Eligible cohort",value:String(epochClose.cohortCount)},
           {label:"Initial claim USD",value:epochClose.initialClaimExactUsd},{label:"Score-pool contribution USD",value:epochClose.scorePoolContributionExactUsd},
+          {label:"Selected cap multiple",value:`${epochClose.capMultiple}×`},{label:"Epoch harvest (aggregate)",value:epochClose.harvestedUnclaimedMinor},
         ]}
       /> : null}
 

--- a/app/[locale]/(app)/workspace/earnings/page.tsx
+++ b/app/[locale]/(app)/workspace/earnings/page.tsx
@@ -300,7 +300,9 @@ export default async function WorkspaceEarningsPage({ params }: WorkspaceEarning
         cycleKey={epochClose.cycleKey}
         rootHash={epochClose.rootHash}
         values={[
-          {label:"Retained initial",value:epochClose.retainedInitialMinor},{label:"Redistribution top-up",value:epochClose.topUpMinor},
+          {label:"Initial claims",value:epochClose.initialClaimMinor},{label:"Redistribution top-up",value:epochClose.topUpMinor},
+          {label:"Top-up ceiling",value:epochClose.redistributionCeilingMinor},{label:"Selected cap multiple",value:`${epochClose.capMultiple}×`},
+          {label:"Epoch harvest (aggregate)",value:epochClose.harvestedUnclaimedMinor},
           {label:"Final minor units",value:epochClose.finalAwardMinor},{label:"Payable state",value:epochClose.payableStatus},
         ]}
       /> : null}

--- a/app/[locale]/(public)/page.tsx
+++ b/app/[locale]/(public)/page.tsx
@@ -1,371 +1,155 @@
-import Link from "next/link"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { getTranslations } from "next-intl/server"
-import { ArrowRight, ExternalLink, HeartHandshake, ShieldCheck, Sparkles, Users } from "lucide-react"
+import { ArrowRight, Bot, Building2, Eye, FlaskConical, LockKeyhole, UserRound } from "lucide-react"
 import { Link as LocaleLink } from "@/i18n/navigation"
 import { isValidLocale } from "@/i18n/routing"
 import { Button } from "@/components/ui/button"
-import {
-  MarketingPage,
-  MarketingSection,
-  SectionBody,
-  SectionEyebrow,
-  SectionTitle,
-} from "@/components/marketing/page-chrome"
+import { MarketingPage, MarketingSection, SectionBody, SectionEyebrow, SectionTitle } from "@/components/marketing/page-chrome"
 import { Reveal } from "@/components/marketing/reveal"
-import { NetworkConstellation } from "@/components/marketing/network-constellation"
-import { JourneyConfidenceBand, type JourneyConfidenceItem } from "@/components/marketing/journey-confidence-band"
-import { RotatingHeroTitle } from "@/components/marketing/rotating-hero-title"
-import { ecosystemSites, resourceLinks } from "@/lib/public-site"
-import { useCases } from "@/lib/use-cases"
+import { MonthlyLoopVisual } from "@/components/marketing/monthly-loop-visual"
 
-const iconMap = {
-  fairdrops: Sparkles,
-  "proof-of-humanity": ShieldCheck,
-  "community-engagement": Users,
-  "give-back": HeartHandshake,
-  "viral-growth": Sparkles,
+type MonthlyStage = { step: string; title: string; body: string }
+type Audience = { id: "people" | "projects" | "research" | "operators"; label: string; title: string; body: string; href: string; cta: string }
+type Principle = { title: string; body: string }
+
+const audienceIcons = {
+  people: UserRound,
+  projects: Building2,
+  research: FlaskConical,
+  operators: Bot,
 } as const
 
-const ecosystemPreviewNames = ["ChainCrew", "ClearPass", "Cubid", "SmarTrust", "TCOIN", "Solar Village"] as const
-
-type HomeStep = {
-  step: string
-  title: string
-  body: string
-}
-
-type EntryPath =
-  {
-    eyebrow: string
-    title: string
-    body: string
-    cta: string
-    href: string
-  }
-
-type PageProps = {
-  params: Promise<{ locale: string }>
-}
+type PageProps = { params: Promise<{ locale: string }> }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { locale } = await params
   const t = await getTranslations({ locale, namespace: "metadata.home" })
-
-  return {
-    title: t("title"),
-    description: t("description"),
-  }
+  return { title: t("title"), description: t("description") }
 }
 
 export default async function Home({ params }: PageProps) {
   const { locale } = await params
-
-  if (!isValidLocale(locale)) {
-    notFound()
-  }
+  if (!isValidLocale(locale)) notFound()
 
   const t = await getTranslations({ locale, namespace: "home" })
-  const polishT = await getTranslations({ locale, namespace: "journeyPolish.home" })
-  const shellT = await getTranslations({ locale, namespace: "shell" })
-  const loopSteps = t.raw("howItWorks.steps") as HomeStep[]
-  const entryPaths = t.raw("entryPaths") as EntryPath[]
-  const heroPrefixes = t.raw("heroPrefixes") as string[]
-  const exploreResourceLinks = resourceLinks.map((link) => ({
-    ...link,
-    label: shellT(`nav.resourceLinks.${link.id}.label`),
-    description: shellT(`nav.resourceLinks.${link.id}.description`),
-  }))
-  const ecosystemPreviewSites = ecosystemPreviewNames
-    .map((name) => ecosystemSites.find((site) => site.name === name))
-    .filter((site): site is (typeof ecosystemSites)[number] => Boolean(site))
+  const stages = t.raw("monthlyLoop.stages") as MonthlyStage[]
+  const audiences = t.raw("audiences.items") as Audience[]
+  const principles = t.raw("trust.items") as Principle[]
 
   return (
-    <MarketingPage>
-      <section className="relative min-h-[calc(100svh-5.5rem)]">
-        <div className="mx-auto grid min-h-[calc(100svh-5.5rem)] max-w-7xl grid-cols-[minmax(0,1fr)] items-end gap-12 px-6 pb-14 pt-10 sm:px-8 lg:grid-cols-[minmax(0,1.02fr)_minmax(22rem,0.98fr)] lg:px-12">
-          <Reveal className="min-w-0 max-w-3xl pb-4">
-            <SectionEyebrow>{t("eyebrow")}</SectionEyebrow>
-            <p className="mt-6 font-display text-[clamp(4rem,12vw,8.5rem)] leading-none tracking-[-0.07em]">FundLoop</p>
-            <RotatingHeroTitle prefixes={heroPrefixes} suffix={t("heroSuffix")} />
-            <SectionBody className="mt-6 max-w-xl font-medium text-[var(--marketing-ink)]">
-              {t("heroThesis")}
-            </SectionBody>
-            <SectionBody className="mt-3 max-w-xl">{t("heroBody")}</SectionBody>
-            <div id="project-signup" className="mt-10 flex scroll-mt-28 flex-col gap-4 sm:flex-row">
-              <Button
-                asChild
-                size="lg"
-                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
-              >
-                <LocaleLink href="/?onboarding=project">
-                  {t("ctas.project")}
-                  <ArrowRight className="h-4 w-4" />
-                </LocaleLink>
+    <MarketingPage className="[--marketing-accent:#d45f35]">
+      <section className="relative min-h-[calc(100svh-5.5rem)] overflow-hidden border-b border-[color:var(--marketing-line)] bg-[#101b1a] text-[#fff9ef]">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_75%_20%,rgba(212,95,53,0.24),transparent_30%),radial-gradient(circle_at_10%_82%,rgba(126,175,203,0.16),transparent_33%)]" />
+        <div className="relative mx-auto grid min-h-[calc(100svh-5.5rem)] max-w-[100rem] items-center gap-10 px-6 py-12 sm:px-8 lg:grid-cols-[minmax(0,0.82fr)_minmax(34rem,1.18fr)] lg:px-12">
+          <Reveal className="z-10 max-w-3xl">
+            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.3em] text-[#f5b195]">{t("eyebrow")}</p>
+            <p className="mt-6 font-display text-[clamp(4.25rem,10vw,8.5rem)] leading-[0.8] tracking-[-0.075em]">FundLoop</p>
+            <h1 className="mt-8 max-w-3xl text-[clamp(2.15rem,5vw,4.65rem)] font-semibold leading-[0.95] tracking-[-0.055em]">
+              {t("heroTitle")}
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg leading-8 text-[#dbe3df]">{t("heroBody")}</p>
+            <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+              <Button asChild size="lg" className="rounded-full bg-[#e06b40] px-7 text-white hover:bg-[#ef7950]">
+                <LocaleLink href="/?onboarding=user">{t("ctas.participant")}<ArrowRight className="h-4 w-4" /></LocaleLink>
               </Button>
-              <Button
-                asChild
-                size="lg"
-                variant="outline"
-                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 text-[var(--marketing-ink)] hover:bg-black/[0.04] dark:text-[var(--marketing-paper)] dark:hover:bg-white/[0.06]"
-              >
-                <LocaleLink href="/?onboarding=user">
-                  {t("ctas.participant")}
-                  <ArrowRight className="h-4 w-4" />
-                </LocaleLink>
+              <Button asChild size="lg" variant="outline" className="rounded-full border-white/28 bg-white/[0.04] px-7 text-white hover:bg-white/10 hover:text-white">
+                <LocaleLink href="/?onboarding=project">{t("ctas.project")}<ArrowRight className="h-4 w-4" /></LocaleLink>
               </Button>
-            </div>
-            <div className="mt-10 grid gap-3 text-sm text-[var(--marketing-muted-strong)] sm:grid-cols-3">
-              <p className="border-t border-[color:var(--marketing-line)] pt-3">{t("statLines.projects")}</p>
-              <p className="border-t border-[color:var(--marketing-line)] pt-3">{t("statLines.people")}</p>
-              <p className="border-t border-[color:var(--marketing-line)] pt-3">{t("statLines.value")}</p>
             </div>
           </Reveal>
 
-          <Reveal delay={120} className="lg:pb-6">
-            <NetworkConstellation />
+          <Reveal
+            delay={120}
+            className="pointer-events-none absolute -right-[19rem] top-20 w-[34rem] min-w-0 opacity-55 sm:-right-64 sm:top-16 lg:pointer-events-auto lg:static lg:w-auto lg:opacity-100"
+          >
+            <MonthlyLoopVisual
+              monthLabel={t("monthlyLoop.visual.month")}
+              centerLabel={t("monthlyLoop.visual.center")}
+              stages={stages.map(({ title }) => title)}
+            />
           </Reveal>
         </div>
       </section>
 
-      <JourneyConfidenceBand
-        eyebrow={polishT("eyebrow")}
-        title={polishT("title")}
-        body={polishT("body")}
-        primaryCta={polishT("primaryCta")}
-        primaryHref="/participation"
-        secondaryCta={polishT("secondaryCta")}
-        secondaryHref="/founders"
-        items={polishT.raw("items") as JourneyConfidenceItem[]}
-      />
-
-      <MarketingSection className="border-b border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
-        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-20">
+      <MarketingSection className="border-b border-[color:var(--marketing-line)] bg-white/35 dark:bg-white/[0.02]">
+        <div className="grid gap-14 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)] lg:gap-24">
           <Reveal className="lg:sticky lg:top-28 lg:self-start">
-            <SectionEyebrow>{t("theoryOfChange.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 max-w-lg text-5xl sm:text-6xl">
-              {t("theoryOfChange.title")}
-            </SectionTitle>
-            <SectionBody className="mt-5">{t("theoryOfChange.body")}</SectionBody>
+            <SectionEyebrow>{t("monthlyLoop.eyebrow")}</SectionEyebrow>
+            <SectionTitle className="mt-5 max-w-xl text-5xl sm:text-6xl">{t("monthlyLoop.title")}</SectionTitle>
+            <SectionBody className="mt-6">{t("monthlyLoop.body")}</SectionBody>
           </Reveal>
-
-          <div>
-            {["capitalism", "basicIncome", "pluralism"].map((idea, index) => (
-              <Reveal key={idea} delay={index * 90}>
-                <article className="grid gap-5 border-t border-[color:var(--marketing-line)] py-8 sm:grid-cols-[4rem_minmax(0,1fr)] sm:py-10">
-                  <p className="font-display text-3xl leading-none text-[var(--marketing-accent)]">
-                    {String(index + 1).padStart(2, "0")}
-                  </p>
+          <ol>
+            {stages.map((stage, index) => (
+              <Reveal key={stage.step} delay={index * 55}>
+                <li className="group grid gap-5 border-t border-[color:var(--marketing-line)] py-7 sm:grid-cols-[5.5rem_minmax(0,1fr)] sm:py-9">
+                  <span className="font-display text-4xl leading-none text-[var(--marketing-accent)] transition-transform duration-300 group-hover:translate-x-1">{stage.step}</span>
                   <div>
-                    <h2 className="max-w-2xl font-display text-3xl leading-[1.02] tracking-[-0.04em] sm:text-4xl">
-                      {t(`theoryOfChange.ideas.${idea}.title`)}
-                    </h2>
-                    <p className="mt-4 max-w-2xl text-base leading-7 text-[var(--marketing-muted-strong)]">
-                      {t(`theoryOfChange.ideas.${idea}.body`)}
-                    </p>
+                    <h2 className="text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">{stage.title}</h2>
+                    <p className="mt-3 max-w-2xl text-base leading-7 text-[var(--marketing-muted-strong)]">{stage.body}</p>
                   </div>
-                </article>
+                </li>
               </Reveal>
             ))}
-          </div>
-        </div>
-      </MarketingSection>
-
-      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
-        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.88fr)_minmax(0,1.12fr)]">
-          <Reveal className="lg:sticky lg:top-28 lg:self-start">
-            <SectionEyebrow>{t("howItWorks.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 max-w-xl text-5xl sm:text-6xl">{t("howItWorks.title")}</SectionTitle>
-            <SectionBody className="mt-5">{t("howItWorks.body")}</SectionBody>
-          </Reveal>
-
-          <div className="space-y-10">
-            {loopSteps.map((item, index) => (
-              <Reveal key={item.step} delay={index * 90}>
-                <div className="grid gap-5 border-t border-[color:var(--marketing-line)] pt-6 sm:grid-cols-[5rem_minmax(0,1fr)]">
-                  <p className="font-display text-4xl leading-none text-[var(--marketing-accent)]">{item.step}</p>
-                  <div>
-                    <h2 className="text-2xl font-semibold tracking-[-0.04em] sm:text-3xl">{item.title}</h2>
-                    <p className="mt-3 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{item.body}</p>
-                  </div>
-                </div>
-              </Reveal>
-            ))}
-          </div>
+          </ol>
         </div>
       </MarketingSection>
 
       <MarketingSection>
-        <div className="grid gap-12 lg:grid-cols-2">
-          {entryPaths.map((path, index) => (
-            <Reveal key={path.title} delay={index * 120}>
-              <div className="flex h-full flex-col justify-between border-t border-[color:var(--marketing-line)] pt-6">
-                <div>
-                  <SectionEyebrow>{path.eyebrow}</SectionEyebrow>
-                  <h2 className="mt-4 max-w-lg font-display text-4xl leading-none tracking-[-0.04em] sm:text-5xl">
-                    {path.title}
-                  </h2>
-                  <p className="mt-5 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{path.body}</p>
-                </div>
-                <LocaleLink
-                  href={path.href}
-                  className="group mt-10 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]"
-                >
-                  {path.cta}
-                  <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
-                </LocaleLink>
-              </div>
-            </Reveal>
-          ))}
-        </div>
-      </MarketingSection>
-
-      <MarketingSection id="use-cases" className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
-        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1.22fr)]">
-          <Reveal className="lg:sticky lg:top-28 lg:self-start">
-            <SectionEyebrow>{t("useCases.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 text-5xl sm:text-6xl">{t("useCases.title")}</SectionTitle>
-            <SectionBody className="mt-5">{t("useCases.body")}</SectionBody>
-          </Reveal>
-
-          <div className="space-y-5">
-            {useCases.map((useCase, index) => {
-              const Icon = iconMap[useCase.slug as keyof typeof iconMap] ?? Sparkles
-
-              return (
-                <Reveal key={useCase.slug} delay={index * 80}>
-                  <LocaleLink
-                    href={useCase.href}
-                    className="group block border-t border-[color:var(--marketing-line)] px-1 py-6 transition-colors hover:text-[var(--marketing-accent)]"
-                  >
-                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="max-w-2xl">
-                        <div className="flex items-center gap-3">
-                          <span className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--marketing-line)] bg-white/55 dark:bg-white/[0.04]">
-                            <Icon className="h-4 w-4" />
-                          </span>
-                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[var(--marketing-muted)]">
-                            {t(`useCases.items.${useCase.slug}.eyebrow`)}
-                          </p>
-                        </div>
-                        <h2 className="mt-4 font-display text-4xl leading-none tracking-[-0.04em]">
-                          {t(`useCases.items.${useCase.slug}.label`)}
-                        </h2>
-                        <p className="mt-4 text-base leading-7 text-[var(--marketing-muted-strong)]">
-                          {t(`useCases.items.${useCase.slug}.description`)}
-                        </p>
-                      </div>
-                      <span className="mt-1 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em]">
-                        {t("useCases.explore")}
-                        <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
-                      </span>
-                    </div>
-                  </LocaleLink>
-                </Reveal>
-              )
-            })}
-          </div>
-        </div>
-      </MarketingSection>
-
-      <MarketingSection>
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.86fr)_minmax(0,1.14fr)]">
-          <Reveal>
-            <SectionEyebrow>{t("ecosystem.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 text-5xl sm:text-6xl">{t("ecosystem.title")}</SectionTitle>
-            <SectionBody className="mt-5">{t("ecosystem.body")}</SectionBody>
-            <LocaleLink
-              href="/ecosystem"
-              className="group mt-8 inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]"
-            >
-              {t("ecosystem.cta")}
-              <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
-            </LocaleLink>
-          </Reveal>
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            {ecosystemPreviewSites.map((site, index) => (
-              <Reveal key={site.url} delay={index * 70}>
-                <Link
-                  href={site.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="group flex h-full flex-col justify-between rounded-[1.75rem] border border-[color:var(--marketing-line)] bg-white/58 p-5 transition-transform duration-200 hover:-translate-y-1 dark:bg-white/[0.03]"
-                >
-                  <div>
-                    <p className="text-sm font-semibold uppercase tracking-[0.18em]">{site.name}</p>
-                    <p className="mt-3 text-sm leading-6 text-[var(--marketing-muted-strong)]">
-                      {t(`ecosystem.sites.${site.name}`)}
-                    </p>
-                  </div>
-                  <span className="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[var(--marketing-accent)]">
-                    {t("ecosystem.visitSite")}
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </span>
-                </Link>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </MarketingSection>
-
-      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-white/34 dark:bg-white/[0.02]">
-        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)]">
-          <Reveal className="lg:sticky lg:top-28 lg:self-start">
-            <SectionEyebrow>{t("resources.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 text-5xl sm:text-6xl">{t("resources.title")}</SectionTitle>
-          </Reveal>
-          <div className="grid gap-5 sm:grid-cols-2">
-            {exploreResourceLinks.map((resource, index) => (
-              <Reveal key={resource.href} delay={index * 70}>
-                <LocaleLink
-                  href={resource.href}
-                  className="group flex min-h-48 flex-col justify-between rounded-[1.75rem] border border-[color:var(--marketing-line)] bg-white/58 p-5 transition-transform duration-200 hover:-translate-y-1 dark:bg-white/[0.03]"
-                >
-                  <div>
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-[var(--marketing-muted)]">
-                      {resource.label}
-                    </p>
-                    <p className="mt-4 text-base leading-7 text-[var(--marketing-muted-strong)]">{resource.description}</p>
-                  </div>
-                  <span className="mt-8 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-[var(--marketing-accent)]">
-                    {t("resources.openPage")}
-                    <ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 group-hover:translate-x-1" />
-                  </span>
-                </LocaleLink>
-              </Reveal>
-            ))}
-          </div>
-        </div>
-      </MarketingSection>
-
-      <MarketingSection className="pb-24 pt-10">
         <Reveal>
-          <div className="rounded-[2rem] border border-[color:var(--marketing-line)] bg-[linear-gradient(135deg,rgba(255,248,238,0.84),rgba(244,203,141,0.2))] p-8 dark:bg-[linear-gradient(135deg,rgba(18,27,25,0.94),rgba(239,139,87,0.12))] sm:p-10">
-            <SectionEyebrow>{t("closing.eyebrow")}</SectionEyebrow>
-            <SectionTitle className="mt-4 max-w-4xl text-5xl sm:text-6xl">{t("closing.title")}</SectionTitle>
-            <SectionBody className="mt-5 max-w-3xl">{t("closing.body")}</SectionBody>
-            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
-              <Button
-                asChild
-                size="lg"
-                className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/92"
-              >
-                <LocaleLink href="/?onboarding=project">
-                  {t("closing.project")}
-                  <ArrowRight className="h-4 w-4" />
+          <SectionEyebrow>{t("audiences.eyebrow")}</SectionEyebrow>
+          <SectionTitle className="mt-5 max-w-4xl text-5xl sm:text-7xl">{t("audiences.title")}</SectionTitle>
+          <SectionBody className="mt-6">{t("audiences.body")}</SectionBody>
+        </Reveal>
+        <div className="mt-14 grid border-t border-[color:var(--marketing-line)] lg:grid-cols-2">
+          {audiences.map((audience, index) => {
+            const Icon = audienceIcons[audience.id]
+            return (
+              <Reveal key={audience.id} delay={index * 70}>
+                <LocaleLink href={audience.href} className="group block min-h-full border-b border-[color:var(--marketing-line)] py-9 lg:odd:border-r lg:odd:pr-10 lg:even:pl-10">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="inline-flex items-center gap-3 text-[0.68rem] font-semibold uppercase tracking-[0.24em] text-[var(--marketing-muted)]"><Icon className="h-4 w-4 text-[var(--marketing-accent)]" />{audience.label}</span>
+                    <ArrowRight className="h-5 w-5 text-[var(--marketing-accent)] transition-transform duration-300 group-hover:translate-x-1" />
+                  </div>
+                  <h2 className="mt-7 max-w-xl font-display text-4xl leading-[0.98] tracking-[-0.045em] sm:text-5xl">{audience.title}</h2>
+                  <p className="mt-5 max-w-xl text-base leading-7 text-[var(--marketing-muted-strong)]">{audience.body}</p>
+                  <span className="mt-7 inline-block text-xs font-semibold uppercase tracking-[0.2em] text-[var(--marketing-accent)]">{audience.cta}</span>
                 </LocaleLink>
-              </Button>
-              <Button
-                asChild
-                variant="outline"
-                size="lg"
-                className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]"
-              >
-                <LocaleLink href="/?onboarding=user">{t("closing.participant")}</LocaleLink>
-              </Button>
-            </div>
+              </Reveal>
+            )
+          })}
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="border-y border-[color:var(--marketing-line)] bg-[#101b1a] text-[#fff9ef]">
+        <div className="grid gap-14 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)] lg:gap-24">
+          <Reveal>
+            <span className="inline-flex h-14 w-14 items-center justify-center rounded-full border border-white/18 text-[#f5b195]"><LockKeyhole className="h-6 w-6" /></span>
+            <p className="mt-7 text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-[#f5b195]">{t("trust.eyebrow")}</p>
+            <h2 className="mt-5 max-w-2xl font-display text-5xl leading-[0.94] tracking-[-0.05em] sm:text-6xl">{t("trust.title")}</h2>
+            <p className="mt-6 max-w-xl text-lg leading-8 text-[#cbd8d3]">{t("trust.body")}</p>
+          </Reveal>
+          <div>
+            {principles.map((principle, index) => (
+              <Reveal key={principle.title} delay={index * 80}>
+                <div className="grid gap-4 border-t border-white/14 py-7 sm:grid-cols-[3rem_minmax(0,1fr)]">
+                  <Eye className="mt-1 h-5 w-5 text-[#f5b195]" />
+                  <div><h3 className="text-xl font-semibold tracking-[-0.025em]">{principle.title}</h3><p className="mt-2 max-w-2xl leading-7 text-[#b9cac4]">{principle.body}</p></div>
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </MarketingSection>
+
+      <MarketingSection className="py-20 sm:py-28">
+        <Reveal>
+          <p className="font-display text-[clamp(3.5rem,9vw,8rem)] leading-[0.83] tracking-[-0.07em] text-[var(--marketing-accent)]">{t("closing.kicker")}</p>
+          <SectionTitle className="mt-7 max-w-5xl text-5xl sm:text-7xl">{t("closing.title")}</SectionTitle>
+          <SectionBody className="mt-6 max-w-3xl">{t("closing.body")}</SectionBody>
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row">
+            <Button asChild size="lg" className="rounded-full bg-[var(--marketing-accent)] px-7 text-white hover:bg-[color:var(--marketing-accent)]/90"><LocaleLink href="/participation">{t("closing.participant")}<ArrowRight className="h-4 w-4" /></LocaleLink></Button>
+            <Button asChild size="lg" variant="outline" className="rounded-full border-[color:var(--marketing-line-strong)] bg-transparent px-7"><LocaleLink href="/documentation">{t("closing.documentation")}</LocaleLink></Button>
           </div>
         </Reveal>
       </MarketingSection>

--- a/app/[locale]/(public)/projects/[slug]/page.tsx
+++ b/app/[locale]/(public)/projects/[slug]/page.tsx
@@ -165,6 +165,8 @@ export default async function ProjectPage({ params }: PageProps) {
           values={[
             {label:"Funded minor",value:epochClose.funded_minor == null ? "Privacy threshold not met" : String(epochClose.funded_minor)},
             {label:"Published cohort",value:epochClose.published_cohort_count == null ? "Privacy threshold not met" : String(epochClose.published_cohort_count)},
+            {label:"Selected cap multiple",value:epochClose.cap_multiple == null ? "Privacy threshold not met" : `${Number(epochClose.cap_multiple).toFixed(2)}×`},
+            {label:"Epoch harvest (aggregate)",value:epochClose.harvested_unclaimed_minor == null ? "Privacy threshold not met" : String(epochClose.harvested_unclaimed_minor)},
             {label:"Sources",value:epochClose.source_count == null ? "Privacy threshold not met" : String(epochClose.source_count)},{label:"Stage",value:epochClose.status ?? "payout_readying"},
           ]}
         /></Reveal>

--- a/app/globals.css
+++ b/app/globals.css
@@ -76,6 +76,16 @@
   }
 }
 
+@keyframes loop-node-pulse {
+  0%, 100% { opacity: 0.58; transform: translate(-50%, -50%) scale(0.96); }
+  45% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+@keyframes loop-dash {
+  0%, 100% { stroke-dasharray: 5 100; stroke-dashoffset: 0; opacity: 0.45; }
+  50% { stroke-dasharray: 26 100; stroke-dashoffset: -18; opacity: 1; }
+}
+
 @keyframes accordion-down {
   from {
     height: 0;

--- a/components/admin/epoch-funded-allocation-actions.tsx
+++ b/components/admin/epoch-funded-allocation-actions.tsx
@@ -9,14 +9,25 @@ import { invokeEpochFundedAllocationBrowser } from "@/lib/edge-functions/epoch-f
 export function EpochFundedAllocationActions({ cycleKey }: { cycleKey: string }) {
   const router=useRouter()
   const {toast}=useToast()
-  const [busy,setBusy]=useState<"lock"|"calculate"|null>(null)
+  const [busy,setBusy]=useState<"preview"|"lock"|"calculate"|null>(null)
+  const [capMultiple,setCapMultiple]=useState("3.00")
+  const [preview,setPreview]=useState<{hash:string;totals:Record<string,string>}|null>(null)
 
-  async function run(action:"lock"|"calculate") {
+  async function run(action:"preview"|"lock"|"calculate") {
     setBusy(action)
-    const result=await invokeEpochFundedAllocationBrowser({action,cycleKey})
+    const result=await invokeEpochFundedAllocationBrowser(action==="preview"
+      ? {action,cycleKey,capMultiple}
+      : action==="lock"
+        ? {action,cycleKey,capMultiple,selectedPreviewHash:preview?.hash ?? ""}
+        : {action,cycleKey})
     setBusy(null)
     if(!result.ok){toast({title:"Settled allocation failed",description:result.error.message,variant:"destructive"});return}
     if(result.data.action==="read"){toast({title:"Settled allocation failed",description:"Unexpected read response.",variant:"destructive"});return}
+    if(result.data.action==="preview"){
+      setPreview({hash:result.data.previewHash,totals:result.data.artifact.totals})
+      toast({title:"Cap scenario previewed",description:`${result.data.artifact.capMultiple}× leaves ${result.data.artifact.totals.carryOutResidueMinor ?? "0"} minor units to carry forward.`})
+      return
+    }
     const description=result.data.action==="calculate"
       ? `Run ${result.data.runId} recorded with result ${result.data.artifact.resultHash.slice(0,12)}…`
       : `Manifest ${result.data.manifestHash.slice(0,12)}… locked without creating a payable.`
@@ -24,8 +35,20 @@ export function EpochFundedAllocationActions({ cycleKey }: { cycleKey: string })
     router.refresh()
   }
 
-  return <div className="flex flex-wrap gap-2">
-    <Button type="button" variant="outline" disabled={busy!==null} onClick={()=>run("lock")}>{busy==="lock"?"Locking…":"Lock funded inputs"}</Button>
-    <Button type="button" disabled={busy!==null} onClick={()=>run("calculate")}>{busy==="calculate"?"Calculating…":"Calculate provisional redistribution"}</Button>
+  return <div className="space-y-3">
+    <div className="flex flex-wrap items-end gap-2">
+      <label className="grid gap-1 text-xs font-medium uppercase tracking-[0.14em] text-[var(--text-soft)]">
+        Redistribution ceiling multiple
+        <input type="number" min="1" max="10" step="0.01" value={capMultiple}
+          onChange={(event)=>{setCapMultiple(Number(event.target.value).toFixed(2));setPreview(null)}}
+          className="h-10 w-32 rounded-[var(--radius-md)] border border-[color:var(--surface-border)] bg-[var(--surface-panel-strong)] px-3 font-mono text-sm text-[var(--text-strong)]" />
+      </label>
+      <Button type="button" variant="outline" disabled={busy!==null} onClick={()=>run("preview")}>{busy==="preview"?"Previewing…":"Preview scenario"}</Button>
+      <Button type="button" variant="outline" disabled={busy!==null||!preview} onClick={()=>run("lock")}>{busy==="lock"?"Locking…":"Lock selected scenario"}</Button>
+      <Button type="button" disabled={busy!==null} onClick={()=>run("calculate")}>{busy==="calculate"?"Calculating…":"Calculate provisional redistribution"}</Button>
+    </div>
+    {preview ? <p className="text-sm text-[var(--text-muted)]">
+      Selected preview <span className="font-mono">{preview.hash.slice(0,12)}…</span>: {preview.totals.finalAllocationMinor ?? "0"} allocated, {preview.totals.harvestedUnclaimedMinor ?? "0"} harvested, {preview.totals.carryOutResidueMinor ?? "0"} carried forward.
+    </p> : null}
   </div>
 }

--- a/components/marketing/monthly-loop-visual.tsx
+++ b/components/marketing/monthly-loop-visual.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import type { CSSProperties } from "react"
+
+type MonthlyLoopVisualProps = {
+  monthLabel: string
+  centerLabel: string
+  stages: string[]
+}
+
+const positions = [
+  { left: "50%", top: "5%" },
+  { left: "82%", top: "20%" },
+  { left: "94%", top: "51%" },
+  { left: "76%", top: "82%" },
+  { left: "34%", top: "91%" },
+  { left: "5%", top: "67%" },
+  { left: "10%", top: "27%" },
+] as const
+
+export function MonthlyLoopVisual({ monthLabel, centerLabel, stages }: MonthlyLoopVisualProps) {
+  return (
+    <div className="relative mx-auto aspect-square w-full max-w-[44rem]" aria-label={centerLabel}>
+      <div className="absolute inset-[13%] rounded-full border border-dashed border-white/18 animate-[spin_50s_linear_infinite] motion-reduce:animate-none" />
+      <div className="absolute inset-[24%] rounded-full border border-white/12" />
+      <div className="absolute inset-[31%] hidden flex-col items-center justify-center rounded-full bg-[#fff9ef] px-8 text-center text-[#101b1a] shadow-[0_0_100px_rgba(224,107,64,0.2)] lg:flex">
+        <span className="text-[0.62rem] font-semibold uppercase tracking-[0.26em] text-[#a74727]">{monthLabel}</span>
+        <span className="mt-3 font-display text-[clamp(1.7rem,4vw,3.5rem)] leading-[0.9] tracking-[-0.05em]">{centerLabel}</span>
+      </div>
+      {stages.slice(0, 7).map((stage, index) => (
+        <div
+          key={`${index}-${stage}`}
+          className="absolute z-10 w-[8.5rem] -translate-x-1/2 -translate-y-1/2 animate-[loop-node-pulse_6s_ease-in-out_infinite] text-center motion-reduce:animate-none sm:w-[10rem]"
+          style={{ ...positions[index], animationDelay: `${index * 420}ms` } as CSSProperties}
+        >
+          <span className="mx-auto block h-2.5 w-2.5 rounded-full bg-[#ef7950] shadow-[0_0_0_7px_rgba(239,121,80,0.12)]" />
+          <span className="mt-3 hidden text-[0.6rem] font-semibold uppercase leading-4 tracking-[0.16em] text-[#dbe3df] lg:block lg:text-[0.67rem]">{stage}</span>
+        </div>
+      ))}
+      <svg className="absolute inset-0 h-full w-full" viewBox="0 0 100 100" aria-hidden="true">
+        <circle cx="50" cy="50" r="37" fill="none" stroke="rgba(255,255,255,0.12)" strokeWidth="0.35" />
+        <path d="M49 13 A37 37 0 0 1 84 39" fill="none" stroke="#ef7950" strokeLinecap="round" strokeWidth="0.8" className="animate-[loop-dash_5s_ease-in-out_infinite] motion-reduce:animate-none" />
+      </svg>
+    </div>
+  )
+}

--- a/docs/engineering/README.md
+++ b/docs/engineering/README.md
@@ -13,6 +13,7 @@ Current high-signal docs:
 
 - [Allocation Architecture](./allocation.md)
 - [Backgrounder for Agents](./backgrounder-for-agents.md)
+- [Capability Review — 2026-08-11](./capability-review-2026-08-11.md)
 - [Beta Runtime Guardrails](./beta-guardrails.md)
 - [Current-State Architecture](./current-state-architecture.md)
 - [CUBID Identity and Snapshot Model](./cubid-identity.md)

--- a/docs/engineering/allocation.md
+++ b/docs/engineering/allocation.md
@@ -1,548 +1,111 @@
-# Allocation Architecture
+# Settled Cubid Redistribution v2
 
-Last updated: 2026-08-09
+Status: implemented behind local, development, preview, and test controls. Production value flow remains disabled.
 
-Related docs:
+Policy key: `settled_cubid_redistribution_v2`
 
-- [Engineering Docs Index](./README.md)
-- [Operational MVP](./operational-mvp.md)
-- [Monthly Cycle Domain Model](./monthly-cycles.md)
-- [Settlement-backed Epoch Treasury](./settlement-backed-epoch-treasury.md)
-- [Outbound Payout Domain](./payouts.md)
+The v1 policy and its persisted artifacts remain reproducible. New monthly calculations use v2 and must never reinterpret or rewrite v1 records.
 
-## Summary
+## Policy summary
 
-FundLoop allocation converts fee-processed, settled, journal-backed project value
-into provisional user awards. The approved Goal #134 model is a deterministic,
-USD-normalized Cubid-score discount followed by one global epoch redistribution:
+Each approved, settled project source is divided equally among that project's eligible cohort. Each theoretical share is multiplied by the member's locked Cubid score divided by the locked maximum score. The result is that member's score-adjusted initial claim for that project.
 
-1. divide each funded project pool equally among that project's eligible users;
-2. discount each theoretical share by the user's locked Cubid score divided by the
-   locked maximum score;
-3. aggregate score-adjusted initial claims across projects;
-4. clamp any aggregate initial claim above three times its largest single-project
-   claim and contribute the proportionally sourced overflow to the pool;
-5. combine every score-discount shortfall and overlap-cap overflow into one epoch
-   redistribution pool;
-6. raise the lowest current user totals first through deterministic water-filling;
-7. exclude users already at cap from top-ups; and
-8. return or carry forward any cap-exhausted residue to its originating funded
-   sources.
+Every user is entitled to the full sum of all score-adjusted initial claims. The redistribution ceiling does not reduce those claims.
 
-This model explicitly supersedes allocation based on a user's share of total
-project points, the sum of eligible scores, or an overlap-derived remainder. A
-Cubid score is an individual factor against an equal theoretical project share; it
-is not a proportional weight against other users' scores.
-
-The allocator remains a pure calculation package. It consumes one immutable lock
-manifest, produces deterministic artifacts and hashes, and performs no live reads,
-provider calls, posting, or value transfer.
-
-## Locked Inputs
-
-The allocator consumes only immutable, versioned inputs:
-
-- approved project packages and eligible project-user cohorts;
-- fee-processed funding applications backed by reconciled custody and ledger
-  postings;
-- source lots identified by project, rail, asset, native amount, custody context,
-  FX snapshot, and functional USD;
-- one positive, versioned locked maximum Cubid score;
-- each eligible user's locked score, bounded from zero through that maximum;
-- project-scoped pseudonymous identity references and inclusion evidence;
-- the epoch FX snapshot and deterministic minor-unit rules;
-- user asset preferences and payout eligibility for later fulfillment only; and
-- stable project, user, source-lot, asset, and epoch identifiers.
-
-Declared contribution amounts, mutable activity points, unconfirmed receipts,
-unresolved receivables, draft cohorts, post-lock identity changes, and
-post-lock preference changes are not canonical allocation inputs. A project with
-no eligible users does not contribute value to the global pool; its funded sources
-follow the explicit return or carryover workflow.
-
-## Eligibility And Privacy
-
-A user is eligible for a project only when the locked package proves a valid,
-whitelisted Cubid identity, approved project-scoped inclusion, and resolution to
-the FundLoop user represented in the manifest. Greylisted, blacklisted, invalid,
-expired, or unresolved evidence follows the versioned exclusion or hold rules.
-
-Operators may inspect the complete audit graph. A project sees only its own
-project-scoped pseudonyms, inputs, and outcomes. Users see only their own
-project-source breakdown. Project and public read models must not expose raw Cubid
-evidence, cross-project membership, another project's pseudonym, or a join key that
-reveals the overlap used by redistribution. Public reporting remains aggregate and
-subject to the approved anti-correlation thresholds.
-
-## Funded Source Model
-
-Each post-fee distributable source remains an immutable provenance lot containing:
-
-- `epochId` and `originProjectId`;
-- rail, asset, custody account, and external/funding reference;
-- exact native quantity and asset decimals;
-- locked FX snapshot and exact functional-USD value;
-- carryover origin and predecessor lot when applicable; and
-- manifest position and stable source-lot key.
-
-The global redistribution pool is a calculated total over these lots, not an
-untracked fungible balance. Score-discount shortfalls and overlap-cap overflow each
-create source-linked pool lots. Top-ups consume those lots in a versioned stable
-order and record partial-lot splits. Unconsumed lots retain their original project,
-rail, asset, native, FX, and USD dimensions when returned or carried forward.
-
-Redistribution principal is funded epoch value. It is never classified as a
-platform fee, platform revenue, treasury sweep, user payable, or newly created
-value. Fee recognition and treasury sweeps occur before the distributable project
-pool is measured.
-
-### Implemented funded-input boundary (Task #135)
-
-The local/dev review path now materializes `epoch_valuation_source_lots` before
-allocation. Each lot retains its approved project package and funding-source ID,
-project, rail, financial asset, custody account, native atomic quantity, posted FX
-snapshot, exact 18-decimal gross/project-fee/base-fee/distributable USD values,
-canonical minor-unit scale, and deterministic source order. The lock-candidate
-view joins those lots to the package's eligible cohort and exposes the locked Cubid
-score, versioned maximum score, and eligible-user count without computing a claim.
-
-The prep boundary resolves each supported settled package source through an exact
-rail/asset custody route: fail-closed Stripe Customer Balance USD, Base
-USDC/USDT/PYUSD epoch-treasury receipts, Canadian CAD PAD, and EUR/GBP Pay by Bank.
-Each rail is revalidated against its canonical settled or exact evidence before FX
-and fee posting; a symbol-only or cross-rail match is rejected. Provider-hosted
-availability remains independent from this local accounting path and cannot enable
-production value flow.
-
-The four `$0.335` precision fixture is stored as four independent exact source lots;
-it is not pre-aggregated or rounded to cents. Carryover creates a successor lot with
-an explicit predecessor reference and the same funded-principal classification.
-Reserved value cannot be harvested. These are provisional funded epoch inputs—not
-fees, recognized revenue, user payables, provider instructions, or production value
-flow—and all Task #135 commands deny production.
-
-### Implemented settled-allocation boundary (Task #136)
-
-The local/dev review path now locks those approved, journal-backed source lots into
-an immutable `settled_cubid_redistribution_v1` manifest. The manifest copies source,
-project, rail, asset, custody, native atomic, FX, exact USD, stable-order,
-project-pseudonym, locked-score, versioned-maximum, and evidence dimensions. Source
-lots are reserved atomically, so the same funded principal cannot enter two
-manifests.
-
-The pure allocator uses exact rational arithmetic until canonical minor-unit
-assignment. It records equal theoretical shares, score-adjusted initial claims,
-score-discount contributions, proportional overlap overflow, cap-aware retained
-lots, lowest-current-total-first top-ups, and returned residue. Each terminal minor
-unit remains linked to one source lot. The database independently enforces source
-capacity, user-cap, pool, award, and funded-total conservation when it records the
-immutable result artifact.
-
-The operator prep workspace exposes manifest/result hashes and funded, retained,
-redistribution, top-up, residue, and final totals. The Edge boundary owns the
-authenticated operator and runtime, and both Edge and database layers deny
-production. These are provisional calculation artifacts only: no liability,
-payable, payout intent, provider call, or value movement is created. The legacy
-`mvp_capped_equalization_v1` calculator remains compatibility-only.
-
-## Allocation Algorithm
-
-All equations use exact decimal functional USD until the rounding stage.
-
-### 1. Equal Theoretical Project Share
-
-For each funded project `p`:
+For user `u`:
 
 ```text
-theoretical_share(p) = funded_project_pool_usd(p) / eligible_user_count(p)
+initial total(u) = sum(all score-adjusted project claims for u)
+baseline(u) = largest single-project score-adjusted initial claim for u
+redistribution top-up ceiling(u) = floor(baseline(u) × selected cap multiple)
+top-up capacity(u) = max(0, redistribution top-up ceiling(u) − initial total(u))
+final award(u) = initial total(u) + redistribution top-up(u)
 ```
 
-Every eligible user in the same project receives the same theoretical share before
-the Cubid factor. Project activity points and the sum of cohort scores do not alter
-this share.
+If the initial total already exceeds the redistribution top-up ceiling, the initial total remains intact and the user receives no top-up.
 
-### 2. Score-adjusted Initial Project Claim
+## Immutable monthly cap selection
 
-For eligible user `u` in project `p`:
+During pre-calculation an internal operator may preview read-only scenarios using a decimal cap multiple from `1.00` through `10.00`, in `0.01` increments. The interface starts at `3.00`, but that value is only an initial scenario, not a permanent policy constant.
+
+The system does not choose an optimization objective. The operator compares scenarios and selects one. Locking persists only the selected scenario and binds these fields into the immutable manifest:
+
+- cap multiple;
+- selected preview hash;
+- input hash and manifest hash;
+- actor and lock timestamp;
+- current project sources, E−3 harvest sources, carry-in sources, cohort, scores, and provenance.
+
+The selected multiple is also bound into the result hash, independent close rerun, root approval package, and all monthly report scopes.
+
+## Redistribution pool
+
+The v2 global pool is exactly:
 
 ```text
-score_factor(u,p) = locked_score(u,p) / locked_max_score
-initial_project_claim(u,p) = theoretical_share(p) * score_factor(u,p)
-project_pool_contribution(u,p) = theoretical_share(p) - initial_project_claim(u,p)
+score-discount contributions
++ unclaimed awards harvested from E−3
++ prior redistribution residue carried into E
 ```
 
-The maximum score must be positive and versioned. A score outside
-`0 <= locked_score <= locked_max_score` is a hard failure. The score-adjusted claim
-and its shortfall retain the funded source mix of the theoretical share.
+There is no v2 overlap pool. The `overlap_pool_minor` value must be zero for v2 runs.
 
-For every project:
+Score-discount contributions are the difference between each theoretical equal share and its score-adjusted initial claim. They retain their source project, rail, custody account, asset, FX snapshot, native amount, exact USD amount, and canonical minor-unit provenance.
+
+Carry-in sources are prior v2 residue lots. A residue lot points to its predecessor disposition so its complete source chain remains reproducible.
+
+## E−3 unclaimed-award harvest
+
+An award from epoch `E−3` remains claimable through three complete payout months and can be harvested only after the target epoch `E` closes. For example, January awards remain claimable through February, March, and April; the unclaimed January balance can enter April's redistribution calculation only after April 30.
+
+Unclaimed value is obligation value not covered by a non-released claim. Claims in `reserved`, `queued`, `held`, `paid`, or `closed` state are protected. A `released` claim no longer protects value and makes it harvestable again.
+
+For partial claims, inventory is treated oldest-first for the claimant and newest-first for the harvest. This preserves the oldest source lots behind timely claims and harvests the newest remaining lots. Partial canonical minor and native quantities use deterministic rounding and retain predecessor fill, inventory, custody, rail, asset, FX, project, and USD provenance.
+
+Harvest and lock are one fail-closed transaction. They lock the cycle and obligations, close the harvestable balance, prevent new claims against harvested value, reserve each source once, and reject stale previews, duplicate harvests, and concurrent lock attempts.
+
+## Redistribution algorithm
+
+1. Build every user's canonical initial total without clipping it.
+2. Calculate the user's redistribution top-up ceiling and remaining top-up capacity.
+3. Order users by current canonical total, then stable user identifier.
+4. Water-fill the lowest current totals first.
+5. Stop a user at their top-up capacity and stop globally when the pool is exhausted or nobody has capacity.
+6. Preserve each consumed source lot's exact USD, canonical minor, native asset, project, rail, custody, FX, and predecessor provenance.
+7. Carry every undistributed exact residue into `E+1` as a dedicated redistribution source.
+
+The algorithm is deterministic under project-source, redistribution-source, and cohort input permutations.
+
+## Required conservation checks
+
+Every v2 artifact must prove:
 
 ```text
-funded_project_pool_usd =
-  sum(initial_project_claim) + sum(project_pool_contribution)
+initial claim + top-up = final award                         (per user)
+top-up <= max(redistribution ceiling − initial claim, 0)     (per user)
+current funded + harvested E−3 + carry-in
+  = final awards + carry-out residue                         (global)
+score pool + harvested E−3 + carry-in
+  = top-ups + carry-out residue                              (pool)
+sum(source dispositions) = source exact and canonical value  (per source)
+overlap pool = 0
 ```
 
-### 3. Aggregate Initial Claim And Baseline
+Exact-decimal conservation is authoritative. Canonical minor units use deterministic largest-remainder assignment, and native quantities stay source-linked through partial dispositions.
 
-For each user:
+## Close, withdrawal, and reporting
 
-```text
-aggregate_initial_claim(u) = sum(initial_project_claim(u,p))
-baseline(u) = max(initial_project_claim(u,p))
-exact_final_cap(u) = 3 * baseline(u)
-minor_unit_cap(u) = floor_to_allocation_minor_unit(exact_final_cap(u))
-```
+Close independently reruns the immutable v2 manifest and rejects a result-hash mismatch. Conditional award controls record full initial claims, selected cap multiple, redistribution top-up ceiling, top-up, and final award. Preparing withdrawal inventory accepts v2 initial-claim and top-up fills and preserves both project-source and redistribution-source provenance.
 
-The baseline is the largest single-project score-adjusted initial claim. The
-canonical executable cap is `minor_unit_cap`, never a nearest-rounded or ceiling
-version of the exact cap. It is not
-the aggregate initial claim, a raw point-proportional entitlement, or a value
-derived from project overlap. A user with a zero baseline has a zero cap.
+The monthly reporting package includes the selected cap multiple and aggregate E−3 harvested amount for:
 
-### 4. Pre-redistribution Cap Clamp
+- operator reports;
+- project reports;
+- private user reports;
+- public and public-project reports when their privacy threshold is met.
 
-The cap applies before redistribution as well as after it. For every user:
+These values are part of report artifact hashes and the close root. Public reports never expose user identifiers, scores, overlap membership, or private source ownership.
 
-```text
-retention_factor(u) =
-  1                                        when aggregate_initial_claim(u) <= exact_final_cap(u)
-  exact_final_cap(u) / aggregate_initial_claim(u)  otherwise
+## Safety boundary
 
-proportional_retained_initial_lot(u,p,source) =
-  initial_project_source_lot(u,p,source) * retention_factor(u)
-
-proportional_overlap_overflow_lot(u,p,source) =
-  initial_project_source_lot(u,p,source)
-  - proportional_retained_initial_lot(u,p,source)
-
-raw_retained_target(u) = sum(proportional_retained_initial_lot(u,p,source))
-canonical_retained_target(u) =
-  min(floor_to_allocation_minor_unit(raw_retained_target(u)), minor_unit_cap(u))
-```
-
-The raw proportional target is `min(aggregate_initial_claim, exact_final_cap)`.
-The exact ledger is immutable: for every source,
-`exact_initial = exact_retained + exact_overflow`, every term is non-negative, and
-`exact_retained = exact_initial × retention_factor`. Canonical rounding never
-rewrites these exact terms.
-
-The canonical retained target is the lesser of the raw target floored to the
-allocation minor unit and `minor_unit_cap`. Canonical retained-lot assignment may
-never exceed that target or cap. Canonical pre-redistribution current is
-`sum(canonical_retained_minor_lot)`, never the higher raw target. The exact amount
-between raw and canonical targets is a separately recorded, source-provenance
-`sub_minor_residual`; it is not computed as exact retained minus a rounded lot and
-is not an exact overflow source lot.
-When aggregate initial value exceeds the cap, each project/source initial lot is
-scaled by the same exact factor. Each lot's exact difference becomes
-source-preserving overlap-cap overflow in the global pool. The clamp may not choose
-one project to absorb another project's overflow or erase rail, asset, native, FX,
-or USD provenance.
-
-A user whose canonical pre-redistribution current equals the minor-unit cap is not a water-filling
-candidate. With non-negative initial lots, a zero baseline means every initial lot
-is zero; the user has cap zero, retains zero, and receives no redistribution top-up.
-
-### 5. Global Epoch Redistribution Pool
-
-```text
-epoch_redistribution_pool =
-  sum(score_discount_pool_contribution(u,p,source))
-  + sum(total_overlap_cap_overflow_lot(u,p,source))
-```
-
-All included score-discount shortfalls and overlap-cap overflow enter this one pool.
-They do not remain restricted to users of the originating project, but their source
-provenance remains intact.
-
-### 6. Lowest-current-total-first Water-filling
-
-Initialize each user's current total to `pre_redistribution_current(u)`. Repeatedly:
-
-1. select uncapped users with the lowest current total;
-2. raise the tied lowest group together toward the next-lowest current total or a
-   member's cap, whichever comes first;
-3. consume no more than the remaining redistribution pool;
-4. remove capped users and continue until the pool is exhausted or no user has cap
-   capacity.
-
-Exact continuous water-filling treats every equal-current user equally until the
-next level, a cap, or pool exhaustion. Aggregate initial claim and baseline do not
-break an equal-current tie. Only after exact targets are fixed are indivisible
-canonical minor units assigned: descending fractional remainder of the exact user
-target, then stable user ID, with cap-aware skipping. An unassignable next unit
-continues to the next eligible user or remains source-linked residue.
-No final allocation may exceed `minor_unit_cap`, and a user that begins at cap receives
-no top-up.
-
-### 7. Returned Or Carried-forward Residue
-
-If every eligible user reaches the cap before the pool is exhausted:
-
-```text
-epoch_redistribution_pool =
-  sum(redistribution_top_up) + sum(returned_or_carryover_residue)
-```
-
-Residue is emitted as deterministic source-linked rows and returns or carries
-forward under the originating lot's project, rail, asset, native, FX, and USD
-provenance. It is not a user credit, fee, revenue, or payable.
-
-### 8. Rounding
-
-- preserve exact decimal theoretical shares, initial lots, retention factors,
-  retained lots, overflow lots, pool lots, and water levels in the artifact;
-- maintain separate exact-decimal and canonical integer-minor-unit ledgers; never
-  substitute a rounded lot into an exact source identity;
-- derive canonical initial source units first: round the exact funded canonical
-  total under the versioned currency rule, floor each exact initial source lot, then
-  assign residual units by descending fractional remainder and stable
-  project/rail/asset/source-lot ID;
-- calculate cap scaling before any minor-unit rounding;
-- assign canonical retained units to the floored, cap-bounded retained target by
-  constrained largest remainder over exact retained lots: require
-  `0 <= retained_minor_lot <= initial_minor_lot`, skip saturated/zero-capacity lots,
-  and use stable project/rail/asset/source-lot ID after fractional remainder;
-- define `overflow_minor_lot = initial_minor_lot - retained_minor_lot`; it is always
-  non-negative, and canonical initial equals canonical retained plus canonical
-  overflow for every source;
-- make every retained-lot and final-award residual assignment cap-aware: skip a
-  user/source assignment whenever its next unit would make the user's retained or
-  final total exceed `minor_unit_cap`;
-- track sub-minor exact residual and deterministic cross-source residual transfers
-  separately with original project/rail/asset/native/FX/USD provenance. Residual
-  may combine into a canonical pool unit, fund another uncapped user, or become
-  returned/carryover residue; it never creates a negative exact or canonical lot;
-- apply the same largest-remainder and stable-key rule within each
-  rail/asset/custody group when an exact factor crosses atomic native units, and set
-  overflow native units to original minus retained units;
-- round canonical user awards in integer minor USD units only after water-filling;
-- assign user residual minor units by descending fractional remainder, then stable
-  user ID, skipping capped candidates rather than crossing their cap;
-- split source-lot native quantities under the asset's exact atomic-unit rules;
-- assign source residuals through the versioned stable lot order; and
-- prove exact source decimals conserve and, independently, integer minor-unit user
-  awards plus integer minor-unit pool/residue equal the integer minor-unit funded
-  pool. No fractional or integer unit may be lost or assigned twice.
-
-### 9. Arbitrary-overlap Invariants
-
-For any number of overlapping project initial lots, including zero and one:
-
-```text
-sum(canonical_retained_minor_lot + canonical_overflow_minor_lot) =
-  sum(canonical_initial_minor_lot)
-
-exact_initial_source_lot =
-  exact_retained_source_lot + exact_overflow_source_lot
-
-canonical_initial_minor_lot =
-  canonical_retained_minor_lot + canonical_overflow_minor_lot
-
-raw_proportional_retained_target = min(aggregate_initial_claim, 3 * baseline)
-
-canonical_pre_redistribution_current =
-  min(floor_to_allocation_minor_unit(raw_proportional_retained_target),
-      floor_to_allocation_minor_unit(3 * baseline))
-
-exact_funded_epoch_pool =
-  sum(exact_retained_source_lot)
-  + sum(exact_score_discount_pool_lot)
-  + sum(exact_overflow_source_lot)
-
-canonical_funded_epoch_minor_units =
-  sum(canonical_retained_minor_lot)
-  + sum(canonical_score_discount_minor_lot)
-  + sum(canonical_overflow_minor_lot)
-```
-
-These identities must hold separately in exact decimals and integer functional-USD minor units,
-and exact native atomic units. Permuting project/source input order cannot change
-retained totals, overflow totals, final allocations, or the result hash.
-
-### Fractional Cap Fixture
-
-Four source lots of `$0.335` produce aggregate initial `$1.34`, baseline `$0.335`,
-exact cap `$1.005`, and canonical cent cap `$1.00`. Raw proportional retention is
-`$0.25125` per source, totaling `$1.005`, with `$0.08375` exact overflow per
-source and `$0.335` exact overflow total. Cap-aware canonical retained-lot rounding emits four
-`$0.25` retained lots totaling `$1.00`, never `$1.01`. The exact `$0.005` retained
-target remainder is recorded separately with source provenance and joins the
-canonical pool/residue bridge. The exact ledger conserves
-`$1.005 + $0.335 = $1.34`; the canonical ledger independently conserves
-100 retained + 34 overflow = 134 cents. No source has negative overflow, and no
-fraction or cent is lost or assigned twice.
-
-### Non-negative Source-lot Counterexample
-
-Two exact retained source lots of `$0.006` have a one-cent canonical retained
-target. First derive canonical initial capacity from the exact funded total: stable
-largest remainder assigns one initial cent to the lower stable source ID and zero
-to the other. Constrained retained rounding assigns that one cent only to the
-one-cent-capacity source; canonical overflow is zero for both, never `-$0.004`.
-The exact ledger independently records `$0.006 = $0.006 + $0` for each source.
-The cross-source rounding transfer and remaining `$0.002` sub-minor residual stay
-source-provenanced outside exact overflow and reconcile the exact `$0.012` total to
-the canonical one-cent total.
-
-### One-cent Equal-current Tie Fixture
-
-Two uncapped users have the same exact current total, equal capacity, and exact
-top-up targets of `$0.005` each when one canonical cent remains. Continuous
-water-filling treats them equally. Their fractional remainders tie, so the lower
-stable user ID receives the cent; aggregate initial claim and baseline are ignored.
-Reversing user or source input order produces the same recipient and result hash.
-
-## Canonical A+B Fixture
-
-Project A has `$300`, three eligible users, locked scores `5`, `10`, and `15`, and a
-locked maximum score of `20`.
-
-```text
-theoretical share per A user = $300 / 3 = $100
-initial A claims             = $25, $50, $75
-A pool contributions         = $75, $50, $25
-A redistribution total       = $150
-```
-
-Project B has `$1,000` and 100 eligible users. In the canonical deterministic
-fixture the 100 B users are each exactly `10/20`, so the `$10` theoretical share becomes a
-`$5` initial claim.
-
-```text
-aggregate B initial claims   = 100 * $5 = $500
-B redistribution total       = $500
-combined epoch pool          = $150 + $500 = $650
-```
-
-The three A users are also B users. Their aggregate initial claims are `$30`, `$55`,
-and `$80`; their baselines are `$25`, `$50`, and `$75`. The other 97 B-only users
-each begin at `$5`, with a `$5` baseline and `$15` cap. Lowest-current-total-first
-water-filling therefore sends the entire `$650` to the 97 B-only users before any
-A+B user. Exact top-up is `$650 / 97`; after cent rounding, 10 stable user IDs
-receive `$6.71` and 87 receive `$6.70`. No user reaches the `$15` cap, no A+B user
-receives a top-up, and no residue remains.
-
-## Four-project Overlap Cap Fixture
-
-One user has four score-adjusted project/source initial lots of `$100` each:
-
-```text
-aggregate initial claim      = $400
-baseline                     = $100
-cap                          = 3 * $100 = $300
-retention factor             = $300 / $400 = 0.75
-retained source lots         = $75, $75, $75, $75
-overlap-cap overflow lots    = $25, $25, $25, $25
-pre-redistribution current   = $300
-```
-
-The `$100` overflow joins the global pool with all four project/source identities
-intact. The user begins at cap and receives no top-up; water-filling proceeds only
-to other uncapped users. If no uncapped capacity remains, the four `$25` lots return
-or carry forward through their originating funded sources.
-
-## Asset Fulfillment
-
-Asset preferences affect later source fulfillment only; they never change the USD
-allocation. Fulfillment consumes eligible source lots in the approved deterministic
-order, may split a user's award across accepted assets, and must retain the exact
-project/rail/asset/native/FX/USD source fills. Unfulfillable value follows the same
-source-linked return or carryover rules and is not presented as a user award.
-
-## Deterministic Outputs
-
-The calculation artifact contains at least:
-
-- funded project pools and immutable source lots;
-- eligible project-user counts and theoretical shares;
-- locked score, locked maximum score, and score factor;
-- initial project claims and project pool contributions;
-- aggregate initial claims, exact and canonical caps, retention factors, separate
-  exact/canonical initial-retained-overflow source lots, and sub-minor residuals;
-- ordered water-filling steps and redistribution top-ups;
-- final provisional allocations and cap status;
-- stable exact/canonical rounding decisions, constrained source capacities,
-  sub-minor residual transfers, and asset/source fills;
-- returned or carryover residue with complete provenance;
-- excluded users and typed reason codes;
-- conservation, privacy, and production-gate results; and
-- canonical input, result, and root hashes.
-
-The current point-proportional calculator and its old raw-entitlement/remainder
-outputs are legacy compatibility surfaces. Task #136 must replace or version them;
-they cannot be the canonical Goal #134 result and must remain production-disabled.
-
-## Verification Requirements
-
-Verification must prove:
-
-- the exact locked manifest hash was consumed;
-- every project dollar is settled, applied, journal-backed, fee-processed, and
-  linked to immutable source provenance;
-- every user and score/max pair was eligible and locked;
-- equal theoretical shares, score-adjusted claims, pre-redistribution cap clamps,
-  retained lots, and both pool-contribution classes recompute;
-- continuous equal-current water-filling and the sole minor-unit tie rule reproduce
-  deterministically under user/source input permutation;
-- `final_allocation_minor <= floor_to_minor_unit(3 * baseline)` for every user;
-- every exact initial lot equals non-negative exact retained plus exact overflow;
-- every canonical initial lot equals bounded canonical retained plus non-negative
-  canonical overflow;
-- funded pool equals retained initial lots plus score-discount contributions plus
-  overlap-cap overflow;
-- score-discount contributions plus overlap-cap overflow equal top-ups plus
-  returned/carryover residue;
-- final allocations equal pre-redistribution current plus top-ups;
-- capped and zero-baseline users receive no top-up;
-- arbitrary overlap count and input permutation properties hold;
-- native, FX, and functional-USD source conservation all hold;
-- project/public outputs cannot reveal cross-project membership; and
-- production allocation, payable posting, provider calls, and real value flow are
-  fail-closed.
-
-## Reporting Boundary
-
-User reporting may show the user's provisional total and permitted project/source
-breakdown. Founder reporting may show only that founder's project cohort and
-aggregate source/pool results. Public reporting may show approved aggregate project
-and epoch totals only after privacy thresholds pass. Authorized operators may see
-the full provenance and overlap evidence.
-
-Allocation and approval are conditional internal records. They do not create user
-ownership, a general-ledger payable, an external transfer, or a production value
-flow. Production activation remains blocked on the named accounting, legal,
-privacy, custody, and payout gates.
-
-## Approved close package boundary
-
-Task #137 consumes only the persisted `settled_cubid_redistribution_v1` result.
-The authenticated operator command independently reruns the immutable manifest and
-must reproduce the exact result hash before Postgres can approve it. Postgres never
-reruns allocation under a different policy during posting.
-
-Approval creates append-only conditional award controls and source-linked neutral
-ledger postings for retained lots, redistribution top-ups, and returned residue.
-The controls are explicitly `not_payable`, `not_user_owned`, and asset-review
-pending. Intermediate score and overlap pool rows remain provenance evidence, not
-additional postings or claims.
-
-One root hash covers trial-balance, custody, project-funds, fee, FX, carryover,
-initial-claim, redistribution-pool, top-up, returned-residue, provisional-award,
-and exception artifacts. The immutable allocation result remains separately bound
-by its result hash and is not substituted for the required returned-residue class.
-Operator artifacts may contain private evidence. User reads
-return only the authenticated user's award; founder reads return only a managed
-project aggregate; public project and epoch reads suppress cohort counts below the
-privacy threshold and never contain user IDs, scores, or overlap membership.
-
-The close command first prepares the deterministic artifacts and root while the
-epoch remains `reviewing`. The same authorized operator must explicitly approve
-that exact root before both required `reviewing -> payout_readying` hard gates are
-recorded. It cannot create a payable, open `payout_open`, call a provider, submit a
-transfer, or enable production value flow.
-
-Every source's terminal exact dispositions must equal its funded exact USD. Any
-fraction remaining after retained and top-up dispositions becomes a zero-minor,
-positive-exact, source-linked returned-residue fill and exact ledger control; it is
-never left only in an aggregate `subMinorExactUsd` field.
+Previewing, locking, calculating, closing, reporting, and withdrawal preparation remain review-only outside production. The v2 schema, functions, Edge handlers, and source tables all fail closed for production value flow. No provider call, payout submission, or transfer is authorized by an allocation or close artifact.

--- a/docs/engineering/capability-review-2026-08-11.md
+++ b/docs/engineering/capability-review-2026-08-11.md
@@ -1,0 +1,66 @@
+# FundLoop capability review — 2026-08-11
+
+Assessment timestamp: 2026-08-11, America/Toronto
+
+Compared environments:
+
+- application source: `origin/dev` at `2b87b9cfeee52f897e0909a995fe7ff42b531cbc`;
+- Supabase Dev: project `kyxtqnfnksvcaugxwzuj`;
+- local operational evidence: the Feature #118 capability matrix and repo-owned tests at the same `dev` commit.
+
+This is a capability review, not a launch claim. “In code” means a typed surface and tests exist on `dev`. “On Supabase Dev” means the required schema and Edge Functions were verified remotely. “Local-real” and “sandbox-real” retain the exact meanings in the Feature #118 validation record; neither means production-ready.
+
+## Executive conclusion
+
+FundLoop has moved well beyond a marketing site or CRUD prototype. The branch contains a credible application shell, identity integration, founder and operator workspaces, deterministic monthly-cycle machinery, financial control-plane foundations, payout orchestration, privacy controls, and MCP contracts.
+
+It is not yet a usable end-to-end monthly economy on Supabase Dev. The application and backend are out of sync. App CI is green, but the remote Supabase deployment is blocked before the newer ledger and epoch migrations, 25 current Edge Function directories are absent remotely, provider capabilities are mixed, report publication is incomplete, and production value flow is intentionally disabled.
+
+The honest short version is: **the workflow design and local control plane are substantially present; the shared dev environment and production operating system are not yet caught up.**
+
+## Evidence snapshot
+
+- `dev` CI run `31521550946` passed for commit `2b87b9c`.
+- The matching Supabase Deploy run `31521550923` failed in migration `20260809020000_neutral_ledger_foundations.sql` with PostgreSQL error `cannot insert multiple commands into a prepared statement` (`SQLSTATE 42601`).
+- The last observed successful Supabase Dev deploy was run `31287337962` on 2026-08-09.
+- The repo contains 62 deployable Edge Function directories; Supabase Dev reported 38 active functions.
+- Supabase Dev still exposes the retired `monthly-cycle-payout-intents-create` function while lacking 25 current functions, including the settlement-backed epoch, neutral-ledger, multi-rail intake, payout-operator, and financial-cutover surfaces.
+- The Feature #118 matrix classifies 14 capabilities as `local-real`, one as `sandbox-real`, two as `stubbed`, and three as `pending`. Production value flow is `false`.
+
+## Target comparison
+
+| Target capability | On `dev` branch | On Supabase Dev | Honest assessment |
+| --- | --- | --- | --- |
+| Multilingual public explanation of the monthly loop and four audiences | Public i18n shell and routes exist. The 2026-08-11 public-home redesign is on a feature branch pending review, not yet on `dev`. | Public content depends primarily on the app deployment, not Supabase. | **Partial.** The product shell is multilingual; the clearest articulation is not deployed yet. |
+| User onboarding and CUBID identity | Resumable onboarding, CUBID email resolution/profile sync, snapshots, score reads, private-by-default publication choice, and remediation UI exist. | Core CUBID and publication-choice functions are active. New epoch score-lock/remediation gates depend on missing financial-prep deployment. | **Useful but incomplete.** Identity linkage is real; full uniqueness/KYC assurance and monthly locked eligibility are not proven end to end remotely. |
+| Project onboarding, membership, and recurring revenue commitment | Founder onboarding, project publication, invitations, payment routes, contribution percentage/default currency, and founder workspaces exist. | Core onboarding, invitation, crypto route, draft payment, contribution, and attribution functions are active. | **Strongest shared-dev area.** Project setup and the older contribution workflow are materially available. |
+| Monthly contribution and attribution submission | Typed contribution and attribution commands, review events, cycle linkage, project package workflows, and operator review surfaces exist. | Older contribution and attribution functions are active; settlement-backed project-package workflow is absent. | **Partial.** Declared monthly data can flow; a reconciled “data plus settled funds” package cannot complete on shared dev. |
+| Settlement-backed multi-rail funding | Code includes Base v2 intake, Stripe bank transfer, Canadian PAD, EUR/GBP Pay by Bank, external-event reconciliation, fee/FX prep, and custody-aware source lots. | All newer intake/reconciliation functions are absent. The remote deploy stopped before their migrations. | **Local-only.** Base USDC is local-real; bank transfer is provider-pending; PAD and Pay by Bank are local-real with hosted capability gates. |
+| Monthly lock, calculation, verification, and approval | Both the legacy MVP calculator and newer funded redistribution path exist, with deterministic artifacts, integrity checks, shadow stages, close packages, and operator review. | Legacy lock/calculation/verification/approval functions are active. New shadow scheduler, funded allocation, financial prep, and allocation close functions are absent. | **Two generations coexist.** The old promise-derived cycle can run; the settlement-backed target cannot run remotely. |
+| Uniqueness-weighted distribution | The funded calculator consumes locked CUBID uniqueness scores within settled source cohorts; legacy capped equalization remains in code for transitional cycles. | Required new epoch functions are absent. | **Implemented and tested locally, not usable on shared dev.** Product copy and reports must name which model produced a result. |
+| User earnings, three-month retroactive claims, and partial withdrawal | Earnings workspace, asset preferences, project-scoped withdrawal requests, exact inventory reservation, partial requests, fee conservation, queueing, and expiry/carryover contracts exist. | Core asset-preference and initial withdrawal-request functions are active, but the newer obligation control plane and `withdrawal-operator` are absent. | **Not end-to-end on shared dev.** A user cannot rely on the target three-month claim and payout lifecycle there. |
+| Actual payouts | Base Safe control plane and Stripe Connect payout orchestration/reconciliation exist with local/sandbox tests. | Base Safe, Stripe Connect account/payout/webhook, and withdrawal-operator functions are absent. | **Not available on shared dev.** Stripe Connect is sandbox-real; Base USDC is local-real; production activation remains prohibited. |
+| Transparent reporting | Public/user/founder/operator report routes, report metadata, audience scoping, artifact conventions, and MCP coverage reads exist. Funded close privacy thresholds are tested. | Older report tables may support read surfaces, but no current report-generation/publication command was verified remotely. | **Read-model scaffold, not a complete reporting system.** Automatic generation, publication, retention, and polished explanatory reports remain gaps. |
+| Privacy and opt-in public visibility | Explicit policy acknowledgement, publication consent, RLS/read boundaries, redacted MCP shapes, and privacy tests exist. | Policy and profile-publication functions are active. | **Good foundation.** Requires hosted role-specific verification and retention/legal approval before production claims. |
+| Operator control plane | Admin workspaces cover cycles, identity, payments, reconciliation, settlement packages, observability, verification, reporting, and payout review. | Older cycle/payment operations are active; the new 12-stage epoch and payout functions are absent. | **Broad UI, split backend.** Operators can inspect more than they can safely execute on shared dev. |
+| MCP parity | Stdio and Edge MCP servers expose typed user, founder, project-member, and operator reads plus allowlisted founder writes, resources, and prompts. | `mcp` and `mcp-workflow-read` are active, but new financial commands they would call are absent. | **Real but bounded.** Read-oriented agent workflows are credible; the full monthly economy is not agent-operable remotely. |
+| Double-entry accounting and financial cutover | Neutral ledger, append-only reversals, shadow financial events/journals, opening-balance cutover, and local control tests exist. Production posting policy remains disabled by design. | Deployment is blocked at the first neutral-ledger migration. | **Not on shared dev.** This is the immediate infrastructure blocker and still requires professional accounting/legal approval for production policy. |
+
+## What can be demonstrated honestly today
+
+Against a clean local Supabase environment, the repo can demonstrate a multi-persona monthly workflow with deterministic fixtures: onboarding and consent, project invitations, CUBID remediation, project package review, funded allocation, partial withdrawal reservation, Base USDC intake/Safe payout controls, Stripe Connect sandbox payout controls, and operator stage review. The evidence is strong for software behavior under those bounded conditions.
+
+On the shared Supabase Dev environment, the honest demo boundary is narrower: onboarding, project/member setup, CUBID sync, contribution and attribution submission, legacy monthly-cycle operations, publication choice, and MCP read workflows. The settlement-backed epoch, newer rails, actual payout execution, neutral ledger, and cutover must not be presented as working there.
+
+## Highest-priority gaps
+
+1. **Repair and replay the Supabase Dev deployment.** Fix the prepared-statement migration failure, prove migration history and schema convergence, deploy the missing current functions, and remove or explicitly quarantine retired remote functions.
+2. **Run hosted role-specific acceptance.** Exercise one founder, one verified user, and one operator against the same Preview/Supabase Dev pair. Include privacy-negative checks and no-value/sandbox-only guardrails.
+3. **Close reporting as a product capability.** Add deterministic generation and publication commands, audience-specific explanations, retention rules, and hosted verification. A metadata table and empty report hub are not transparency.
+4. **Prove the three-month claim lifecycle end to end.** Verify open-month eligibility, oldest-first consumption, partial claims, expiry, rollover provenance, destination readiness, and operator reconciliation in the shared dev environment.
+5. **Resolve provider reality.** Confirm exact Stripe account/currency capabilities and reviewed Base token addresses. Keep unsupported rails visibly pending or stubbed.
+6. **Complete governance before production value.** Obtain legal, accounting, tax, privacy/retention, sanctions/KYC/KYB, unclaimed-property, and custody conclusions; then authorize a separate production activation and rollback plan.
+
+## Review rule going forward
+
+Every capability statement should name its environment and evidence class: `in code`, `local-real`, `sandbox-real`, `on Supabase Dev`, `hosted-verified`, or `production-enabled`. Passing application CI, a generated artifact, or an active Edge Function is narrower evidence than a completed role-specific economic workflow.

--- a/docs/engineering/current-state-architecture.md
+++ b/docs/engineering/current-state-architecture.md
@@ -1,6 +1,6 @@
 # FundLoop Current-State Architecture
 
-Last reviewed: 2026-04-14
+Last reviewed: 2026-08-11
 
 Related planning docs:
 - [Engineering Docs Index](./README.md)
@@ -9,6 +9,15 @@ Related planning docs:
 - [Target-State Architecture](./target-state-architecture.md)
 - [Archived Sessions 1-52 Roadmap](../../agent-context/todo-1-through-52.md)
 - [MCP TODO Roadmap](../../agent-context/todo-mcp.md)
+- [2026-08-11 Capability Review](./capability-review-2026-08-11.md)
+
+## 2026-08-11 status note
+
+This document still explains the repo structure, but the April subsystem descriptions below are no longer a complete capability inventory. `dev` now also contains the settlement-backed epoch shadow state machine, neutral-ledger foundations, funded allocation, withdrawal reservation, Base Safe and Stripe Connect payout control planes, multi-rail intake contracts, financial cutover controls, review-policy gates, publication consent, and expanded local operational validation.
+
+Those additions must not be read as proof of a working dev or production economy. At the review timestamp, application CI on `dev` passed, but Supabase Dev deployment was blocked at the neutral-ledger migration and its remote Edge Function inventory was materially behind the branch. Most of the new financial paths are explicitly local-real, sandbox-real, stubbed, or pending—not production enabled. The linked capability review records that distinction and should be treated as the current environment-level truth.
+
+The `codex/public-monthly-coordination-story` worktree adds a local-only `settled_cubid_redistribution_v2` implementation. It preserves full score-adjusted initial claims, applies the selected monthly cap multiple only to redistribution top-ups, and adds exactly E−3 unclaimed-award harvest plus carry-forward residue as source-linked pool inputs. This worktree state is not deployed and does not enable production value flow.
 
 ## 1. What This Repo Is Today
 

--- a/docs/engineering/operational-mvp.md
+++ b/docs/engineering/operational-mvp.md
@@ -225,11 +225,12 @@ Definitions:
 - Project pool contribution = theoretical project share minus the initial project claim; all contributions enter one global epoch redistribution pool.
 - Aggregate initial claim = the sum of one user's score-adjusted initial project claims.
 - User baseline = the largest single-project score-adjusted initial claim for that user.
-- Exact user cap = `3 ×` baseline; canonical minor-unit cap = floor of that exact cap to the allocation minor unit. Before redistribution, aggregate initial claim is clamped, and neither retained-lot nor final-award rounding may cross the canonical cap.
-- Raw proportional retained source lot = exact initial project/source lot multiplied by `min(1, exact cap / aggregate initial claim)`; its non-negative exact difference is exact overflow. Canonical initial/retained/overflow units are derived independently, while the source-provenanced sub-minor residual bridges exact and canonical totals.
-- Global epoch redistribution pool = score-discount project pool contributions plus overlap-cap overflow.
-- Pre-redistribution current = the canonical retained target: floor `min(aggregate initial claim, exact cap)` to the allocation minor unit and bound it by the floored minor-unit cap. A user already at cap, including a zero-baseline user at cap zero, receives no top-up.
-- User final allocation = pre-redistribution current plus the deterministic lowest-current-total-first water-filling top-up, never above the cap.
+- Selected monthly cap multiple = an operator-selected decimal from `1.00` through `10.00`, previewed read-only and persisted only when selected. `3.00` is the initial scenario, not a permanent constant.
+- Redistribution top-up ceiling = floor of `largest single-project initial claim × selected cap multiple` to canonical minor units.
+- Initial total = the full canonical sum of every score-adjusted initial project claim. It is never reduced by the redistribution top-up ceiling.
+- Top-up capacity = `max(0, redistribution top-up ceiling − initial total)`. A user whose initial total already exceeds the ceiling keeps that full initial total and receives no top-up.
+- Global epoch redistribution pool = score-discount project contributions plus exactly E−3 unclaimed awards plus prior carry-in residue.
+- User final allocation = full initial total plus deterministic lowest-current-total-first water-filling top-up, bounded only by top-up capacity.
 - Asset fulfillment = selected asset credit fills based on the user's highest-priority accepted available assets.
 - Every initial claim, pool contribution, top-up, and returned/carryover residue retains project, rail, asset, native, FX, and USD provenance.
 
@@ -238,7 +239,7 @@ Scores are individual discounts against equal project shares, not weights divide
 the sum of cohort scores. Redistribution principal is not a fee, revenue, treasury
 sweep, or payable.
 
-Task #136 implements this as a separate `settled_cubid_redistribution_v1`
+The corrected path is `settled_cubid_redistribution_v2`
 local/dev path. It reserves only approved, reconciled, neutral-ledger-backed source
 lots; records immutable manifest and result hashes; and proves canonical source,
 pool, cap, award, and returned-residue conservation. The operator prep workspace
@@ -252,12 +253,12 @@ cross-project overlap.
 
 Rounding:
 
-- Maintain separate exact-decimal and canonical integer-minor-unit source ledgers. Every exact source satisfies non-negative `exact initial = exact retained + exact overflow`.
+- Maintain separate exact-decimal and canonical integer-minor-unit source ledgers. Every exact source is assigned to initial claims, score-discount pool, top-ups, or carry-out residue without clipping an initial claim.
 - Derive canonical initial source units first against the funded canonical total using descending fractional remainder then stable project/rail/asset/source-lot ID.
-- Calculate exact-decimal cap scaling before rounding.
-- Floor the retained-total target to the allocation minor unit and bound it by the canonical floored cap. Assign canonical retained units by constrained largest remainder, requiring `0 <= retained minor lot <= initial minor lot` and skipping saturated or zero-capacity lots.
-- Define canonical overflow units only as `initial minor lot - retained minor lot`; they are never negative.
-- Move an exact fraction or candidate minor unit rejected by the cap into the global overflow pool as cap-floor overflow with its original project/rail/asset/native/FX/USD provenance; together with proportional overlap overflow it may fund another uncapped user and otherwise becomes source-linked returned/carryover residue.
+- Calculate the exact redistribution top-up ceiling before rounding, but never scale or clip initial claims.
+- Assign canonical initial units by constrained largest remainder, then calculate top-up capacity as `max(ceiling − initial, 0)`.
+- Put only score discounts, E−3 harvested lots, and carry-in residue into the redistribution pool.
+- Carry an undistributed exact fraction or canonical unit into the next epoch with its original project/rail/asset/native/FX/USD and predecessor provenance.
 - Track sub-minor exact residual and deterministic cross-source residual transfers separately with source provenance; never calculate exact overflow from a rounded retained lot.
 - Apply the same stable largest-remainder rule within each rail/asset/custody group for native atomic units.
 - Round after USD normalization.
@@ -268,7 +269,7 @@ Outputs:
 
 - per-user result rows
 - per-project/user theoretical-share, score-factor, and initial-claim rows
-- source-linked retained-initial, score-discount contribution, overlap-cap overflow,
+- source-linked full initial-claim, score-discount contribution, E−3 harvest, carry-in,
   and redistribution-top-up rows
 - selected asset fill rows
 - returned/carryover residue rows with originating source provenance
@@ -280,14 +281,14 @@ Outputs:
 Acceptance criteria:
 
 - Same locked manifest produces same result hash.
-- Every non-negative exact initial source lot equals exact retained plus exact overflow; independently, every canonical initial source unit equals bounded canonical retained plus non-negative canonical overflow.
-- Retained initial lots plus score-discount contributions plus overlap-cap overflow equal the funded pool.
-- Top-ups plus returned/carryover residue equal score-discount contributions plus overlap-cap overflow.
+- Every score-adjusted initial claim remains intact, including when a user's aggregate initial total exceeds the redistribution top-up ceiling.
+- Initial claims plus score-discount contributions equal current funded project sources.
+- Top-ups plus carry-out residue equal score-discount contributions plus E−3 harvest plus carry-in residue.
 - Final allocations plus returned/carryover residue equal total funded pool USD after deterministic rounding.
-- No retained-lot target or final allocation exceeds the floored minor-unit `3 ×` baseline cap.
+- No top-up exceeds `max(redistribution top-up ceiling − initial total, 0)`; a final allocation may exceed the ceiling only because its preserved initial total already did.
 - The canonical A+B fixture uses 100 B users each exactly `10/20`, produces `$150 + $500 = $650` of redistribution, and sends it first to the 97 B-only lowest earners.
-- The four-project overlap fixture `[100,100,100,100]` clamps `$400` to a `$300` cap, retains `$75` per source, and contributes four `$25` overflow lots before water-filling.
-- The fractional fixture with four `$0.335` lots has aggregate `$1.34`, baseline `$0.335`, exact cap `$1.005`, canonical cent cap `$1.00`, four `$0.25` retained lots, `$0.335` exact overflow, 34 canonical overflow cents, and a separately source-linked `$0.005` exact-to-canonical residual; it never awards `$1.01`.
+- The four-project fixture `[100,100,100,100]` preserves the full `$400` initial total. With a `$300` top-up ceiling it receives zero top-up and contributes no ceiling-derived value to the pool.
+- Decimal multiples at `1.00`, `3.00`, `10.00`, and intermediate `0.01` increments reproduce the same hashes for equivalent input permutations.
 - The two-`$0.006` retained-lot/one-cent-target counterexample assigns canonical initial capacity first, retains the cent only on that source, produces no negative source overflow, and separately reconciles exact `$0.012` to one canonical cent.
 - The one-cent equal-current-user fixture gives two users exact `$0.005` top-up targets; fractional remainders tie, so stable user ID alone selects the cent and input permutation leaves the result hash unchanged.
 - Arbitrary overlap count and project/source input permutation properties conserve exact decimals, USD minor units, and native atomic units.
@@ -305,9 +306,9 @@ Verification checks:
 - all included projects have approved packages and reconciled, journal-backed funded sources
 - all included project cohorts and score/max snapshots are approved and locked
 - all included users are CUBID-linked at lock time
-- retained initial lots, both pool-contribution classes, top-ups, and source-linked returned/carryover residue conserve the monthly pool after rounding
-- no user allocation exceeds the floored canonical minor-unit `3 ×` baseline cap
-- users already at cap and zero-baseline users receive no top-up
+- full initial claims, score discounts, E−3 harvest, carry-in, top-ups, and source-linked carry-out residue conserve the monthly pool after rounding
+- no top-up exceeds `max(redistribution top-up ceiling − full initial total, 0)`
+- users without top-up capacity and zero-baseline users receive no top-up
 - asset fills respect accepted preference order and recorded availability
 - no negative credits
 - artifact hashes exist

--- a/docs/engineering/settlement-backed-epoch-treasury.md
+++ b/docs/engineering/settlement-backed-epoch-treasury.md
@@ -507,20 +507,18 @@ short transaction.
 - Each funded project's theoretical share is equal across its eligible users. The
   initial project claim is that share multiplied by `locked score / locked maximum
   score`; it is not weighted by the sum of cohort scores or mutable activity points.
-- Baseline is the largest single-project score-adjusted initial claim and cap is
-  exact `3 ×` baseline. The canonical minor-unit cap is that exact value floored to
-  the allocation minor unit. Before redistribution, aggregate initial claim is clamped to that
-  canonical rounding bound, and retained-lot and final-award rounding may never exceed it. If aggregate exceeds the exact cap, every project/source initial lot is scaled by
-  `exact cap / aggregate`; each lot's exact difference enters the pool as overlap-cap
-  overflow. A zero-baseline user has cap zero, and any user already at cap receives
-  no top-up.
+- Baseline is the largest single-project score-adjusted initial claim. The operator
+  previews decimal multiples from `1.00` through `10.00` and selects one per epoch;
+  `3.00` is only the initial scenario. The floored product is a redistribution
+  top-up ceiling, never an initial-claim cap. Every initial claim remains intact.
+  Top-up capacity is `max(ceiling - aggregate initial, 0)`.
 - Descending-fraction residual assignment is cap-aware and skips any user/source
   whose next unit would cross the canonical cap. Sub-minor exact residuals and
   rejected candidate canonical units retain original source provenance, may combine
   in the global pool or fund another uncapped user, and otherwise become
   source-linked returned/carryover residue.
-- Every theoretical-share score discount and overlap-cap overflow enters one global
-  epoch redistribution pool. Exact equal-current users are raised together until
+- Every theoretical-share score discount, exactly E−3 unclaimed-award harvest, and
+  prior carry-in residue enters one global epoch redistribution pool. Exact equal-current users are raised together until
   the next level/cap/exhaustion. Aggregate initial and baseline do not break ties;
   indivisible units use only exact-target fractional remainder then stable user ID.
 - Pool source lots and top-up fills preserve project, rail, asset, native quantity,
@@ -537,10 +535,10 @@ short transaction.
   users each exactly `10/20`, producing `$500` initial claims and `$500` of pool. The
   three A users also use B, so the combined `$650` goes first to the 97 B-only users
   with the lowest aggregate initial claims.
-- Adversarial overlap evidence uses initial lots `[100,100,100,100]`: aggregate
-  `$400`, baseline `$100`, cap `$300`, four retained `$75` lots, and four source-linked
-  `$25` overflow lots before water-filling. Arbitrary overlap counts must preserve
-  the same exact-decimal, minor-unit, native-unit, and input-order invariants.
+- Adversarial multi-project evidence uses initial lots `[100,100,100,100]`: aggregate
+  `$400`, baseline `$100`, and a selected `3.00` top-up ceiling of `$300`. The full
+  `$400` initial total remains awarded, the user receives no top-up, and no
+  ceiling-derived value enters the pool.
 - Fractional-cap evidence uses four `$0.335` lots: aggregate `$1.34`, baseline
   `$0.335`, exact cap `$1.005`, and canonical cent cap `$1.00`. Four `$0.25`
   retained lots total `$1.00`; exact overflow remains `$0.335`, canonical overflow
@@ -1001,7 +999,7 @@ boundary while the production value path remains disabled behind its named gate.
 | Base custody | Separate platform and epoch Safe accounts; new versioned intake or explicit reconciled split; old single-treasury deployment is never reinterpreted | Tasks #132 and #140 approve deployments | Base intake/payout activation |
 | Limited signer | $20 per payout, $500 per rolling 24-hour window, $5,000 per epoch; token/recipient allowlists, nonce, expiry, pause, and independent Safe enforcement | Task #140 selects Safe owner threshold, audited module deployment, paymaster budget, and alert thresholds | Automated Base payouts |
 | FX and depeg | Immutable monthly rate, primary/fallback/manual evidence, reasonability review, and ±0.3% stablecoin pause | Task #135 selects source hierarchy and recovery/reactivation runbook | Valuing and later stages |
-| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; equal theoretical project share discounted by locked score/max; aggregate initials pre-clamped to `3 ×` largest-project baseline with source-linked overflow, then lowest-earner-first global redistribution; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
+| Cubid evidence | Valid and whitelisted IDs only; project pseudonyms; equal theoretical project share discounted by locked score/max; full aggregate initials preserved; operator-selected monthly multiple limits redistribution top-ups only; score discounts, E−3 harvest, and carry-in fund lowest-earner-first redistribution; grey/black holds | Task #136 selects numeric cache TTL and authorized exception workflow | Allocation lock |
 | Project review deadline | Midnight Pacific at the end of the next FundLoop business day after accepted reconciliation-email delivery | Tasks #128/#133 select provider event mapping and versioned holiday rows | Project-package lock |
 | Risk reserve | Reversals never silently reduce unrelated awards; losses and receivables are explicit | Tasks #121/#135 set reserve target, chargeback recovery, and bad-debt policy | Controlled production value |
 | Rounding and queues | Exact atomic native quantities, exact numeric USD, deterministic sequence, explicit dust, and no negative inventory | Task #139 sets per-asset dust and queued-request terminal policy | Payout opening |
@@ -1078,9 +1076,9 @@ partial indexes cover unresolved events and open work queues.
 ### `conditional_award.v1`
 
 - source allocation/epoch, user, theoretical project shares, locked score/max,
-  initial claims, aggregate initial claim, largest-single-project baseline, cap,
-  retention factor, retained initial lots, overlap-cap overflow, pre-redistribution
-  current, redistribution top-up, final locked USD amount, project/source fills, eligible
+  initial claims, aggregate initial claim, largest-single-project baseline, selected
+  cap multiple, redistribution top-up ceiling and capacity, E−3 harvest, carry-in,
+  redistribution top-up, carry-out residue, final locked USD amount, project/source fills, eligible
   rail/asset inventory, expiry, Cubid evidence, hold state, and immutable result hash;
 - available, reserved, queued, processed, expired, and reversed memorandum amounts
   whose conservation equals the approved award; and

--- a/docs/engineering/target-state-architecture.md
+++ b/docs/engineering/target-state-architecture.md
@@ -1,6 +1,6 @@
 # FundLoop Target-State Architecture
 
-Last drafted: 2026-04-14
+Last reviewed: 2026-08-11
 
 Related planning docs:
 - [Engineering Docs Index](./README.md)
@@ -12,13 +12,12 @@ Related planning docs:
 
 ## 1. North Star
 
-FundLoop should become a production-grade monthly economic coordination engine that serves two first-class audiences:
+FundLoop should become a production-grade monthly economic coordination engine that serves four first-class audiences:
 
-- humans
-  - regular users discovering projects, proving personhood, participating, and managing earnings
-  - founders and project members onboarding, funding the loop, managing contribution operations, and growing their project presence
-- agents
-  - MCP-compatible software agents acting on behalf of users, founders, or project teams through deterministic protocol-facing interfaces
+- regular users discovering projects, proving personhood through CUBID.me, participating, tracking earnings, and managing payouts;
+- founders, developers, and project members onboarding projects, committing revenue, funding monthly epochs, submitting attribution, and reporting to their communities;
+- researchers and the general public studying practical post-capitalistic and decentralized economic coordination through privacy-safe public evidence; and
+- internal operators and MCP-compatible agents running, verifying, reconciling, reporting, or assisting with the same governed workflows.
 
 The target system is not just a website and not just an internal dashboard. It is:
 
@@ -26,6 +25,17 @@ The target system is not just a website and not just an internal dashboard. It i
 - a reliable money and identity workflow engine
 - an audit-friendly monthly bookkeeping and distribution system
 - an agent-operable protocol interface
+
+The core economic loop is:
+
+1. projects commit a recurring percentage of revenue;
+2. people prove uniqueness through CUBID.me and build participation signal;
+3. projects submit monthly contribution and attribution data together with funds;
+4. FundLoop locks the epoch, calculates distributions, reconciles inputs, and records verification;
+5. approved awards remain claimable through three complete payout months, after which unclaimed value is harvested into a future redistribution pool; and
+6. public, user, project, and operator reports explain the outcome without publishing PII, profiles, or earnings unless the person explicitly opted in.
+
+Allocation preserves the full sum of every score-adjusted initial claim. An operator-selected monthly multiple limits redistribution top-ups only. The global redistribution pool contains score discounts, exactly E−3 unclaimed awards, and prior carry-in residue; no ceiling-derived overflow enters it. The selected multiple and aggregate harvest are immutable monthly report and root-hash inputs.
 
 ## 2. Product Outcomes the Architecture Must Satisfy
 
@@ -43,12 +53,13 @@ The target architecture is successful only if it supports all of the following s
 - support for EVM and Solana rails through chain-abstracted execution services
 - stubbed but intentional multi-currency fiat rails for inbound project funding and outbound user payouts
 - a first-class monthly economic cadence:
+  - project funding and attribution submission
   - end-of-month lock
-  - prep
-  - zk-calculation / distribution
-  - cleanup / verification
-  - distribution / payout
-  - reporting
+  - settlement and identity preparation
+  - deterministic calculation
+  - cleanup, verification, and approval
+  - claim and payout execution
+  - privacy-scoped reporting
 
 ## 3. Target System Shape
 
@@ -172,6 +183,8 @@ Target capabilities:
 - founder acquisition and onboarding funnels
 - transparent explanation of identity, cadence, payouts, and verification
 - data-forward reporting pages that build trust instead of hype
+- public research context that distinguishes a testable economic experiment from ideological or financial claims
+- explicit privacy language: public economic evidence does not imply public identity or earnings
 
 All current placeholder, half-marketing, or stubbed public pages should resolve into one of three states:
 

--- a/i18n/messages/en.ts
+++ b/i18n/messages/en.ts
@@ -8,7 +8,7 @@ export const enMessages = {
     home: {
       title: "FundLoop - Mutual prosperity, made operational",
       description:
-        "Explore FundLoop’s public home, learn how the loop works, and discover how projects and participants share in aligned upside.",
+        "FundLoop helps projects pool part of their revenue and distribute it monthly to verified people based on participation and contribution.",
     },
     participation: {
       title: "Participation - FundLoop",
@@ -1245,7 +1245,7 @@ export const enMessages = {
   },
   home: {
     eyebrow: "Mutual prosperity, made operational",
-    heroTitle: "A Network State for Mutual Prosperity",
+    heroTitle: "A monthly economy for shared prosperity.",
     heroSuffix: "for Mutual Prosperity",
     heroPrefixes: [
       "A Network State",
@@ -1270,7 +1270,7 @@ export const enMessages = {
     ],
     heroThesis: "A networked economy where projects feed the loop and people share in the upside.",
     heroBody:
-      "FundLoop helps teams reward real contribution, grow with stronger proof-of-humanity signal, and route part of success back to the communities that make the whole system work.",
+      "Projects pool a slice of revenue. Verified people contribute. Every month, FundLoop closes the books, explains the result, and makes each person’s share claimable.",
     ctas: {
       project: "Start a project profile",
       participant: "Join as a participant",
@@ -1279,6 +1279,46 @@ export const enMessages = {
       projects: "Projects pledge 1%+ into the loop.",
       people: "People create signal through use.",
       value: "Value returns with more context.",
+    },
+    monthlyLoop: {
+      eyebrow: "One accountable month at a time",
+      title: "From project revenue to a person’s payment.",
+      body:
+        "FundLoop is the workflow engine between participation and payout. Each epoch locks money, identity, and attribution into one reproducible economic record.",
+      visual: {
+        month: "Monthly epoch",
+        center: "Pool. Verify. Distribute.",
+      },
+      stages: [
+        { step: "01", title: "Commit revenue", body: "Projects choose a recurring percentage of revenue to route into FundLoop." },
+        { step: "02", title: "Prove personhood", body: "People connect CUBID.me so uniqueness can be verified without turning private identity data into public content." },
+        { step: "03", title: "Build participation signal", body: "People use and support projects; projects record contribution and participation context." },
+        { step: "04", title: "Submit the month", body: "Projects send their funds, contribution totals, and attribution data for the open epoch." },
+        { step: "05", title: "Lock and verify", body: "FundLoop freezes the cycle, calculates distributions, reconciles money and data, and requires an operator review." },
+        { step: "06", title: "Claim the result", body: "Awards stay claimable for three complete payout months. After that window closes, unclaimed value returns to a future redistribution pool." },
+        { step: "07", title: "Publish the why", body: "Public, user, project, and operator reports explain what happened while respecting each person’s publication choices." },
+      ],
+    },
+    audiences: {
+      eyebrow: "Four views of the same system",
+      title: "One economic loop. Different workspaces.",
+      body: "Humans and agents use the same underlying workflows, permissions, and audit trail.",
+      items: [
+        { id: "people", label: "For people", title: "Discover, participate, and understand what you earned.", body: "Link your CUBID identity, find projects, build a contribution record, choose payout preferences, and review each monthly result.", href: "/participation", cta: "Explore participation" },
+        { id: "projects", label: "For project teams", title: "Turn a revenue commitment into a repeatable monthly practice.", body: "Onboard a project, manage members and payment routes, fund the epoch, submit attribution, and explain the outcome to your community.", href: "/founders", cta: "Explore the founder path" },
+        { id: "research", label: "For researchers and the public", title: "Study a practical experiment in post-capitalistic coordination.", body: "Follow public projects and monthly reports to see how identity, participation, capital, and pluralistic distribution interact in practice.", href: "/reports", cta: "Open public reporting" },
+        { id: "operators", label: "For operators and agents", title: "Run the same workflow through a control plane or MCP.", body: "Prepare epochs, verify exceptions, reconcile rails, publish reports, and automate bounded tasks through shared Edge Function contracts.", href: "/mcp", cta: "Explore the MCP interface" },
+      ],
+    },
+    trust: {
+      eyebrow: "Transparent without being extractive",
+      title: "Explain the money. Protect the person.",
+      body: "Auditability is not permission to expose people. FundLoop separates reproducible economic evidence from optional public identity and earnings visibility.",
+      items: [
+        { title: "Monthly records are reproducible", body: "Locked inputs, versioned policy, calculation artifacts, verification decisions, and payment events keep the result traceable." },
+        { title: "Private by default", body: "CUBID identity and payout details stay scoped to authorized workflows. Profiles and earnings appear publicly only through explicit publication choices." },
+        { title: "Humans and agents share the rules", body: "The web app and MCP interface converge on the same typed Edge Function commands, authorization boundaries, and event history." },
+      ],
     },
     theoryOfChange: {
       eyebrow: "Our theory of change",
@@ -1403,13 +1443,15 @@ export const enMessages = {
       openPage: "Open page",
     },
     closing: {
+      kicker: "Month one",
       eyebrow: "Start where you are",
       title:
-        "FundLoop already saves onboarding drafts, supports project profiles, and is ready for the next wave of aligned builders.",
+        "Join the people and projects building a transparent monthly economy.",
       body:
-        "If you are building a project, join the loop. If you are a participant, create your profile and be ready when value starts moving through the network.",
+        "Discover the model, create a private-by-default profile, or read the product and protocol documentation before stepping into the loop.",
       project: "Join as a project",
       participant: "Join as a participant",
+      documentation: "Read the documentation",
     },
   },
   participation: {

--- a/i18n/messages/es.ts
+++ b/i18n/messages/es.ts
@@ -8,7 +8,7 @@ export const esMessages = {
     home: {
       title: "FundLoop - Prosperidad mutua hecha operativa",
       description:
-        "Explora la página pública de inicio de FundLoop, entiende cómo funciona el loop y descubre cómo proyectos y participantes comparten valor alineado.",
+        "FundLoop ayuda a los proyectos a reunir parte de sus ingresos y distribuirlos cada mes a personas verificadas según participación y contribución.",
     },
     participation: {
       title: "Participación - FundLoop",
@@ -1229,7 +1229,7 @@ export const esMessages = {
   },
   home: {
     eyebrow: "Prosperidad mutua, hecha operativa",
-    heroTitle: "Una economía en red donde los proyectos alimentan el loop y las personas comparten el valor generado.",
+    heroTitle: "Una economía mensual para la prosperidad compartida.",
     heroSuffix: "para la prosperidad mutua",
     heroPrefixes: [
       "Un estado-red",
@@ -1255,7 +1255,7 @@ export const esMessages = {
     heroThesis:
       "Una economía en red donde los proyectos alimentan el loop y las personas comparten el valor generado.",
     heroBody:
-      "FundLoop ayuda a los equipos a recompensar contribuciones reales, crecer con mejor señal de prueba de humanidad y redirigir parte del éxito hacia las comunidades que hacen posible el sistema.",
+      "Los proyectos reúnen una parte de sus ingresos. Personas verificadas contribuyen. Cada mes, FundLoop cierra las cuentas, explica el resultado y permite reclamar la parte de cada persona.",
     ctas: {
       project: "Crear perfil de proyecto",
       participant: "Unirse como participante",
@@ -1264,6 +1264,42 @@ export const esMessages = {
       projects: "Los proyectos destinan 1 % o más al loop.",
       people: "Las personas crean señal mediante el uso.",
       value: "El valor regresa con más contexto.",
+    },
+    monthlyLoop: {
+      eyebrow: "Un mes responsable a la vez",
+      title: "De los ingresos del proyecto al pago de una persona.",
+      body: "FundLoop es el motor de flujo entre participación y pago. Cada época bloquea dinero, identidad y atribución en un registro económico reproducible.",
+      visual: { month: "Época mensual", center: "Reunir. Verificar. Distribuir." },
+      stages: [
+        { step: "01", title: "Comprometer ingresos", body: "Los proyectos eligen un porcentaje recurrente de ingresos para aportar a FundLoop." },
+        { step: "02", title: "Probar humanidad", body: "Las personas conectan CUBID.me para verificar su unicidad sin convertir datos privados de identidad en contenido público." },
+        { step: "03", title: "Crear señal", body: "Las personas usan y apoyan proyectos; los proyectos registran el contexto de contribución y participación." },
+        { step: "04", title: "Presentar el mes", body: "Los proyectos envían fondos, totales de contribución y datos de atribución para la época abierta." },
+        { step: "05", title: "Bloquear y verificar", body: "FundLoop congela el ciclo, calcula distribuciones, concilia dinero y datos y exige revisión operativa." },
+        { step: "06", title: "Reclamar el resultado", body: "Las asignaciones pueden reclamarse durante tres meses completos de pago. Al cerrarse ese plazo, el valor no reclamado vuelve a un fondo de redistribución futuro." },
+        { step: "07", title: "Publicar el porqué", body: "Informes públicos, personales, de proyecto y operación explican el resultado respetando cada elección de publicación." },
+      ],
+    },
+    audiences: {
+      eyebrow: "Cuatro vistas del mismo sistema",
+      title: "Un ciclo económico. Distintos espacios.",
+      body: "Personas y agentes usan los mismos flujos, permisos y registro de auditoría.",
+      items: [
+        { id: "people", label: "Para las personas", title: "Descubre, participa y entiende lo que ganaste.", body: "Vincula tu identidad CUBID, encuentra proyectos, crea un historial de contribución, elige preferencias de pago y revisa cada resultado mensual.", href: "/participation", cta: "Explorar la participación" },
+        { id: "projects", label: "Para equipos de proyecto", title: "Convierte un compromiso de ingresos en una práctica mensual.", body: "Incorpora un proyecto, gestiona miembros y rutas de pago, financia la época, presenta atribución y explica el resultado a tu comunidad.", href: "/founders", cta: "Explorar la ruta de fundadores" },
+        { id: "research", label: "Para investigación y público", title: "Estudia un experimento práctico de coordinación poscapitalista.", body: "Sigue proyectos e informes públicos para ver cómo identidad, participación, capital y distribución pluralista interactúan en la práctica.", href: "/reports", cta: "Abrir informes públicos" },
+        { id: "operators", label: "Para operadores y agentes", title: "Ejecuta el mismo flujo mediante un panel de control o MCP.", body: "Prepara épocas, verifica excepciones, concilia canales, publica informes y automatiza tareas acotadas mediante contratos Edge Function compartidos.", href: "/mcp", cta: "Explorar la interfaz MCP" },
+      ],
+    },
+    trust: {
+      eyebrow: "Transparente sin ser extractivo",
+      title: "Explicar el dinero. Proteger a la persona.",
+      body: "La auditabilidad no autoriza exponer a las personas. FundLoop separa la evidencia económica reproducible de la visibilidad pública opcional de identidad e ingresos.",
+      items: [
+        { title: "Registros mensuales reproducibles", body: "Entradas bloqueadas, política versionada, artefactos de cálculo, decisiones de verificación y eventos de pago mantienen el resultado rastreable." },
+        { title: "Privado por defecto", body: "La identidad CUBID y los datos de pago quedan limitados a flujos autorizados. Perfiles e ingresos solo son públicos por elección explícita." },
+        { title: "Personas y agentes comparten reglas", body: "La web y la interfaz MCP convergen en los mismos comandos Edge Function tipados, límites de autorización e historial de eventos." },
+      ],
     },
     theoryOfChange: {
       eyebrow: "Nuestra teoría del cambio",
@@ -1388,13 +1424,13 @@ export const esMessages = {
       openPage: "Abrir página",
     },
     closing: {
+      kicker: "Primer mes",
       eyebrow: "Empieza donde estás",
-      title:
-        "FundLoop ya guarda borradores de onboarding, admite perfiles de proyecto y está listo para la próxima ola de builders alineados.",
-      body:
-        "Si estás construyendo un proyecto, entra al loop. Si participas, crea tu perfil y prepárate para cuando el valor empiece a moverse por la red.",
+      title: "Únete a las personas y proyectos que construyen una economía mensual transparente.",
+      body: "Descubre el modelo, crea un perfil privado por defecto o lee la documentación del producto y protocolo antes de entrar en el ciclo.",
       project: "Unirse como proyecto",
       participant: "Unirse como participante",
+      documentation: "Leer la documentación",
     },
   },
   participation: {

--- a/i18n/messages/fr.ts
+++ b/i18n/messages/fr.ts
@@ -8,7 +8,7 @@ export const frMessages = {
     home: {
       title: "FundLoop - Une prospérité mutuelle rendue opérationnelle",
       description:
-        "Découvrez la page d’accueil publique de FundLoop, comprenez le fonctionnement de la boucle et voyez comment projets et participants partagent une croissance alignée.",
+        "FundLoop aide les projets à mutualiser une part de leurs revenus et à la distribuer chaque mois à des personnes vérifiées selon leur participation et leur contribution.",
     },
     participation: {
       title: "Participation - FundLoop",
@@ -1229,7 +1229,7 @@ export const frMessages = {
   },
   home: {
     eyebrow: "Prospérité mutuelle, rendue opérationnelle",
-    heroTitle: "Une économie en réseau où les projets alimentent la boucle et où les personnes partagent la valeur créée.",
+    heroTitle: "Une économie mensuelle pour une prospérité partagée.",
     heroSuffix: "pour une prospérité mutuelle",
     heroPrefixes: [
       "Un État-réseau",
@@ -1255,7 +1255,7 @@ export const frMessages = {
     heroThesis:
       "Une économie en réseau où les projets alimentent la boucle et où les personnes partagent la valeur créée.",
     heroBody:
-      "FundLoop aide les équipes à récompenser de vraies contributions, à croître avec un meilleur signal de preuve d’humanité et à redistribuer une partie de leur succès aux communautés qui rendent le système possible.",
+      "Les projets mettent en commun une part de leurs revenus. Des personnes vérifiées contribuent. Chaque mois, FundLoop clôture les comptes, explique le résultat et rend la part de chacun réclamable.",
     ctas: {
       project: "Créer un profil projet",
       participant: "Rejoindre comme participant",
@@ -1264,6 +1264,42 @@ export const frMessages = {
       projects: "Les projets consacrent 1 % ou plus à la boucle.",
       people: "Les personnes créent du signal par l’usage.",
       value: "La valeur revient avec plus de contexte.",
+    },
+    monthlyLoop: {
+      eyebrow: "Un mois responsable à la fois",
+      title: "Du revenu du projet au paiement d’une personne.",
+      body: "FundLoop est le moteur de workflow entre participation et paiement. Chaque époque verrouille argent, identité et attribution dans un registre économique reproductible.",
+      visual: { month: "Époque mensuelle", center: "Mutualiser. Vérifier. Distribuer." },
+      stages: [
+        { step: "01", title: "Engager des revenus", body: "Les projets choisissent un pourcentage récurrent de leurs revenus à verser dans FundLoop." },
+        { step: "02", title: "Prouver son humanité", body: "Les personnes connectent CUBID.me afin que leur unicité soit vérifiée sans rendre publiques leurs données d’identité." },
+        { step: "03", title: "Construire le signal", body: "Les personnes utilisent et soutiennent les projets ; les projets consignent le contexte de contribution et de participation." },
+        { step: "04", title: "Soumettre le mois", body: "Les projets envoient les fonds, les totaux de contribution et les données d’attribution pour l’époque ouverte." },
+        { step: "05", title: "Verrouiller et vérifier", body: "FundLoop fige le cycle, calcule les distributions, rapproche argent et données, puis exige une revue opérateur." },
+        { step: "06", title: "Réclamer le résultat", body: "Les allocations restent réclamables pendant trois mois de paiement complets. À la clôture de ce délai, la valeur non réclamée retourne dans un futur fonds de redistribution." },
+        { step: "07", title: "Publier l’explication", body: "Les rapports publics, personnels, projet et opérateur expliquent le résultat tout en respectant les choix de publication." },
+      ],
+    },
+    audiences: {
+      eyebrow: "Quatre vues du même système",
+      title: "Une boucle économique. Des espaces distincts.",
+      body: "Humains et agents utilisent les mêmes workflows, permissions et traces d’audit.",
+      items: [
+        { id: "people", label: "Pour les personnes", title: "Découvrez, participez et comprenez vos gains.", body: "Liez votre identité CUBID, trouvez des projets, construisez un historique de contribution, choisissez vos préférences de paiement et examinez chaque résultat mensuel.", href: "/participation", cta: "Explorer la participation" },
+        { id: "projects", label: "Pour les équipes projet", title: "Transformez un engagement de revenus en pratique mensuelle.", body: "Intégrez un projet, gérez membres et routes de paiement, financez l’époque, soumettez l’attribution et expliquez le résultat à votre communauté.", href: "/founders", cta: "Explorer le parcours fondateur" },
+        { id: "research", label: "Pour la recherche et le public", title: "Étudiez une expérience concrète de coordination post-capitaliste.", body: "Suivez les projets et rapports publics pour observer comment identité, participation, capital et distribution pluraliste interagissent en pratique.", href: "/reports", cta: "Ouvrir les rapports publics" },
+        { id: "operators", label: "Pour opérateurs et agents", title: "Exécutez le même workflow par un poste de contrôle ou MCP.", body: "Préparez les époques, vérifiez les exceptions, rapprochez les rails, publiez des rapports et automatisez des tâches bornées via des contrats Edge Function partagés.", href: "/mcp", cta: "Explorer l’interface MCP" },
+      ],
+    },
+    trust: {
+      eyebrow: "Transparent sans être extractif",
+      title: "Expliquer l’argent. Protéger la personne.",
+      body: "L’auditabilité n’autorise pas l’exposition des personnes. FundLoop sépare les preuves économiques reproductibles de la visibilité publique optionnelle de l’identité et des gains.",
+      items: [
+        { title: "Des registres mensuels reproductibles", body: "Entrées verrouillées, politique versionnée, artefacts de calcul, décisions de vérification et événements de paiement rendent le résultat traçable." },
+        { title: "Privé par défaut", body: "L’identité CUBID et les détails de paiement restent réservés aux workflows autorisés. Profils et gains ne deviennent publics que par choix explicite." },
+        { title: "Humains et agents partagent les règles", body: "L’application web et l’interface MCP convergent vers les mêmes commandes Edge Function typées, limites d’autorisation et historiques d’événements." },
+      ],
     },
     theoryOfChange: {
       eyebrow: "Notre théorie du changement",
@@ -1388,13 +1424,13 @@ export const frMessages = {
       openPage: "Ouvrir la page",
     },
     closing: {
+      kicker: "Premier mois",
       eyebrow: "Commencez là où vous êtes",
-      title:
-        "FundLoop enregistre déjà des brouillons d’onboarding, prend en charge les profils projet et se prépare pour la prochaine vague de builders alignés.",
-      body:
-        "Si vous construisez un projet, rejoignez la boucle. Si vous participez, créez votre profil et soyez prêt lorsque la valeur commencera à circuler dans le réseau.",
+      title: "Rejoignez les personnes et projets qui bâtissent une économie mensuelle transparente.",
+      body: "Découvrez le modèle, créez un profil privé par défaut ou lisez la documentation produit et protocole avant d’entrer dans la boucle.",
       project: "Rejoindre comme projet",
       participant: "Rejoindre comme participant",
+      documentation: "Lire la documentation",
     },
   },
   participation: {

--- a/lib/edge-functions/epoch-funded-allocation-contract.ts
+++ b/lib/edge-functions/epoch-funded-allocation-contract.ts
@@ -2,10 +2,13 @@ import { edgeCommandFailure, edgeCommandSuccess, type EdgeCommandResult } from "
 
 export type EpochFundedAllocationInput =
   | { action: "read"; cycleKey?: string }
-  | { action: "lock"; cycleKey: string }
+  | { action: "preview"; cycleKey: string; capMultiple: string }
+  | { action: "lock"; cycleKey: string; capMultiple: string; selectedPreviewHash: string }
   | { action: "calculate"; cycleKey: string }
 
 const cycleKeyPattern = /^\d{4}-(?:0[1-9]|1[0-2])$/
+const capMultiplePattern = /^(?:[1-9]\.\d{2}|10\.00)$/
+const hashPattern = /^[0-9a-f]{64}$/
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value))
@@ -30,11 +33,30 @@ export function validateEpochFundedAllocationInput(value: unknown): EdgeCommandR
     }
     return edgeCommandSuccess({ action: "read", ...(typeof value.cycleKey === "string" ? { cycleKey: value.cycleKey } : {}) })
   }
-  if ((value.action === "lock" || value.action === "calculate") && hasExactKeys(value, ["action", "cycleKey"])) {
+  if (value.action === "preview" && hasExactKeys(value, ["action", "cycleKey", "capMultiple"])) {
     if (typeof value.cycleKey !== "string" || !cycleKeyPattern.test(value.cycleKey)) {
       return edgeCommandFailure("invalid_cycle", "Cycle key must use YYYY-MM.")
     }
-    return edgeCommandSuccess({ action: value.action, cycleKey: value.cycleKey })
+    if (typeof value.capMultiple !== "string" || !capMultiplePattern.test(value.capMultiple)) {
+      return edgeCommandFailure("invalid_cap_multiple", "Cap multiple must be between 1.00 and 10.00 in 0.01 increments.")
+    }
+    return edgeCommandSuccess({ action: "preview", cycleKey: value.cycleKey, capMultiple: value.capMultiple })
+  }
+  if (value.action === "lock" && hasExactKeys(value, ["action", "cycleKey", "capMultiple", "selectedPreviewHash"])) {
+    if (typeof value.cycleKey !== "string" || !cycleKeyPattern.test(value.cycleKey)) {
+      return edgeCommandFailure("invalid_cycle", "Cycle key must use YYYY-MM.")
+    }
+    if (typeof value.capMultiple !== "string" || !capMultiplePattern.test(value.capMultiple)
+      || typeof value.selectedPreviewHash !== "string" || !hashPattern.test(value.selectedPreviewHash)) {
+      return edgeCommandFailure("invalid_payload", "A governed cap multiple and selected preview hash are required.")
+    }
+    return edgeCommandSuccess({ action: "lock", cycleKey: value.cycleKey, capMultiple: value.capMultiple, selectedPreviewHash: value.selectedPreviewHash })
+  }
+  if (value.action === "calculate" && hasExactKeys(value, ["action", "cycleKey"])) {
+    if (typeof value.cycleKey !== "string" || !cycleKeyPattern.test(value.cycleKey)) {
+      return edgeCommandFailure("invalid_cycle", "Cycle key must use YYYY-MM.")
+    }
+    return edgeCommandSuccess({ action: "calculate", cycleKey: value.cycleKey })
   }
   return edgeCommandFailure("invalid_payload", "The allocation command is invalid.")
 }

--- a/lib/edge-functions/epoch-funded-allocation.ts
+++ b/lib/edge-functions/epoch-funded-allocation.ts
@@ -3,6 +3,7 @@ import type { EpochFundedAllocationInput } from "./epoch-funded-allocation-contr
 
 export type EpochFundedAllocationOutput =
   | { action: "read"; allocations: unknown[] }
+  | { action: "preview"; previewHash: string; artifact: { resultHash: string; capMultiple: string; totals: Record<string, string> } }
   | { action: "lock"; manifestId: number; manifestHash: string; manifest: unknown }
   | { action: "calculate"; manifestId: number; runId: number; artifact: { resultHash: string } }
 

--- a/lib/monthly-cycles/epoch-close-review.ts
+++ b/lib/monthly-cycles/epoch-close-review.ts
@@ -16,16 +16,23 @@ export type EpochCloseOperatorRow = {
   top_up_minor: string | number | null
   returned_residue_minor: string | number | null
   artifact_count: number | null
+  policy_key: string | null
+  cap_multiple: string | number | null
+  current_funded_minor: string | number | null
+  harvested_unclaimed_minor: string | number | null
+  carry_in_minor: string | number | null
 }
 
 export type EpochCloseUserRow = {
   cycleKey: string
   rootHash: string
   status: string
-  retainedInitialMinor: string
+  initialClaimMinor: string
   topUpMinor: string
   finalAwardMinor: string
-  minorUnitCap: string
+  redistributionCeilingMinor: string
+  capMultiple: string
+  harvestedUnclaimedMinor: string
   payableStatus: string
   ownershipStatus: string
   assetEligibilityStatus: string
@@ -41,6 +48,8 @@ export type EpochCloseProjectRow = {
   initialClaimExactUsd: string
   scorePoolContributionExactUsd: string
   sourceCount: number
+  capMultiple: string
+  harvestedUnclaimedMinor: string
 }
 
 function enabled() {
@@ -62,15 +71,24 @@ export async function loadLatestUserEpochClose(userId: string): Promise<EpochClo
   if (!control.data) return null
   const [cycle, approval] = await Promise.all([
     admin.from("monthly_cycles").select("cycle_key").eq("id", control.data.monthly_cycle_id).single(),
-    admin.from("epoch_close_packages").select("root_hash,status").eq("approval_id", control.data.approval_id).eq("status", "payout_readying").maybeSingle(),
+    admin.from("epoch_close_packages").select("*").eq("approval_id", control.data.approval_id).eq("status", "payout_readying").maybeSingle(),
   ])
   if (cycle.error) throw new Error(cycle.error.message)
   if (approval.error) throw new Error(approval.error.message)
   if (!approval.data) return null
+  const controlRow = control.data as typeof control.data & {
+    initial_claim_minor?: string | number | null
+    redistribution_ceiling_minor?: string | number | null
+    cap_multiple?: string | number | null
+  }
+  const closeRow = approval.data as typeof approval.data & { harvested_unclaimed_minor?: string | number | null }
   return {
-    cycleKey: cycle.data.cycle_key, rootHash: approval.data.root_hash, status: approval.data.status,
-    retainedInitialMinor: String(control.data.retained_initial_minor), topUpMinor: String(control.data.redistribution_top_up_minor),
-    finalAwardMinor: String(control.data.final_award_minor), minorUnitCap: String(control.data.minor_unit_cap),
+    cycleKey: cycle.data.cycle_key, rootHash: closeRow.root_hash, status: closeRow.status,
+    initialClaimMinor: String(controlRow.initial_claim_minor ?? controlRow.retained_initial_minor),
+    topUpMinor: String(controlRow.redistribution_top_up_minor), finalAwardMinor: String(controlRow.final_award_minor),
+    redistributionCeilingMinor: String(controlRow.redistribution_ceiling_minor ?? controlRow.minor_unit_cap),
+    capMultiple: Number(controlRow.cap_multiple ?? 3).toFixed(2),
+    harvestedUnclaimedMinor: String(closeRow.harvested_unclaimed_minor ?? 0),
     payableStatus: control.data.payable_status, ownershipStatus: control.data.ownership_status,
     assetEligibilityStatus: control.data.asset_eligibility_status,
   }
@@ -89,18 +107,28 @@ export async function loadLatestProjectEpochClose(projectId: number): Promise<Ep
   if (cycle.error) throw new Error(cycle.error.message)
   if (close.error) throw new Error(close.error.message)
   if (!close.data) return null
+  const summaryRow = summary.data as typeof summary.data & {
+    cap_multiple?: string | number | null
+    harvested_unclaimed_minor?: string | number | null
+  }
   return {
     cycleKey: cycle.data.cycle_key, rootHash: close.data.root_hash, status: close.data.status,
-    fundedMinor: String(summary.data.funded_minor), cohortCount: summary.data.cohort_count,
-    theoreticalShareExactUsd: String(summary.data.theoretical_share_exact_usd), initialClaimExactUsd: String(summary.data.initial_claim_exact_usd),
-    scorePoolContributionExactUsd: String(summary.data.score_pool_contribution_exact_usd), sourceCount: summary.data.source_count,
+    fundedMinor: String(summaryRow.funded_minor), cohortCount: summaryRow.cohort_count,
+    theoreticalShareExactUsd: String(summaryRow.theoretical_share_exact_usd), initialClaimExactUsd: String(summaryRow.initial_claim_exact_usd),
+    scorePoolContributionExactUsd: String(summaryRow.score_pool_contribution_exact_usd), sourceCount: summaryRow.source_count,
+    capMultiple: Number(summaryRow.cap_multiple ?? 3).toFixed(2),
+    harvestedUnclaimedMinor: String(summaryRow.harvested_unclaimed_minor ?? 0),
   }
 }
 
-export async function loadPublicProjectEpochClose(projectSlug: string) {
+export async function loadPublicProjectEpochClose(projectSlug: string): Promise<{
+  cycle_key: string | null; project_slug: string | null; root_hash: string | null; status: string | null
+  funded_minor: string | number | null; published_cohort_count: number | null; source_count: number | null
+  cap_multiple: string | number | null; harvested_unclaimed_minor: string | number | null; created_at: string | null
+} | null> {
   if (!enabled()) return null
   const result = await getAdminSupabaseClient().from("epoch_close_public_project_view").select("*").eq("project_slug", projectSlug)
     .order("created_at", { ascending: false }).limit(1).maybeSingle()
   if (result.error) throw new Error(result.error.message)
-  return result.data
+  return result.data as unknown as Awaited<ReturnType<typeof loadPublicProjectEpochClose>>
 }

--- a/lib/monthly-cycles/funded-redistribution-v2-calculator.ts
+++ b/lib/monthly-cycles/funded-redistribution-v2-calculator.ts
@@ -1,0 +1,564 @@
+const ZERO_BIGINT = BigInt(0)
+const ONE_BIGINT = BigInt(1)
+const TEN_BIGINT = BigInt(10)
+
+export const FUNDED_REDISTRIBUTION_V2_POLICY = "settled_cubid_redistribution_v2" as const
+
+type Fraction = { numerator: bigint; denominator: bigint }
+
+export type FundedProjectSourceInput = {
+  sourceLotId: string
+  sourceLotKey: string
+  projectId: number
+  projectKey: string
+  exactUsd: string
+  canonicalMinorCapacity: string
+  minorUnitScale: number
+  sourceOrder: string
+  railKey: string
+  assetKey: string
+  custodyKey: string
+  nativeAtomicAmount: string
+  fxSnapshotId: string
+  evidenceHash: string
+}
+
+export type FundedRedistributionPoolSourceInput = Omit<FundedProjectSourceInput, "projectKey"> & {
+  originKind: "harvested_unclaimed" | "carryforward_residue"
+  originCycleKey: string
+}
+
+export type FundedAllocationCohortV2Input = {
+  projectId: number
+  projectKey: string
+  userId: string
+  projectPseudonym: string
+  lockedScore: string
+  lockedMaximumScore: string
+  cubidEvidenceHash: string
+}
+
+export type FundedRedistributionV2Input = {
+  cycleKey: string
+  manifestHash: string
+  minorUnitScale: number
+  capMultiple: string
+  selectedPreviewHash: string
+  projectSources: FundedProjectSourceInput[]
+  redistributionSources: FundedRedistributionPoolSourceInput[]
+  cohort: FundedAllocationCohortV2Input[]
+}
+
+export type FundedSourceDispositionV2 = {
+  sourceLotId: string
+  sourceLotKey: string
+  userId: string | null
+  projectId: number
+  kind: "initial_claim" | "score_pool" | "harvested_pool" | "carryin_pool" | "top_up" | "carryout_residue"
+  canonicalMinor: string
+  exactUsd: string
+}
+
+export type FundedUserAllocationV2 = {
+  userId: string
+  aggregateInitialExactUsd: string
+  baselineExactUsd: string
+  capMultiple: string
+  redistributionCeilingExactUsd: string
+  redistributionCeilingMinor: string
+  initialClaimMinor: string
+  topUpCapacityMinor: string
+  topUpMinor: string
+  finalMinor: string
+  projectClaims: Array<{
+    projectId: number
+    theoreticalShareExactUsd: string
+    scoreFactor: string
+    initialClaimExactUsd: string
+    scorePoolContributionExactUsd: string
+  }>
+}
+
+export type FundedRedistributionV2Result = {
+  policy: typeof FUNDED_REDISTRIBUTION_V2_POLICY
+  cycleKey: string
+  manifestHash: string
+  selectedPreviewHash: string
+  minorUnitScale: number
+  capMultiple: string
+  totals: {
+    currentFundedExactUsd: string
+    currentFundedMinor: string
+    harvestedUnclaimedMinor: string
+    carryInMinor: string
+    totalInputMinor: string
+    initialClaimMinor: string
+    scorePoolMinor: string
+    topUpMinor: string
+    carryOutResidueMinor: string
+    finalAllocationMinor: string
+    subMinorExactUsd: string
+  }
+  users: FundedUserAllocationV2[]
+  sourceDispositions: FundedSourceDispositionV2[]
+  invariantChecks: Array<{ code: string; ok: boolean }>
+  hashInput: unknown
+  resultHash: string
+}
+
+const ZERO: Fraction = { numerator: ZERO_BIGINT, denominator: ONE_BIGINT }
+
+function abs(value: bigint) {
+  return value < ZERO_BIGINT ? -value : value
+}
+
+function gcd(left: bigint, right: bigint): bigint {
+  let a = abs(left)
+  let b = abs(right)
+  while (b !== ZERO_BIGINT) {
+    const next = a % b
+    a = b
+    b = next
+  }
+  return a === ZERO_BIGINT ? ONE_BIGINT : a
+}
+
+function fraction(numerator: bigint, denominator = ONE_BIGINT): Fraction {
+  if (denominator === ZERO_BIGINT) throw new Error("funded_allocation_v2_division_by_zero")
+  const sign = denominator < ZERO_BIGINT ? -ONE_BIGINT : ONE_BIGINT
+  const divisor = gcd(numerator, denominator)
+  return { numerator: (numerator / divisor) * sign, denominator: abs(denominator) / divisor }
+}
+
+function add(left: Fraction, right: Fraction) {
+  return fraction(left.numerator * right.denominator + right.numerator * left.denominator, left.denominator * right.denominator)
+}
+
+function subtract(left: Fraction, right: Fraction) {
+  return fraction(left.numerator * right.denominator - right.numerator * left.denominator, left.denominator * right.denominator)
+}
+
+function multiply(left: Fraction, right: Fraction) {
+  return fraction(left.numerator * right.numerator, left.denominator * right.denominator)
+}
+
+function divide(left: Fraction, right: Fraction) {
+  return fraction(left.numerator * right.denominator, left.denominator * right.numerator)
+}
+
+function compare(left: Fraction, right: Fraction) {
+  const difference = left.numerator * right.denominator - right.numerator * left.denominator
+  return difference < ZERO_BIGINT ? -1 : difference > ZERO_BIGINT ? 1 : 0
+}
+
+function floorFraction(value: Fraction) {
+  if (value.numerator < ZERO_BIGINT) throw new Error("funded_allocation_v2_negative_value")
+  return value.numerator / value.denominator
+}
+
+function power10(scale: number) {
+  if (!Number.isInteger(scale) || scale < 0 || scale > 18) throw new Error("funded_allocation_v2_minor_scale_invalid")
+  let result = ONE_BIGINT
+  for (let index = 0; index < scale; index += 1) result *= TEN_BIGINT
+  return result
+}
+
+function parseDecimal(value: string): Fraction {
+  if (!/^-?\d+(?:\.\d+)?$/.test(value)) throw new Error("funded_allocation_v2_decimal_invalid")
+  const negative = value.startsWith("-")
+  const unsigned = negative ? value.slice(1) : value
+  const [whole, decimals = ""] = unsigned.split(".")
+  const denominator = power10(decimals.length)
+  const numerator = BigInt(whole) * denominator + BigInt(decimals || "0")
+  return fraction(negative ? -numerator : numerator, denominator)
+}
+
+function toMinorFraction(value: Fraction, scale: number) {
+  return multiply(value, fraction(power10(scale)))
+}
+
+function decimalString(value: Fraction, maxScale = 18) {
+  const negative = value.numerator < ZERO_BIGINT
+  const numerator = abs(value.numerator)
+  const scale = power10(maxScale)
+  const scaled = (numerator * scale) / value.denominator
+  const whole = scaled / scale
+  const decimals = (scaled % scale).toString().padStart(maxScale, "0").replace(/0+$/, "")
+  return `${negative ? "-" : ""}${whole}${decimals ? `.${decimals}` : ""}`
+}
+
+function stableCompare(left: string, right: string) {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`
+  const record = value as Record<string, unknown>
+  return `{${Object.keys(record).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(",")}}`
+}
+
+async function sha256Hex(value: unknown) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(stableStringify(value)))
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("")
+}
+
+type RoundingCandidate = { key: string; exactMinor: Fraction; capacity?: bigint }
+
+function allocateMinorTarget(candidates: RoundingCandidate[], target: bigint) {
+  const assigned = new Map<string, bigint>()
+  for (const candidate of candidates) {
+    const floored = floorFraction(candidate.exactMinor)
+    assigned.set(candidate.key, candidate.capacity == null || floored < candidate.capacity ? floored : candidate.capacity)
+  }
+  let remaining = target - [...assigned.values()].reduce((sum, value) => sum + value, ZERO_BIGINT)
+  const order = [...candidates].sort((left, right) => {
+    const leftFloor = floorFraction(left.exactMinor)
+    const rightFloor = floorFraction(right.exactMinor)
+    return compare(
+      subtract(right.exactMinor, fraction(rightFloor)),
+      subtract(left.exactMinor, fraction(leftFloor)),
+    ) || stableCompare(left.key, right.key)
+  })
+  while (remaining > ZERO_BIGINT) {
+    let progressed = false
+    for (const candidate of order) {
+      if (remaining === ZERO_BIGINT) break
+      const current = assigned.get(candidate.key) ?? ZERO_BIGINT
+      if (candidate.capacity != null && current >= candidate.capacity) continue
+      assigned.set(candidate.key, current + ONE_BIGINT)
+      remaining -= ONE_BIGINT
+      progressed = true
+    }
+    if (!progressed) break
+  }
+  if (remaining !== ZERO_BIGINT) throw new Error("funded_allocation_v2_rounding_capacity_exhausted")
+  return assigned
+}
+
+type ExactClaim = {
+  key: string
+  userId: string
+  projectId: number
+  source: FundedProjectSourceInput
+  theoretical: Fraction
+  initial: Fraction
+  scoreContribution: Fraction
+}
+
+function validateCapMultiple(value: string) {
+  if (!/^(?:[1-9](?:\.\d{2})?|10(?:\.00)?)$/.test(value)) throw new Error("funded_allocation_v2_cap_multiple_invalid")
+  const parsed = parseDecimal(value)
+  if (compare(parsed, fraction(ONE_BIGINT)) < 0 || compare(parsed, fraction(BigInt(10))) > 0) {
+    throw new Error("funded_allocation_v2_cap_multiple_invalid")
+  }
+  const [, decimals = ""] = value.split(".")
+  if (decimals.length !== 2) throw new Error("funded_allocation_v2_cap_multiple_invalid")
+  return parsed
+}
+
+function validateAndNormalize(input: FundedRedistributionV2Input) {
+  if (!/^\d{4}-\d{2}$/.test(input.cycleKey) || !/^[0-9a-f]{64}$/.test(input.manifestHash) || !/^[0-9a-f]{64}$/.test(input.selectedPreviewHash)) {
+    throw new Error("funded_allocation_v2_manifest_invalid")
+  }
+  const scale = input.minorUnitScale
+  power10(scale)
+  const capMultiple = validateCapMultiple(input.capMultiple)
+  const projectSources = [...input.projectSources].sort(
+    (left, right) => stableCompare(left.sourceOrder, right.sourceOrder) || stableCompare(left.sourceLotKey, right.sourceLotKey),
+  )
+  if (projectSources.length === 0) throw new Error("funded_allocation_v2_project_sources_missing")
+  const redistributionSources = [...input.redistributionSources].sort(
+    (left, right) => stableCompare(left.sourceOrder, right.sourceOrder) || stableCompare(left.sourceLotKey, right.sourceLotKey),
+  )
+  const sourceKeys = new Set<string>()
+  for (const source of [...projectSources, ...redistributionSources]) {
+    if (sourceKeys.has(source.sourceLotKey)) throw new Error("funded_allocation_v2_source_duplicate")
+    sourceKeys.add(source.sourceLotKey)
+    if (source.minorUnitScale !== scale || compare(parseDecimal(source.exactUsd), ZERO) <= 0
+      || !/^\d+$/.test(source.canonicalMinorCapacity)) {
+      throw new Error("funded_allocation_v2_source_invalid")
+    }
+  }
+  const cohort = [...input.cohort].sort(
+    (left, right) => left.projectId - right.projectId || stableCompare(left.userId, right.userId),
+  )
+  const cohortKeys = new Set<string>()
+  for (const member of cohort) {
+    const key = `${member.projectId}:${member.userId}`
+    if (cohortKeys.has(key)) throw new Error("funded_allocation_v2_cohort_duplicate")
+    cohortKeys.add(key)
+    const score = parseDecimal(member.lockedScore)
+    const maximum = parseDecimal(member.lockedMaximumScore)
+    if (compare(maximum, ZERO) <= 0 || compare(score, ZERO) < 0 || compare(score, maximum) > 0) {
+      throw new Error("funded_allocation_v2_score_invalid")
+    }
+  }
+  return { projectSources, redistributionSources, cohort, scale, capMultiple }
+}
+
+export async function calculateFundedRedistributionV2(input: FundedRedistributionV2Input): Promise<FundedRedistributionV2Result> {
+  const { projectSources, redistributionSources, cohort, scale, capMultiple } = validateAndNormalize(input)
+  const cohortByProject = new Map<number, FundedAllocationCohortV2Input[]>()
+  for (const member of cohort) cohortByProject.set(member.projectId, [...(cohortByProject.get(member.projectId) ?? []), member])
+  for (const projectId of new Set(projectSources.map((source) => source.projectId))) {
+    if ((cohortByProject.get(projectId)?.length ?? 0) === 0) throw new Error("funded_allocation_v2_project_cohort_missing")
+  }
+
+  const allSources = [...projectSources, ...redistributionSources]
+  const totalInputExact = allSources.reduce((sum, source) => add(sum, parseDecimal(source.exactUsd)), ZERO)
+  const totalInputMinor = allSources.reduce((sum, source) => sum + BigInt(source.canonicalMinorCapacity), ZERO_BIGINT)
+  const sourceCapacity = new Map(allSources.map((source) => [source.sourceLotKey, BigInt(source.canonicalMinorCapacity)]))
+
+  const claims: ExactClaim[] = []
+  for (const source of projectSources) {
+    const members = cohortByProject.get(source.projectId) ?? []
+    const theoretical = divide(parseDecimal(source.exactUsd), fraction(BigInt(members.length)))
+    for (const member of members) {
+      const scoreFactor = divide(parseDecimal(member.lockedScore), parseDecimal(member.lockedMaximumScore))
+      const initial = multiply(theoretical, scoreFactor)
+      claims.push({
+        key: `${member.userId}:${source.sourceLotKey}`,
+        userId: member.userId,
+        projectId: source.projectId,
+        source,
+        theoretical,
+        initial,
+        scoreContribution: subtract(theoretical, initial),
+      })
+    }
+  }
+
+  const canonicalInitialByClaim = new Map<string, bigint>()
+  const canonicalScorePoolBySource = new Map<string, bigint>()
+  for (const source of projectSources) {
+    const sourceClaims = claims.filter((claim) => claim.source.sourceLotKey === source.sourceLotKey)
+    const assigned = allocateMinorTarget([
+      ...sourceClaims.map((claim) => ({ key: `initial:${claim.key}`, exactMinor: toMinorFraction(claim.initial, scale) })),
+      ...sourceClaims.map((claim) => ({ key: `score:${claim.key}`, exactMinor: toMinorFraction(claim.scoreContribution, scale) })),
+    ], sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT)
+    for (const claim of sourceClaims) canonicalInitialByClaim.set(claim.key, assigned.get(`initial:${claim.key}`) ?? ZERO_BIGINT)
+    canonicalScorePoolBySource.set(source.sourceLotKey, sourceClaims.reduce(
+      (sum, claim) => sum + (assigned.get(`score:${claim.key}`) ?? ZERO_BIGINT), ZERO_BIGINT,
+    ))
+  }
+
+  const userState = [...new Set(cohort.map((member) => member.userId))].sort(stableCompare).map((userId) => {
+    const userClaims = claims.filter((claim) => claim.userId === userId)
+    const projectTotals = new Map<number, Fraction>()
+    for (const claim of userClaims) projectTotals.set(claim.projectId, add(projectTotals.get(claim.projectId) ?? ZERO, claim.initial))
+    const aggregate = userClaims.reduce((sum, claim) => add(sum, claim.initial), ZERO)
+    const baseline = [...projectTotals.values()].reduce((largest, value) => compare(value, largest) > 0 ? value : largest, ZERO)
+    const redistributionCeiling = multiply(baseline, capMultiple)
+    const redistributionCeilingMinor = floorFraction(toMinorFraction(redistributionCeiling, scale))
+    const initialClaimMinor = userClaims.reduce((sum, claim) => sum + (canonicalInitialByClaim.get(claim.key) ?? ZERO_BIGINT), ZERO_BIGINT)
+    const topUpCapacityMinor = redistributionCeilingMinor > initialClaimMinor ? redistributionCeilingMinor - initialClaimMinor : ZERO_BIGINT
+    return {
+      userId,
+      aggregate,
+      baseline,
+      redistributionCeiling,
+      redistributionCeilingMinor,
+      initialClaimMinor,
+      topUpCapacityMinor,
+      currentMinor: initialClaimMinor,
+      topUpMinor: ZERO_BIGINT,
+      claims: userClaims,
+    }
+  })
+
+  const availablePoolBySource = new Map<string, bigint>()
+  const availableExactPoolBySource = new Map<string, Fraction>()
+  for (const source of projectSources) {
+    const sourceClaims = claims.filter((claim) => claim.source.sourceLotKey === source.sourceLotKey)
+    availablePoolBySource.set(source.sourceLotKey, canonicalScorePoolBySource.get(source.sourceLotKey) ?? ZERO_BIGINT)
+    availableExactPoolBySource.set(source.sourceLotKey, sourceClaims.reduce((sum, claim) => add(sum, claim.scoreContribution), ZERO))
+  }
+  for (const source of redistributionSources) {
+    availablePoolBySource.set(source.sourceLotKey, sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT)
+    availableExactPoolBySource.set(source.sourceLotKey, parseDecimal(source.exactUsd))
+  }
+
+  let poolMinor = [...availablePoolBySource.values()].reduce((sum, value) => sum + value, ZERO_BIGINT)
+  const maximumIterations = userState.length * 4 + allSources.length + 10
+  let iterations = 0
+  while (poolMinor > ZERO_BIGINT) {
+    iterations += 1
+    if (iterations > maximumIterations) throw new Error("funded_allocation_v2_waterfill_stalled")
+    const candidates = userState
+      .filter((user) => user.currentMinor < user.redistributionCeilingMinor)
+      .sort((left, right) => left.currentMinor < right.currentMinor ? -1 : left.currentMinor > right.currentMinor ? 1 : stableCompare(left.userId, right.userId))
+    if (candidates.length === 0) break
+    const level = candidates[0].currentMinor
+    const group = candidates.filter((candidate) => candidate.currentMinor === level)
+    const nextLevel = candidates.find((candidate) => candidate.currentMinor > level)?.currentMinor
+    const groupCeiling = group.reduce(
+      (lowest, user) => user.redistributionCeilingMinor < lowest ? user.redistributionCeilingMinor : lowest,
+      group[0].redistributionCeilingMinor,
+    )
+    const target = nextLevel == null || groupCeiling < nextLevel ? groupCeiling : nextLevel
+    const needed = (target - level) * BigInt(group.length)
+    if (needed > ZERO_BIGINT && needed <= poolMinor) {
+      for (const user of group) {
+        const delta = target - user.currentMinor
+        user.currentMinor = target
+        user.topUpMinor += delta
+      }
+      poolMinor -= needed
+      continue
+    }
+    const perUser = poolMinor / BigInt(group.length)
+    const residual = poolMinor % BigInt(group.length)
+    for (const [index, user] of group.entries()) {
+      const requested = perUser + (BigInt(index) < residual ? ONE_BIGINT : ZERO_BIGINT)
+      const capacity = user.redistributionCeilingMinor - user.currentMinor
+      const delta = requested < capacity ? requested : capacity
+      user.currentMinor += delta
+      user.topUpMinor += delta
+      poolMinor -= delta
+    }
+    if (perUser === ZERO_BIGINT && residual === ZERO_BIGINT) break
+  }
+
+  const sourceDispositions: FundedSourceDispositionV2[] = []
+  for (const claim of claims) {
+    const canonicalMinor = canonicalInitialByClaim.get(claim.key) ?? ZERO_BIGINT
+    if (canonicalMinor > ZERO_BIGINT || compare(claim.initial, ZERO) > 0) sourceDispositions.push({
+      sourceLotId: claim.source.sourceLotId,
+      sourceLotKey: claim.source.sourceLotKey,
+      userId: claim.userId,
+      projectId: claim.projectId,
+      kind: "initial_claim",
+      canonicalMinor: canonicalMinor.toString(),
+      exactUsd: decimalString(claim.initial),
+    })
+  }
+  for (const source of projectSources) {
+    const canonicalMinor = canonicalScorePoolBySource.get(source.sourceLotKey) ?? ZERO_BIGINT
+    const exactUsd = availableExactPoolBySource.get(source.sourceLotKey) ?? ZERO
+    if (canonicalMinor > ZERO_BIGINT || compare(exactUsd, ZERO) > 0) sourceDispositions.push({
+      sourceLotId: source.sourceLotId, sourceLotKey: source.sourceLotKey, userId: null, projectId: source.projectId,
+      kind: "score_pool", canonicalMinor: canonicalMinor.toString(), exactUsd: decimalString(exactUsd),
+    })
+  }
+  for (const source of redistributionSources) sourceDispositions.push({
+    sourceLotId: source.sourceLotId, sourceLotKey: source.sourceLotKey, userId: null, projectId: source.projectId,
+    kind: source.originKind === "harvested_unclaimed" ? "harvested_pool" : "carryin_pool",
+    canonicalMinor: (sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT).toString(), exactUsd: source.exactUsd,
+  })
+
+  for (const user of [...userState].sort((left, right) => stableCompare(left.userId, right.userId))) {
+    let needed = user.topUpMinor
+    for (const source of allSources) {
+      if (needed === ZERO_BIGINT) break
+      const available = availablePoolBySource.get(source.sourceLotKey) ?? ZERO_BIGINT
+      const consumed = needed < available ? needed : available
+      if (consumed === ZERO_BIGINT) continue
+      const availableExact = availableExactPoolBySource.get(source.sourceLotKey) ?? ZERO
+      const canonicalExact = fraction(consumed, power10(scale))
+      const consumedExact = compare(canonicalExact, availableExact) < 0 ? canonicalExact : availableExact
+      sourceDispositions.push({
+        sourceLotId: source.sourceLotId, sourceLotKey: source.sourceLotKey, userId: user.userId, projectId: source.projectId,
+        kind: "top_up", canonicalMinor: consumed.toString(), exactUsd: decimalString(consumedExact),
+      })
+      availablePoolBySource.set(source.sourceLotKey, available - consumed)
+      availableExactPoolBySource.set(source.sourceLotKey, subtract(availableExact, consumedExact))
+      needed -= consumed
+    }
+    if (needed !== ZERO_BIGINT) throw new Error("funded_allocation_v2_pool_provenance_exhausted")
+  }
+
+  for (const source of allSources) {
+    const canonicalMinor = availablePoolBySource.get(source.sourceLotKey) ?? ZERO_BIGINT
+    const exactUsd = availableExactPoolBySource.get(source.sourceLotKey) ?? ZERO
+    if (canonicalMinor > ZERO_BIGINT || compare(exactUsd, ZERO) > 0) sourceDispositions.push({
+      sourceLotId: source.sourceLotId, sourceLotKey: source.sourceLotKey, userId: null, projectId: source.projectId,
+      kind: "carryout_residue", canonicalMinor: canonicalMinor.toString(), exactUsd: decimalString(exactUsd),
+    })
+  }
+
+  const users: FundedUserAllocationV2[] = userState.map((user) => ({
+    userId: user.userId,
+    aggregateInitialExactUsd: decimalString(user.aggregate),
+    baselineExactUsd: decimalString(user.baseline),
+    capMultiple: input.capMultiple,
+    redistributionCeilingExactUsd: decimalString(user.redistributionCeiling),
+    redistributionCeilingMinor: user.redistributionCeilingMinor.toString(),
+    initialClaimMinor: user.initialClaimMinor.toString(),
+    topUpCapacityMinor: user.topUpCapacityMinor.toString(),
+    topUpMinor: user.topUpMinor.toString(),
+    finalMinor: user.currentMinor.toString(),
+    projectClaims: [...new Set(user.claims.map((claim) => claim.projectId))].sort((a, b) => a - b).map((projectId) => {
+      const rows = user.claims.filter((claim) => claim.projectId === projectId)
+      const member = cohort.find((row) => row.projectId === projectId && row.userId === user.userId)
+      return {
+        projectId,
+        theoreticalShareExactUsd: decimalString(rows.reduce((sum, row) => add(sum, row.theoretical), ZERO)),
+        scoreFactor: member ? decimalString(divide(parseDecimal(member.lockedScore), parseDecimal(member.lockedMaximumScore))) : "0",
+        initialClaimExactUsd: decimalString(rows.reduce((sum, row) => add(sum, row.initial), ZERO)),
+        scorePoolContributionExactUsd: decimalString(rows.reduce((sum, row) => add(sum, row.scoreContribution), ZERO)),
+      }
+    }),
+  }))
+
+  const currentFundedExact = projectSources.reduce((sum, source) => add(sum, parseDecimal(source.exactUsd)), ZERO)
+  const currentFundedMinor = projectSources.reduce((sum, source) => sum + (sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT), ZERO_BIGINT)
+  const harvestedUnclaimedMinor = redistributionSources.filter((source) => source.originKind === "harvested_unclaimed")
+    .reduce((sum, source) => sum + (sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT), ZERO_BIGINT)
+  const carryInMinor = redistributionSources.filter((source) => source.originKind === "carryforward_residue")
+    .reduce((sum, source) => sum + (sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT), ZERO_BIGINT)
+  const initialClaimMinor = userState.reduce((sum, user) => sum + user.initialClaimMinor, ZERO_BIGINT)
+  const scorePoolMinor = [...canonicalScorePoolBySource.values()].reduce((sum, value) => sum + value, ZERO_BIGINT)
+  const topUpMinor = userState.reduce((sum, user) => sum + user.topUpMinor, ZERO_BIGINT)
+  const carryOutResidueMinor = [...availablePoolBySource.values()].reduce((sum, value) => sum + value, ZERO_BIGINT)
+  const finalAllocationMinor = userState.reduce((sum, user) => sum + user.currentMinor, ZERO_BIGINT)
+  const canonicalConserved = finalAllocationMinor + carryOutResidueMinor === totalInputMinor
+  const topUpCeilingsRespected = userState.every((user) => user.topUpMinor <= user.topUpCapacityMinor)
+  const poolConserved = topUpMinor + carryOutResidueMinor === scorePoolMinor + harvestedUnclaimedMinor + carryInMinor
+  const sourceConserved = allSources.every((source) => sourceDispositions
+    .filter((row) => row.sourceLotKey === source.sourceLotKey && ["initial_claim", "top_up", "carryout_residue"].includes(row.kind))
+    .reduce((sum, row) => sum + BigInt(row.canonicalMinor), ZERO_BIGINT) === (sourceCapacity.get(source.sourceLotKey) ?? ZERO_BIGINT))
+  const exactSourceConserved = allSources.every((source) => compare(sourceDispositions
+    .filter((row) => row.sourceLotKey === source.sourceLotKey && ["initial_claim", "top_up", "carryout_residue"].includes(row.kind))
+    .reduce((sum, row) => add(sum, parseDecimal(row.exactUsd)), ZERO), parseDecimal(source.exactUsd)) === 0)
+  if (!canonicalConserved || !topUpCeilingsRespected || !poolConserved || !sourceConserved || !exactSourceConserved) {
+    throw new Error("funded_allocation_v2_invariant_failed")
+  }
+
+  const totals = {
+    currentFundedExactUsd: decimalString(currentFundedExact),
+    currentFundedMinor: currentFundedMinor.toString(),
+    harvestedUnclaimedMinor: harvestedUnclaimedMinor.toString(),
+    carryInMinor: carryInMinor.toString(),
+    totalInputMinor: totalInputMinor.toString(),
+    initialClaimMinor: initialClaimMinor.toString(),
+    scorePoolMinor: scorePoolMinor.toString(),
+    topUpMinor: topUpMinor.toString(),
+    carryOutResidueMinor: carryOutResidueMinor.toString(),
+    finalAllocationMinor: finalAllocationMinor.toString(),
+    subMinorExactUsd: decimalString(subtract(totalInputExact, fraction(totalInputMinor, power10(scale)))),
+  }
+  const invariantChecks = [
+    { code: "canonical_minor_conservation", ok: canonicalConserved },
+    { code: "redistribution_top_up_ceilings_respected", ok: topUpCeilingsRespected },
+    { code: "redistribution_pool_conserved", ok: poolConserved },
+    { code: "source_provenance_conserved", ok: sourceConserved },
+    { code: "exact_source_provenance_conserved", ok: exactSourceConserved },
+    { code: "overlap_pool_absent", ok: true },
+  ]
+  const hashInput = {
+    policy: FUNDED_REDISTRIBUTION_V2_POLICY,
+    cycleKey: input.cycleKey,
+    manifestHash: input.manifestHash,
+    selectedPreviewHash: input.selectedPreviewHash,
+    minorUnitScale: scale,
+    capMultiple: input.capMultiple,
+    totals,
+    users,
+    sourceDispositions: sourceDispositions.sort(
+      (left, right) => stableCompare(left.sourceLotKey, right.sourceLotKey) || stableCompare(left.kind, right.kind) || stableCompare(left.userId ?? "", right.userId ?? ""),
+    ),
+    invariantChecks,
+  }
+  return { ...hashInput, hashInput, resultHash: await sha256Hex(hashInput) }
+}

--- a/lib/monthly-cycles/monthly-cycle-prep.ts
+++ b/lib/monthly-cycles/monthly-cycle-prep.ts
@@ -124,7 +124,23 @@ export type EpochFinancialPrepReview = {
 }
 
 export type EpochFundedAllocationReview = {
-  allocation: Database["public"]["Views"]["epoch_allocation_operator_view"]["Row"] | null
+  allocation: {
+    cycle_key: string | null
+    status: string | null
+    cap_multiple: number | null
+    current_funded_minor: string | number | null
+    harvested_unclaimed_minor: string | number | null
+    carry_in_minor: string | number | null
+    funded_minor: string | number | null
+    score_pool_minor: string | number | null
+    top_up_minor: string | number | null
+    carry_out_residue_minor: string | number | null
+    final_allocation_minor: string | number | null
+    user_count: number | null
+    manifest_hash: string | null
+    selected_preview_hash: string | null
+    result_hash: string | null
+  } | null
   productionDisabled: boolean
   runtimeAvailable: boolean
 }
@@ -135,9 +151,10 @@ export async function loadEpochFundedAllocationReview(cycleKey: string): Promise
     return {allocation:null,productionDisabled:true,runtimeAvailable:false}
   }
   const supabase=getAdminSupabaseClient()
-  const result=await supabase.from("epoch_allocation_operator_view").select("*").eq("cycle_key",parsedCycleKey).maybeSingle()
+  const result=await supabase.from("epoch_allocation_operator_view_v2" as "epoch_allocation_operator_view")
+    .select("*").eq("cycle_key",parsedCycleKey).maybeSingle()
   if (result.error) throw new Error(result.error.message)
-  return {allocation:result.data,productionDisabled:true,runtimeAvailable:true}
+  return {allocation:result.data as EpochFundedAllocationReview["allocation"],productionDisabled:true,runtimeAvailable:true}
 }
 
 export async function loadEpochFinancialPrepReview(cycleKey: string): Promise<EpochFinancialPrepReview> {

--- a/supabase/functions/epoch-allocation-close/index.ts
+++ b/supabase/functions/epoch-allocation-close/index.ts
@@ -1,4 +1,4 @@
-import { calculateFundedRedistribution, type FundedRedistributionInput } from "../../../lib/monthly-cycles/funded-redistribution-calculator.ts"
+import { calculateFundedRedistributionV2, type FundedRedistributionV2Input } from "../../../lib/monthly-cycles/funded-redistribution-v2-calculator.ts"
 import { validateEpochAllocationCloseInput } from "../../../lib/edge-functions/epoch-allocation-close-contract.ts"
 import { edgeCommandFailure, edgeCommandSuccess } from "../../../lib/edge-functions/result.ts"
 import { isInternalAdminEmail } from "../../../lib/internal-admin-emails.ts"
@@ -6,7 +6,9 @@ import { authenticateRequest, getEnv, json, parseJsonBody, serve } from "../_sha
 
 const allowedEnvironments = new Set(["local", "development", "dev", "preview", "test"])
 function environment() { return (getEnv("FUNDLOOP_DEPLOYMENT_ENV") ?? "production").trim().toLowerCase() }
-function errorCode(message: string) { return message.match(/epoch_close_[a-z_]+/)?.[0] ?? "epoch_close_failed" }
+function errorCode(message: string) {
+  return message.match(/epoch_close_[a-z0-9_]+/)?.[0] ?? message.match(/funded_allocation_v2_[a-z0-9_]+/)?.[0] ?? "epoch_close_failed"
+}
 
 async function handleRequest(request: Request) {
   if (request.method === "OPTIONS") return new Response("ok", { headers: { "access-control-allow-origin": "*", "access-control-allow-headers": "authorization,apikey,content-type" } })
@@ -47,18 +49,30 @@ async function handleRequest(request: Request) {
     if (confirmed.error) return json(edgeCommandFailure(errorCode(confirmed.error.message), confirmed.error.message))
     return json(edgeCommandSuccess({ action: "confirm_root", ...(confirmed.data as Record<string, unknown>) }))
   }
-  const locked = await auth.adminClient.rpc("lock_funded_epoch_allocation", {
-    p_command: { contractVersion: "epoch_funded_allocation_lock.v1", deploymentEnvironment, actorUserId: auth.user.id, cycleKey: input.cycleKey },
-  })
-  if (locked.error) return json(edgeCommandFailure(errorCode(locked.error.message), locked.error.message))
-  const manifest = locked.data as { manifestId: number; manifestHash: string; manifest: Omit<FundedRedistributionInput, "manifestHash"> }
+  const cycle = await auth.adminClient.from("monthly_cycles").select("id").eq("cycle_key", input.cycleKey).maybeSingle()
+  if (cycle.error || !cycle.data) return json(edgeCommandFailure("epoch_close_cycle_invalid", "Cycle not found."))
+  const locked = await auth.adminClient.from("epoch_allocation_manifests")
+    .select("id,manifest_hash,manifest,status")
+    .eq("monthly_cycle_id", cycle.data.id)
+    .eq("policy_key", "settled_cubid_redistribution_v2")
+    .order("version", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (locked.error || !locked.data || !["locked", "calculated"].includes(locked.data.status)) {
+    return json(edgeCommandFailure("epoch_close_v2_manifest_unavailable", "A selected and calculated v2 allocation manifest is required."))
+  }
+  const manifest = {
+    manifestId: locked.data.id,
+    manifestHash: locked.data.manifest_hash,
+    manifest: locked.data.manifest as Omit<FundedRedistributionV2Input, "manifestHash">,
+  }
   const run = await auth.adminClient.from("epoch_allocation_runs").select("id,result_hash").eq("manifest_id", manifest.manifestId).maybeSingle()
   if (run.error || !run.data) return json(edgeCommandFailure("epoch_close_run_unavailable", "A persisted allocation result is required."))
   try {
-    const rerun = await calculateFundedRedistribution({ ...manifest.manifest, manifestHash: manifest.manifestHash })
+    const rerun = await calculateFundedRedistributionV2({ ...manifest.manifest, manifestHash: manifest.manifestHash })
     if (rerun.resultHash !== run.data.result_hash) return json(edgeCommandFailure("epoch_close_deterministic_rerun_mismatch", "The independent deterministic rerun did not match the persisted result."))
-    const approved = await auth.adminClient.rpc("approve_epoch_allocation_close", { p_command: {
-      contractVersion: "epoch_allocation_close.v1", deploymentEnvironment, actorUserId: auth.user.id, runId: run.data.id,
+    const approved = await auth.adminClient.rpc("approve_epoch_allocation_close_v2", { p_command: {
+      contractVersion: "epoch_allocation_close.v2", deploymentEnvironment, actorUserId: auth.user.id, runId: run.data.id,
       manifestHash: manifest.manifestHash, resultHash: run.data.result_hash, rerunResultHash: rerun.resultHash,
     } })
     if (approved.error) return json(edgeCommandFailure(errorCode(approved.error.message), approved.error.message))

--- a/supabase/functions/epoch-funded-allocation/index.ts
+++ b/supabase/functions/epoch-funded-allocation/index.ts
@@ -1,4 +1,4 @@
-import { calculateFundedRedistribution, type FundedRedistributionInput } from "../../../lib/monthly-cycles/funded-redistribution-calculator.ts"
+import { calculateFundedRedistributionV2, type FundedRedistributionV2Input } from "../../../lib/monthly-cycles/funded-redistribution-v2-calculator.ts"
 import { validateEpochFundedAllocationInput } from "../../../lib/edge-functions/epoch-funded-allocation-contract.ts"
 import { edgeCommandFailure, edgeCommandSuccess } from "../../../lib/edge-functions/result.ts"
 import { isInternalAdminEmail } from "../../../lib/internal-admin-emails.ts"
@@ -11,7 +11,7 @@ function deploymentEnvironment() {
 }
 
 function errorCode(message: string) {
-  return message.match(/epoch_allocation_[a-z_]+/)?.[0] ?? "epoch_allocation_failed"
+  return message.match(/epoch_allocation_[a-z0-9_]+/)?.[0] ?? message.match(/funded_allocation_v2_[a-z0-9_]+/)?.[0] ?? "epoch_allocation_failed"
 }
 
 async function handleRequest(request: Request) {
@@ -34,35 +34,71 @@ async function handleRequest(request: Request) {
   }
   const input = validated.data
   if (input.action === "read") {
-    let query = auth.adminClient.from("epoch_allocation_operator_view").select("*").order("cycle_key", { ascending: false })
+    let query = auth.adminClient.from("epoch_allocation_operator_view_v2").select("*").order("cycle_key", { ascending: false })
     if (input.cycleKey) query = query.eq("cycle_key", input.cycleKey)
     const { data, error } = await query
     if (error) return json(edgeCommandFailure("epoch_allocation_read_failed", error.message))
     return json(edgeCommandSuccess({ action: "read", allocations: data ?? [] }))
   }
-  const lock = await auth.adminClient.rpc("lock_funded_epoch_allocation", {
-    p_command: {
-      contractVersion: "epoch_funded_allocation_lock.v1",
-      deploymentEnvironment: environment,
-      actorUserId: auth.user.id,
-      cycleKey: input.cycleKey,
-    },
-  })
-  if (lock.error) return json(edgeCommandFailure(errorCode(lock.error.message), lock.error.message))
-  const locked = lock.data as { manifestId: number; manifestHash: string; manifest: Omit<FundedRedistributionInput, "manifestHash"> }
-  if (input.action === "lock") return json(edgeCommandSuccess({ action: "lock", ...locked }))
-  try {
-    const artifact = await calculateFundedRedistribution({ ...locked.manifest, manifestHash: locked.manifestHash })
-    const recorded = await auth.adminClient.rpc("record_funded_epoch_allocation", {
+  if (input.action === "preview") {
+    const preview = await auth.adminClient.rpc("epoch_allocation_v2_preview_input", {
+      p_cycle_key: input.cycleKey,
+      p_cap_multiple: input.capMultiple,
+      p_environment: environment,
+    })
+    if (preview.error) return json(edgeCommandFailure(errorCode(preview.error.message), preview.error.message))
+    const previewInput = preview.data as Omit<FundedRedistributionV2Input, "manifestHash" | "selectedPreviewHash"> & { inputHash: string }
+    try {
+      const artifact = await calculateFundedRedistributionV2({
+        ...previewInput,
+        manifestHash: previewInput.inputHash,
+        selectedPreviewHash: previewInput.inputHash,
+      })
+      return json(edgeCommandSuccess({ action: "preview", previewHash: previewInput.inputHash, artifact }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Allocation preview failed."
+      return json(edgeCommandFailure(errorCode(message), message))
+    }
+  }
+  if (input.action === "lock") {
+    const lock = await auth.adminClient.rpc("lock_funded_epoch_allocation_v2", {
       p_command: {
-        contractVersion: "epoch_funded_allocation_result.v1",
+        contractVersion: "epoch_funded_allocation_lock.v2",
         deploymentEnvironment: environment,
         actorUserId: auth.user.id,
-        manifestId: locked.manifestId,
-        resultHash: artifact.resultHash,
-        artifact,
+        cycleKey: input.cycleKey,
+        capMultiple: input.capMultiple,
+        selectedPreviewHash: input.selectedPreviewHash,
       },
     })
+    if (lock.error) return json(edgeCommandFailure(errorCode(lock.error.message), lock.error.message))
+    return json(edgeCommandSuccess({ action: "lock", ...(lock.data as Record<string, unknown>) }))
+  }
+  const cycle = await auth.adminClient.from("monthly_cycles").select("id").eq("cycle_key", input.cycleKey).maybeSingle()
+  if (cycle.error || !cycle.data) return json(edgeCommandFailure("epoch_allocation_cycle_invalid", "Cycle not found."))
+  const lockedResult = await auth.adminClient.from("epoch_allocation_manifests")
+    .select("id,manifest_hash,manifest").eq("monthly_cycle_id", cycle.data.id)
+    .eq("policy_key", "settled_cubid_redistribution_v2").order("version", { ascending: false }).limit(1).maybeSingle()
+  if (lockedResult.error || !lockedResult.data) {
+    return json(edgeCommandFailure("epoch_allocation_v2_manifest_not_locked", "Select and lock a cap preview before calculating."))
+  }
+  const locked = {
+    manifestId: lockedResult.data.id,
+    manifestHash: lockedResult.data.manifest_hash,
+    manifest: lockedResult.data.manifest as Omit<FundedRedistributionV2Input, "manifestHash">,
+  }
+  try {
+    const artifact = await calculateFundedRedistributionV2({ ...locked.manifest, manifestHash: locked.manifestHash })
+    const recorded = await auth.adminClient.rpc("record_funded_epoch_allocation_v2", {
+    p_command: {
+      contractVersion: "epoch_funded_allocation_result.v2",
+      deploymentEnvironment: environment,
+      actorUserId: auth.user.id,
+      manifestId: locked.manifestId,
+      resultHash: artifact.resultHash,
+      artifact,
+    },
+  })
     if (recorded.error) return json(edgeCommandFailure(errorCode(recorded.error.message), recorded.error.message))
     return json(edgeCommandSuccess({ action: "calculate", manifestId: locked.manifestId, runId: Number(recorded.data), artifact }))
   } catch (error) {

--- a/supabase/migrations/20260811120000_epoch_allocation_policy_v2.sql
+++ b/supabase/migrations/20260811120000_epoch_allocation_policy_v2.sql
@@ -35,6 +35,140 @@ FROM public.user_withdrawal_obligations obligation
 LEFT JOIN public.user_withdrawal_obligation_claims claim ON claim.obligation_id=obligation.id
 GROUP BY obligation.id;
 
+CREATE OR REPLACE FUNCTION public.refresh_withdrawal_obligation_state() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_total numeric(78,0); v_harvested numeric(78,0); v_claimed numeric(78,0); v_state text;
+BEGIN
+  SELECT total_minor,harvested_minor INTO v_total,v_harvested
+  FROM public.user_withdrawal_obligations WHERE id=NEW.obligation_id FOR UPDATE;
+  SELECT coalesce(sum(claimed_minor),0) INTO v_claimed FROM public.user_withdrawal_obligation_claims
+    WHERE obligation_id=NEW.obligation_id AND status<>'released';
+  IF v_claimed<v_total-v_harvested THEN v_state:='available';
+  ELSIF EXISTS(SELECT 1 FROM public.user_withdrawal_obligation_claims WHERE obligation_id=NEW.obligation_id AND status='held') THEN v_state:='held';
+  ELSIF EXISTS(SELECT 1 FROM public.user_withdrawal_obligation_claims WHERE obligation_id=NEW.obligation_id AND status='queued') THEN v_state:='queued';
+  ELSIF EXISTS(SELECT 1 FROM public.user_withdrawal_obligation_claims WHERE obligation_id=NEW.obligation_id AND status='reserved') THEN v_state:='reserved';
+  ELSIF EXISTS(SELECT 1 FROM public.user_withdrawal_obligation_claims WHERE obligation_id=NEW.obligation_id AND status='paid') THEN v_state:='paid';
+  ELSE v_state:='closed'; END IF;
+  UPDATE public.user_withdrawal_obligations SET state=v_state WHERE id=NEW.obligation_id;
+  RETURN NEW;
+END; $$;
+
+-- Keep harvested value out of both the aggregate availability check and the
+-- oldest-first obligation allocator. The claim guard remains the final
+-- concurrency boundary, but valid newer obligations are no longer shadowed by a
+-- harvested older obligation.
+CREATE OR REPLACE FUNCTION public.create_user_withdrawal_request_v3(p_actor_user_id uuid,p_command jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_environment text:=lower(p_command->>'deploymentEnvironment'); v_route public.user_payout_routes%ROWTYPE;
+  v_asset public.financial_assets%ROWTYPE; v_existing public.user_withdrawal_requests%ROWTYPE; v_request public.user_withdrawal_requests%ROWTYPE;
+  v_key text:=btrim(p_command->>'idempotencyKey'); v_hash text; v_amount numeric(78,0); v_fee_bps integer; v_fee numeric(78,0); v_net numeric(78,0);
+  v_project_id bigint; v_destination_hash text; v_rail text; v_currency text; v_available numeric(78,0); v_remaining numeric(78,0); v_obligation record; v_take numeric(78,0); v_seq integer:=0;
+  v_reserved boolean; v_cycle_id bigint; v_queue_origin_cycle_id bigint; v_queue_cycle_id bigint; v_queue_cycle_key text; v_intent_id bigint; v_native numeric(78,0); v_status text;
+BEGIN
+  IF NOT public.withdrawal_runtime_enabled(v_environment) THEN RAISE EXCEPTION 'withdrawal_runtime_disabled'; END IF;
+  IF p_command->>'contractVersion'<>'withdrawal_request.v3'
+    OR v_key IS NULL OR length(v_key)<8 OR length(v_key)>128 THEN RAISE EXCEPTION 'withdrawal_request_contract_invalid'; END IF;
+  v_amount:=(p_command->>'requestedMinor')::numeric; v_fee_bps:=(p_command->>'userFeeBps')::integer;
+  v_project_id:=(p_command->>'projectId')::bigint;
+  IF v_amount<=0 OR v_amount<>trunc(v_amount) OR v_fee_bps NOT BETWEEN 0 AND 10000 OR v_project_id<=0
+  THEN RAISE EXCEPTION 'withdrawal_request_amount_invalid'; END IF;
+  SELECT * INTO v_route FROM public.user_payout_routes WHERE id=(p_command->>'payoutRouteId')::bigint AND user_id=p_actor_user_id AND status='active' FOR UPDATE;
+  IF v_route.id IS NULL THEN RAISE EXCEPTION 'active_payout_route_required'; END IF;
+  v_rail:=CASE v_route.rail WHEN 'fiat_stub' THEN 'stripe_bank_transfer' WHEN 'evm' THEN 'base_stablecoin' ELSE NULL END;
+  IF v_rail IS NULL THEN RAISE EXCEPTION 'withdrawal_rail_not_supported'; END IF;
+  IF (v_rail='stripe_bank_transfer' AND v_amount<1000) OR (v_rail='base_stablecoin' AND v_amount<500) THEN RAISE EXCEPTION 'withdrawal_minimum_not_met'; END IF;
+  SELECT * INTO v_asset FROM public.financial_assets WHERE asset_key=p_command->>'assetKey' AND NOT production_enabled;
+  IF v_asset.id IS NULL OR NOT EXISTS(SELECT 1 FROM public.payout_inventory_lots lot
+    WHERE lot.user_id=p_actor_user_id AND lot.project_id=v_project_id AND lot.financial_asset_id=v_asset.id AND lot.rail_key=v_rail)
+  THEN RAISE EXCEPTION 'withdrawal_asset_not_eligible'; END IF;
+  v_currency:=CASE WHEN v_asset.symbol IN('USD','CAD') THEN v_asset.symbol ELSE 'USD' END;
+  v_destination_hash:=encode(extensions.digest(pg_catalog.convert_to(v_route.destination::text,'UTF8'),'sha256'),'hex');
+  v_hash:=encode(extensions.digest(pg_catalog.convert_to(jsonb_build_object('contractVersion','withdrawal_request.v3','payoutRouteId',v_route.id,
+    'requestedMinor',v_amount::text,'userFeeBps',v_fee_bps,'projectId',v_project_id,'assetKey',v_asset.asset_key,'destinationHash',v_destination_hash)::text,'UTF8'),'sha256'),'hex');
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('withdrawal:'||p_actor_user_id::text||':'||v_key,0));
+  SELECT * INTO v_existing FROM public.user_withdrawal_requests WHERE user_id=p_actor_user_id AND idempotency_key=v_key;
+  IF FOUND THEN
+    IF v_existing.request_hash IS DISTINCT FROM v_hash THEN RAISE EXCEPTION 'withdrawal_idempotency_conflict'; END IF;
+    RETURN jsonb_build_object('requestId',v_existing.id,'status',v_existing.status,'requestedMinor',v_existing.requested_minor::text,
+      'feeMinor',v_existing.fee_minor::text,'netMinor',v_existing.net_minor::text,'projectId',v_existing.project_id,'assetKey',v_asset.asset_key,'railKey',v_existing.rail_key,
+      'payoutIntentId',(SELECT id FROM public.payout_intents WHERE withdrawal_request_id=v_existing.id ORDER BY id DESC LIMIT 1),'noPayoutExecuted',true);
+  END IF;
+  SELECT coalesce(sum(obligation.total_minor-obligation.harvested_minor-coalesce((SELECT sum(claim.claimed_minor)
+    FROM public.user_withdrawal_obligation_claims claim WHERE claim.obligation_id=obligation.id
+      AND claim.status IN('reserved','queued','held','paid','closed')),0)),0)
+  INTO v_available FROM public.user_withdrawal_obligations obligation
+  WHERE obligation.user_id=p_actor_user_id AND obligation.state IN('available','reserved','queued','held')
+    AND EXISTS(SELECT 1 FROM public.payout_inventory_lots lot WHERE lot.obligation_id=obligation.id AND lot.user_id=p_actor_user_id
+      AND lot.project_id=v_project_id AND lot.financial_asset_id=v_asset.id AND lot.rail_key=v_rail AND lot.status IN('available','reserved'));
+  IF v_available<v_amount THEN RAISE EXCEPTION 'withdrawal_available_amount_insufficient'; END IF;
+  v_fee:=floor(v_amount*v_fee_bps/10000); v_net:=v_amount-v_fee;
+  INSERT INTO public.user_withdrawal_requests(user_id,payout_route_id,status,requested_usd_amount,currency_code,idempotency_key,
+    requested_minor,fee_minor,net_minor,user_fee_bps,rail_key,financial_asset_id,project_id,destination_hash,request_hash)
+  VALUES(p_actor_user_id,v_route.id,'requested',v_amount/100,v_currency,v_key,v_amount,v_fee,v_net,v_fee_bps,v_rail,v_asset.id,v_project_id,v_destination_hash,v_hash)
+  RETURNING * INTO v_request;
+  v_remaining:=v_amount;
+  FOR v_obligation IN
+    SELECT obligation.*,obligation.total_minor-obligation.harvested_minor-coalesce((SELECT sum(claim.claimed_minor)
+      FROM public.user_withdrawal_obligation_claims claim WHERE claim.obligation_id=obligation.id
+        AND claim.status IN('reserved','queued','held','paid','closed')),0) AS unclaimed_minor
+    FROM public.user_withdrawal_obligations obligation
+    WHERE obligation.user_id=p_actor_user_id AND obligation.state IN('available','reserved','queued','held')
+      AND obligation.total_minor-obligation.harvested_minor-coalesce((SELECT sum(claim.claimed_minor)
+        FROM public.user_withdrawal_obligation_claims claim WHERE claim.obligation_id=obligation.id
+          AND claim.status IN('reserved','queued','held','paid','closed')),0)>0
+      AND EXISTS(SELECT 1 FROM public.payout_inventory_lots lot WHERE lot.obligation_id=obligation.id AND lot.user_id=p_actor_user_id
+        AND lot.project_id=v_project_id AND lot.financial_asset_id=v_asset.id AND lot.rail_key=v_rail AND lot.status IN('available','reserved'))
+    ORDER BY obligation.available_at,obligation.id FOR UPDATE OF obligation
+  LOOP
+    EXIT WHEN v_remaining=0;
+    v_take:=least(v_remaining,v_obligation.unclaimed_minor); v_seq:=v_seq+1;
+    INSERT INTO public.user_withdrawal_obligation_claims(withdrawal_request_id,obligation_id,sequence_no,claimed_minor,status)
+    VALUES(v_request.id,v_obligation.id,v_seq,v_take,'queued');
+    v_remaining:=v_remaining-v_take;
+  END LOOP;
+  IF v_remaining<>0 THEN RAISE EXCEPTION 'withdrawal_concurrent_credit_reservation_failed'; END IF;
+  SELECT min(obligation.monthly_cycle_id) INTO v_cycle_id FROM public.user_withdrawal_obligation_claims claim
+    JOIN public.user_withdrawal_obligations obligation ON obligation.id=claim.obligation_id WHERE claim.withdrawal_request_id=v_request.id;
+  IF v_net=0 THEN
+    UPDATE public.user_withdrawal_obligation_claims SET status='closed',updated_at=clock_timestamp() WHERE withdrawal_request_id=v_request.id;
+    UPDATE public.user_withdrawal_requests SET status='closed',status_reason='fee_consumed_full_request',closed_at=clock_timestamp() WHERE id=v_request.id;
+    v_status:='closed'; v_intent_id:=NULL;
+  ELSE
+    v_reserved:=public.reserve_withdrawal_inventory(v_request.id);
+    IF v_reserved THEN
+      SELECT sum(native_atomic_amount) INTO v_native FROM public.payout_inventory_reservations WHERE withdrawal_request_id=v_request.id AND status='reserved';
+      UPDATE public.user_withdrawal_obligation_claims SET status='reserved',updated_at=clock_timestamp() WHERE withdrawal_request_id=v_request.id;
+      UPDATE public.user_withdrawal_requests SET status='reserved' WHERE id=v_request.id;
+      INSERT INTO public.payout_intents(monthly_cycle_id,source_result_id,user_id,payout_route_id,rail,currency_code,amount_usd,status,idempotency_key,
+        created_by_user_id,updated_by_user_id,withdrawal_request_id,financial_asset_id,native_atomic_amount,user_fee_bps,fee_amount_usd)
+      VALUES(v_cycle_id,NULL,p_actor_user_id,v_route.id,v_route.rail,v_currency,v_net/100,'draft','withdrawal:'||v_request.id::text,
+        p_actor_user_id,p_actor_user_id,v_request.id,v_asset.id,v_native,v_fee_bps,v_fee/100) RETURNING id INTO v_intent_id;
+      v_status:='reserved';
+    ELSE
+      SELECT cycle.id INTO v_queue_origin_cycle_id FROM public.epoch_shadow_states state
+        JOIN public.monthly_cycles cycle ON cycle.id=state.monthly_cycle_id
+        WHERE state.current_stage<>'closed' AND NOT state.production_enabled
+        ORDER BY cycle.period_start DESC,cycle.id DESC LIMIT 1;
+      IF v_queue_origin_cycle_id IS NULL THEN v_queue_origin_cycle_id:=v_cycle_id; END IF;
+      SELECT cycle.id,to_char(cycle.period_start,'YYYY-MM') INTO v_queue_cycle_id,v_queue_cycle_key
+        FROM public.monthly_cycles cycle
+        WHERE cycle.period_start>(SELECT period_start FROM public.monthly_cycles WHERE id=v_queue_origin_cycle_id)
+        ORDER BY cycle.period_start,cycle.id LIMIT 1;
+      IF v_queue_cycle_key IS NULL THEN
+        SELECT to_char(period_start+interval '1 month','YYYY-MM') INTO v_queue_cycle_key FROM public.monthly_cycles WHERE id=v_queue_origin_cycle_id;
+      END IF;
+      UPDATE public.user_withdrawal_requests SET status='queued',queue_for_cycle_id=v_queue_cycle_id,
+        queue_for_cycle_key=v_queue_cycle_key,status_reason='eligible_inventory_depleted' WHERE id=v_request.id;
+      v_status:='queued'; v_intent_id:=NULL;
+    END IF;
+  END IF;
+  INSERT INTO public.withdrawal_lifecycle_events(withdrawal_request_id,event_type,from_status,to_status,actor_user_id,evidence)
+  VALUES(v_request.id,CASE v_status WHEN 'reserved' THEN 'reserved' WHEN 'queued' THEN 'queued' ELSE 'closed' END,'requested',v_status,p_actor_user_id,
+    jsonb_build_object('requestHash',v_hash,'projectId',v_project_id,'feeBps',v_fee_bps,'noProviderCall',true));
+  RETURN jsonb_build_object('requestId',v_request.id,'status',v_status,'requestedMinor',v_amount::text,'feeMinor',v_fee::text,'netMinor',v_net::text,
+    'projectId',v_project_id,'assetKey',v_asset.asset_key,'railKey',v_rail,'payoutIntentId',v_intent_id,'noPayoutExecuted',true);
+END; $$;
+
 CREATE TABLE public.epoch_redistribution_pool_sources (
   id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
   source_lot_key text NOT NULL UNIQUE,

--- a/supabase/migrations/20260811120000_epoch_allocation_policy_v2.sql
+++ b/supabase/migrations/20260811120000_epoch_allocation_policy_v2.sql
@@ -1,0 +1,830 @@
+-- Corrected settled Cubid redistribution policy for Goal #134.
+-- This migration is additive, preserves v1 artifacts, and remains local/dev/test only.
+
+ALTER TABLE public.user_withdrawal_obligations
+  ADD COLUMN harvested_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN claim_window_closed_at timestamptz,
+  ADD CONSTRAINT withdrawal_obligation_harvest_amount CHECK(harvested_minor>=0 AND harvested_minor<=total_minor);
+
+CREATE FUNCTION public.prevent_harvested_obligation_claim() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_total numeric(78,0); v_harvested numeric(78,0); v_claimed numeric(78,0);
+BEGIN
+  SELECT total_minor,harvested_minor INTO v_total,v_harvested
+  FROM public.user_withdrawal_obligations WHERE id=NEW.obligation_id FOR UPDATE;
+  SELECT coalesce(sum(claimed_minor),0) INTO v_claimed
+  FROM public.user_withdrawal_obligation_claims
+  WHERE obligation_id=NEW.obligation_id AND status<>'released' AND id IS DISTINCT FROM NEW.id;
+  IF v_claimed+(CASE WHEN NEW.status='released' THEN 0 ELSE NEW.claimed_minor END)>v_total-v_harvested
+  THEN RAISE EXCEPTION 'withdrawal_obligation_claim_window_closed'; END IF;
+  RETURN NEW;
+END; $$;
+CREATE TRIGGER withdrawal_claim_harvest_guard BEFORE INSERT OR UPDATE OF claimed_minor,status
+ON public.user_withdrawal_obligation_claims FOR EACH ROW EXECUTE FUNCTION public.prevent_harvested_obligation_claim();
+
+CREATE OR REPLACE VIEW public.user_withdrawal_obligation_balances WITH (security_invoker=true) AS
+SELECT obligation.id,obligation.user_id,obligation.monthly_cycle_id,obligation.total_minor,obligation.state,
+  (obligation.total_minor-obligation.harvested_minor-coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status<>'released'),0))::numeric(78,0) AS available_minor,
+  coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status='reserved'),0)::numeric(78,0) AS reserved_minor,
+  coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status='queued'),0)::numeric(78,0) AS queued_minor,
+  coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status='held'),0)::numeric(78,0) AS held_minor,
+  coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status='paid'),0)::numeric(78,0) AS paid_minor,
+  coalesce(sum(claim.claimed_minor) FILTER(WHERE claim.status='closed'),0)::numeric(78,0) AS closed_minor,
+  obligation.harvested_minor,obligation.claim_window_closed_at
+FROM public.user_withdrawal_obligations obligation
+LEFT JOIN public.user_withdrawal_obligation_claims claim ON claim.obligation_id=obligation.id
+GROUP BY obligation.id;
+
+CREATE TABLE public.epoch_redistribution_pool_sources (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  source_lot_key text NOT NULL UNIQUE,
+  target_monthly_cycle_id bigint NOT NULL REFERENCES public.monthly_cycles(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_monthly_cycle_id bigint NOT NULL REFERENCES public.monthly_cycles(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_kind text NOT NULL,
+  predecessor_pool_source_id bigint UNIQUE REFERENCES public.epoch_redistribution_pool_sources(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_disposition_id bigint UNIQUE REFERENCES public.epoch_allocation_source_dispositions(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_obligation_id bigint REFERENCES public.user_withdrawal_obligations(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_inventory_lot_id bigint REFERENCES public.payout_inventory_lots(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_award_fill_id bigint REFERENCES public.epoch_provisional_award_source_fills(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  project_id bigint NOT NULL REFERENCES public.projects(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  rail_key text NOT NULL,
+  financial_asset_id bigint NOT NULL REFERENCES public.financial_assets(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  custody_account_id bigint NOT NULL REFERENCES public.financial_custody_accounts(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  fx_snapshot_id bigint NOT NULL REFERENCES public.epoch_fx_snapshots(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  native_atomic_amount numeric(78,0) NOT NULL,
+  exact_usd numeric(38,18) NOT NULL,
+  canonical_minor numeric(78,0) NOT NULL,
+  minor_unit_scale smallint NOT NULL DEFAULT 2,
+  source_order numeric(78,0) NOT NULL,
+  state text NOT NULL DEFAULT 'ready_for_lock',
+  evidence_hash text NOT NULL,
+  production_enabled boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT epoch_redistribution_source_kind CHECK(origin_kind IN('harvested_unclaimed','carryforward_residue')),
+  CONSTRAINT epoch_redistribution_source_origin CHECK(
+    (origin_kind='harvested_unclaimed' AND predecessor_pool_source_id IS NULL AND origin_obligation_id IS NOT NULL
+      AND origin_inventory_lot_id IS NOT NULL AND origin_award_fill_id IS NOT NULL)
+    OR (origin_kind='carryforward_residue' AND origin_disposition_id IS NOT NULL)
+  ),
+  CONSTRAINT epoch_redistribution_source_amount CHECK(native_atomic_amount>0 AND exact_usd>0 AND canonical_minor>=0),
+  CONSTRAINT epoch_redistribution_source_scale CHECK(minor_unit_scale BETWEEN 0 AND 18),
+  CONSTRAINT epoch_redistribution_source_state CHECK(state IN('ready_for_lock','reserved','carried_forward')),
+  CONSTRAINT epoch_redistribution_source_hash CHECK(evidence_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT epoch_redistribution_source_production_closed CHECK(production_enabled=false)
+);
+CREATE UNIQUE INDEX epoch_redistribution_harvest_once_idx
+ON public.epoch_redistribution_pool_sources(target_monthly_cycle_id,origin_inventory_lot_id)
+WHERE origin_kind='harvested_unclaimed';
+CREATE INDEX epoch_redistribution_source_target_idx
+ON public.epoch_redistribution_pool_sources(target_monthly_cycle_id,state,source_order,id);
+
+ALTER TABLE public.epoch_allocation_manifests
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN selected_preview_hash text,
+  ADD COLUMN current_funded_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN harvested_unclaimed_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN carry_in_minor numeric(78,0) NOT NULL DEFAULT 0;
+ALTER TABLE public.epoch_allocation_manifests DROP CONSTRAINT epoch_allocation_manifest_policy;
+ALTER TABLE public.epoch_allocation_manifests ADD CONSTRAINT epoch_allocation_manifest_policy
+  CHECK(policy_key IN('settled_cubid_redistribution_v1','settled_cubid_redistribution_v2'));
+ALTER TABLE public.epoch_allocation_manifests ADD CONSTRAINT epoch_allocation_manifest_v2_shape CHECK(
+  policy_key<>'settled_cubid_redistribution_v2' OR (
+    cap_multiple BETWEEN 1 AND 10 AND cap_multiple=round(cap_multiple,2)
+    AND selected_preview_hash ~ '^[0-9a-f]{64}$'
+    AND funded_minor=current_funded_minor+harvested_unclaimed_minor+carry_in_minor
+  )
+);
+
+CREATE TABLE public.epoch_allocation_manifest_pool_sources (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  manifest_id bigint NOT NULL REFERENCES public.epoch_allocation_manifests(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  pool_source_id bigint NOT NULL UNIQUE REFERENCES public.epoch_redistribution_pool_sources(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  source_lot_key text NOT NULL,
+  project_id bigint NOT NULL REFERENCES public.projects(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  origin_kind text NOT NULL,
+  origin_cycle_key text NOT NULL,
+  rail_key text NOT NULL,
+  financial_asset_id bigint NOT NULL REFERENCES public.financial_assets(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  custody_account_id bigint NOT NULL REFERENCES public.financial_custody_accounts(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  fx_snapshot_id bigint NOT NULL REFERENCES public.epoch_fx_snapshots(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  native_atomic_amount numeric(78,0) NOT NULL,
+  exact_usd numeric(38,18) NOT NULL,
+  canonical_minor_capacity numeric(78,0) NOT NULL,
+  source_order numeric(78,0) NOT NULL,
+  evidence_hash text NOT NULL,
+  UNIQUE(manifest_id,source_lot_key),
+  CONSTRAINT epoch_allocation_pool_source_amount CHECK(native_atomic_amount>0 AND exact_usd>0 AND canonical_minor_capacity>=0),
+  CONSTRAINT epoch_allocation_pool_source_kind CHECK(origin_kind IN('harvested_unclaimed','carryforward_residue')),
+  CONSTRAINT epoch_allocation_pool_source_cycle CHECK(origin_cycle_key ~ '^\d{4}-(0[1-9]|1[0-2])$'),
+  CONSTRAINT epoch_allocation_pool_source_hash CHECK(evidence_hash ~ '^[0-9a-f]{64}$')
+);
+CREATE INDEX epoch_allocation_manifest_pool_order_idx
+ON public.epoch_allocation_manifest_pool_sources(manifest_id,source_order,id);
+
+ALTER TABLE public.epoch_allocation_runs
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN current_funded_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN harvested_unclaimed_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN carry_in_minor numeric(78,0) NOT NULL DEFAULT 0;
+ALTER TABLE public.epoch_allocation_runs DROP CONSTRAINT epoch_allocation_run_policy;
+ALTER TABLE public.epoch_allocation_runs DROP CONSTRAINT epoch_allocation_run_amounts;
+ALTER TABLE public.epoch_allocation_runs ADD CONSTRAINT epoch_allocation_run_policy
+  CHECK(policy_key IN('settled_cubid_redistribution_v1','settled_cubid_redistribution_v2'));
+ALTER TABLE public.epoch_allocation_runs ADD CONSTRAINT epoch_allocation_run_amounts CHECK(
+  funded_minor>=0 AND retained_initial_minor>=0 AND score_pool_minor>=0 AND overlap_pool_minor>=0
+  AND top_up_minor>=0 AND returned_residue_minor>=0 AND final_allocation_minor>=0
+  AND final_allocation_minor+returned_residue_minor=funded_minor
+  AND (
+    (policy_key='settled_cubid_redistribution_v1' AND top_up_minor+returned_residue_minor=score_pool_minor+overlap_pool_minor)
+    OR (policy_key='settled_cubid_redistribution_v2' AND overlap_pool_minor=0 AND cap_multiple BETWEEN 1 AND 10
+      AND funded_minor=current_funded_minor+harvested_unclaimed_minor+carry_in_minor
+      AND top_up_minor+returned_residue_minor=score_pool_minor+harvested_unclaimed_minor+carry_in_minor)
+  )
+);
+
+ALTER TABLE public.epoch_allocation_user_awards
+  ADD COLUMN policy_key text NOT NULL DEFAULT 'settled_cubid_redistribution_v1',
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN initial_claim_minor numeric(78,0),
+  ADD COLUMN top_up_capacity_minor numeric(78,0);
+ALTER TABLE public.epoch_allocation_user_awards DROP CONSTRAINT epoch_allocation_award_amounts;
+ALTER TABLE public.epoch_allocation_user_awards ADD CONSTRAINT epoch_allocation_award_amounts CHECK(
+  aggregate_initial_exact_usd>=0 AND baseline_exact_usd>=0 AND minor_unit_cap>=0
+  AND retained_initial_minor>=0 AND top_up_minor>=0 AND final_minor=retained_initial_minor+top_up_minor
+  AND (
+    (policy_key='settled_cubid_redistribution_v1' AND exact_cap_usd=3*baseline_exact_usd AND final_minor<=minor_unit_cap)
+    OR (policy_key='settled_cubid_redistribution_v2' AND cap_multiple BETWEEN 1 AND 10
+      AND initial_claim_minor=retained_initial_minor AND initial_claim_minor>=0 AND top_up_capacity_minor>=0
+      AND top_up_capacity_minor=greatest(minor_unit_cap-initial_claim_minor,0) AND top_up_minor<=top_up_capacity_minor)
+  )
+);
+
+ALTER TABLE public.epoch_allocation_source_dispositions
+  ALTER COLUMN manifest_source_id DROP NOT NULL,
+  ADD COLUMN manifest_pool_source_id bigint REFERENCES public.epoch_allocation_manifest_pool_sources(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN policy_key text NOT NULL DEFAULT 'settled_cubid_redistribution_v1';
+ALTER TABLE public.epoch_allocation_source_dispositions DROP CONSTRAINT epoch_allocation_disposition_kind;
+ALTER TABLE public.epoch_allocation_source_dispositions DROP CONSTRAINT epoch_allocation_disposition_user_shape;
+ALTER TABLE public.epoch_allocation_source_dispositions ADD CONSTRAINT epoch_allocation_disposition_one_source
+  CHECK((manifest_source_id IS NOT NULL) <> (manifest_pool_source_id IS NOT NULL));
+ALTER TABLE public.epoch_allocation_source_dispositions ADD CONSTRAINT epoch_allocation_disposition_kind CHECK(
+  (policy_key='settled_cubid_redistribution_v1' AND disposition_kind IN('initial_retained','score_pool','overlap_pool','top_up','returned_residue'))
+  OR (policy_key='settled_cubid_redistribution_v2' AND disposition_kind IN('initial_claim','score_pool','harvested_pool','carryin_pool','top_up','carryout_residue'))
+);
+ALTER TABLE public.epoch_allocation_source_dispositions ADD CONSTRAINT epoch_allocation_disposition_user_shape CHECK(
+  (disposition_kind IN('initial_retained','initial_claim','top_up') AND user_id IS NOT NULL)
+  OR (disposition_kind IN('score_pool','overlap_pool','harvested_pool','carryin_pool','returned_residue','carryout_residue') AND user_id IS NULL)
+);
+
+CREATE FUNCTION public.epoch_allocation_v2_preview_input(p_cycle_key text,p_cap_multiple numeric,p_environment text)
+RETURNS jsonb LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_target public.monthly_cycles%ROWTYPE; v_origin public.monthly_cycles%ROWTYPE;
+  v_project_sources jsonb; v_cohort jsonb; v_pool_sources jsonb; v_input jsonb; v_hash text;
+BEGIN
+  IF NOT public.epoch_allocation_runtime_enabled(p_environment) THEN RAISE EXCEPTION 'epoch_allocation_runtime_disabled'; END IF;
+  IF p_cap_multiple<1 OR p_cap_multiple>10 OR p_cap_multiple<>round(p_cap_multiple,2) THEN
+    RAISE EXCEPTION 'epoch_allocation_v2_cap_multiple_invalid'; END IF;
+  SELECT * INTO v_target FROM public.monthly_cycles WHERE cycle_key=p_cycle_key;
+  SELECT * INTO v_origin FROM public.monthly_cycles WHERE period_start=(v_target.period_start-interval '3 months')::date;
+  IF v_target.id IS NULL OR v_origin.id IS NULL THEN RAISE EXCEPTION 'epoch_allocation_v2_harvest_epoch_missing'; END IF;
+  IF clock_timestamp()<((v_target.period_end+1)::timestamp AT TIME ZONE 'America/Los_Angeles') THEN
+    RAISE EXCEPTION 'epoch_allocation_v2_claim_window_open'; END IF;
+
+  SELECT coalesce(jsonb_agg(jsonb_build_object(
+    'sourceLotId',lot.id::text,'sourceLotKey',lot.source_lot_key,'projectId',lot.project_id,'projectKey',project.slug,
+    'exactUsd',lot.distributable_exact_usd::text,'minorUnitScale',lot.canonical_minor_unit_scale,
+    'sourceOrder',lot.deterministic_source_order::text,'railKey',lot.rail_key,'assetKey',asset.asset_key,
+    'custodyKey',custody.custody_key,'nativeAtomicAmount',lot.native_atomic_amount::text,
+    'fxSnapshotId',lot.fx_snapshot_id::text,'evidenceHash',lot.evidence_hash
+  ) ORDER BY lot.deterministic_source_order,lot.source_lot_key),'[]'::jsonb) INTO v_project_sources
+  FROM public.epoch_valuation_source_lots lot
+  JOIN public.epoch_project_packages package ON package.id=lot.package_id
+  JOIN public.projects project ON project.id=lot.project_id
+  JOIN public.financial_assets asset ON asset.id=lot.financial_asset_id
+  JOIN public.financial_custody_accounts custody ON custody.id=lot.custody_account_id
+  WHERE lot.monthly_cycle_id=v_target.id AND lot.state='ready_for_lock' AND lot.reserved_exact_usd=0 AND NOT lot.production_enabled
+    AND package.canonical_cycle_id=v_target.id AND package.status IN('approved','silent_approved')
+    AND package.funding_status='settled' AND package.compliance_status='passed' AND package.cubid_status='eligible';
+  IF jsonb_array_length(v_project_sources)=0 THEN RAISE EXCEPTION 'epoch_allocation_v2_project_sources_missing'; END IF;
+
+  SELECT coalesce(jsonb_agg(row_value ORDER BY (row_value->>'projectId')::bigint,row_value->>'userId'),'[]'::jsonb) INTO v_cohort
+  FROM (
+    SELECT DISTINCT jsonb_build_object('projectId',lot.project_id,'projectKey',project.slug,'userId',cohort.user_id::text,
+      'projectPseudonym',cohort.project_pseudonym,'lockedScore',cohort.locked_cubid_score::text,
+      'lockedMaximumScore',cohort.locked_max_cubid_score::text,'cubidEvidenceHash',cohort.evidence_hash) row_value
+    FROM public.epoch_valuation_source_lots lot
+    JOIN public.epoch_project_packages package ON package.id=lot.package_id
+    JOIN public.projects project ON project.id=lot.project_id
+    JOIN public.epoch_project_package_cohort cohort ON cohort.package_id=package.id AND cohort.eligibility_status='eligible'
+    WHERE lot.monthly_cycle_id=v_target.id AND lot.state='ready_for_lock' AND lot.reserved_exact_usd=0 AND NOT lot.production_enabled
+      AND package.canonical_cycle_id=v_target.id AND package.status IN('approved','silent_approved')
+  ) rows;
+
+  WITH inventory AS (
+    SELECT obligation.id obligation_id,balance.available_minor,lot.id inventory_lot_id,lot.source_fill_id,lot.project_id,lot.rail_key,
+      lot.financial_asset_id,lot.custody_account_id,lot.fx_snapshot_id,lot.native_atomic_total,lot.canonical_minor_total,
+      lot.deterministic_sequence,fill.exact_usd,
+      greatest(0,lot.canonical_minor_total-coalesce((SELECT sum(reserved_minor) FROM public.payout_inventory_reservations reservation
+        WHERE reservation.inventory_lot_id=lot.id AND reservation.status IN('reserved','held','consumed')),0)) available_inventory_minor
+    FROM public.user_withdrawal_obligations obligation
+    JOIN public.user_withdrawal_obligation_balances balance ON balance.id=obligation.id
+    JOIN public.payout_inventory_lots lot ON lot.obligation_id=obligation.id
+    JOIN public.epoch_provisional_award_source_fills fill ON fill.id=lot.source_fill_id
+    WHERE obligation.monthly_cycle_id=v_origin.id AND balance.available_minor>0 AND lot.status IN('available','reserved')
+  ), ordered AS (
+    SELECT inventory.*,coalesce(sum(available_inventory_minor) OVER(PARTITION BY obligation_id ORDER BY deterministic_sequence DESC,inventory_lot_id DESC
+      ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING),0) prior_newest_minor
+    FROM inventory WHERE available_inventory_minor>0
+  ), harvested AS (
+    SELECT ordered.*,least(available_inventory_minor,greatest(0,available_minor-prior_newest_minor)) harvest_minor
+    FROM ordered
+  ), candidates AS (
+    SELECT jsonb_build_object('sourceLotId','harvest:'||v_target.id::text||':'||harvested.inventory_lot_id::text,
+      'sourceLotKey','harvest:'||v_target.cycle_key||':'||harvested.inventory_lot_id::text,'projectId',harvested.project_id,
+      'exactUsd',(harvested.exact_usd*harvested.harvest_minor/harvested.canonical_minor_total)::text,'minorUnitScale',2,
+      'canonicalMinorCapacity',harvested.harvest_minor::text,
+      'sourceOrder',(900000000000000000::numeric+harvested.deterministic_sequence)::text,'railKey',harvested.rail_key,
+      'assetKey',asset.asset_key,'custodyKey',custody.custody_key,
+      'nativeAtomicAmount',greatest(1,floor(harvested.native_atomic_total*harvested.harvest_minor/harvested.canonical_minor_total))::text,
+      'fxSnapshotId',harvested.fx_snapshot_id::text,'evidenceHash',encode(extensions.digest(convert_to(
+        'harvest:'||v_target.cycle_key||':'||harvested.inventory_lot_id::text||':'||harvested.harvest_minor::text,'UTF8'),'sha256'),'hex'),
+      'originKind','harvested_unclaimed','originCycleKey',v_origin.cycle_key) row_value
+    FROM harvested JOIN public.financial_assets asset ON asset.id=harvested.financial_asset_id
+    JOIN public.financial_custody_accounts custody ON custody.id=harvested.custody_account_id
+    WHERE harvested.harvest_minor>0
+    UNION ALL
+    SELECT jsonb_build_object('sourceLotId',pool.id::text,'sourceLotKey',pool.source_lot_key,'projectId',pool.project_id,
+      'exactUsd',pool.exact_usd::text,'minorUnitScale',pool.minor_unit_scale,'sourceOrder',pool.source_order::text,
+      'canonicalMinorCapacity',pool.canonical_minor::text,
+      'railKey',pool.rail_key,'assetKey',asset.asset_key,'custodyKey',custody.custody_key,
+      'nativeAtomicAmount',pool.native_atomic_amount::text,'fxSnapshotId',pool.fx_snapshot_id::text,'evidenceHash',pool.evidence_hash,
+      'originKind','carryforward_residue','originCycleKey',origin.cycle_key) row_value
+    FROM public.epoch_redistribution_pool_sources pool
+    JOIN public.monthly_cycles origin ON origin.id=pool.origin_monthly_cycle_id
+    JOIN public.financial_assets asset ON asset.id=pool.financial_asset_id
+    JOIN public.financial_custody_accounts custody ON custody.id=pool.custody_account_id
+    WHERE pool.target_monthly_cycle_id=v_target.id AND pool.origin_kind='carryforward_residue' AND pool.state='ready_for_lock'
+  ) SELECT coalesce(jsonb_agg(row_value ORDER BY row_value->>'sourceOrder',row_value->>'sourceLotKey'),'[]'::jsonb) INTO v_pool_sources FROM candidates;
+
+  -- Bind deterministic canonical capacities into the preview itself. Current
+  -- project sources use largest remainder; harvested and carried sources retain
+  -- their already-authoritative canonical obligation/residue amount.
+  WITH source_rows AS (
+    SELECT item.value row_value,(item.value->>'exactUsd')::numeric*100 exact_minor
+    FROM jsonb_array_elements(v_project_sources) AS item(value)
+  ), ranked AS (
+    SELECT source_rows.*,floor(exact_minor) base_minor,
+      row_number() OVER(ORDER BY exact_minor-floor(exact_minor) DESC,row_value->>'sourceLotKey') remainder_rank,
+      floor(sum(exact_minor) OVER())-sum(floor(exact_minor)) OVER() residual_units
+    FROM source_rows
+  ), enriched AS (
+    SELECT row_value||jsonb_build_object('canonicalMinorCapacity',
+      (base_minor+CASE WHEN remainder_rank<=residual_units THEN 1 ELSE 0 END)::numeric(78,0)::text) row_value
+    FROM ranked
+  )
+  SELECT coalesce(jsonb_agg(row_value ORDER BY row_value->>'sourceOrder',row_value->>'sourceLotKey'),'[]'::jsonb)
+  INTO v_project_sources FROM enriched;
+
+  v_input:=jsonb_build_object('policy','settled_cubid_redistribution_v2','cycleKey',v_target.cycle_key,'minorUnitScale',2,
+    'capMultiple',to_char(p_cap_multiple,'FM90.00'),'projectSources',v_project_sources,'redistributionSources',v_pool_sources,'cohort',v_cohort);
+  v_hash:=encode(extensions.digest(convert_to(v_input::text,'UTF8'),'sha256'),'hex');
+  RETURN v_input||jsonb_build_object('inputHash',v_hash,'originCycleKey',v_origin.cycle_key);
+END; $$;
+
+CREATE FUNCTION public.lock_funded_epoch_allocation_v2(p_command jsonb) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_cycle public.monthly_cycles%ROWTYPE; v_preview jsonb; v_manifest jsonb; v_manifest_id bigint; v_hash text;
+  v_version integer; v_funded_exact numeric(38,18); v_funded_minor numeric(78,0); v_current_minor numeric(78,0);
+  v_harvest_minor numeric(78,0); v_carry_minor numeric(78,0); v_pool jsonb; v_existing public.epoch_allocation_manifests%ROWTYPE;
+BEGIN
+  IF p_command->>'contractVersion'<>'epoch_funded_allocation_lock.v2'
+    OR NOT public.epoch_allocation_runtime_enabled(p_command->>'deploymentEnvironment') THEN RAISE EXCEPTION 'epoch_allocation_runtime_disabled'; END IF;
+  IF nullif(p_command->>'actorUserId','') IS NULL OR (p_command->>'selectedPreviewHash') !~ '^[0-9a-f]{64}$' THEN
+    RAISE EXCEPTION 'epoch_allocation_v2_selection_invalid'; END IF;
+  SELECT * INTO v_cycle FROM public.monthly_cycles WHERE cycle_key=p_command->>'cycleKey' FOR UPDATE;
+  IF v_cycle.id IS NULL THEN RAISE EXCEPTION 'epoch_allocation_cycle_invalid'; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('epoch-allocation-v2:'||v_cycle.id::text,0));
+  SELECT * INTO v_existing FROM public.epoch_allocation_manifests
+  WHERE monthly_cycle_id=v_cycle.id AND policy_key='settled_cubid_redistribution_v2' ORDER BY version DESC LIMIT 1;
+  IF v_existing.id IS NOT NULL THEN
+    IF v_existing.cap_multiple<>(p_command->>'capMultiple')::numeric
+      OR v_existing.selected_preview_hash<>p_command->>'selectedPreviewHash'
+    THEN RAISE EXCEPTION 'epoch_allocation_v2_selection_conflict'; END IF;
+    RETURN jsonb_build_object('manifestId',v_existing.id,'manifestHash',v_existing.manifest_hash,'manifest',v_existing.manifest);
+  END IF;
+  v_preview:=public.epoch_allocation_v2_preview_input(v_cycle.cycle_key,(p_command->>'capMultiple')::numeric,p_command->>'deploymentEnvironment');
+  IF v_preview->>'inputHash'<>p_command->>'selectedPreviewHash' THEN RAISE EXCEPTION 'epoch_allocation_v2_preview_stale'; END IF;
+
+  -- Serialize claim creation against harvest and recheck the locked obligation
+  -- balances before reserving any harvested source.
+  PERFORM 1 FROM public.user_withdrawal_obligations obligation
+  JOIN public.payout_inventory_lots inventory ON inventory.obligation_id=obligation.id
+  WHERE inventory.id IN(
+    SELECT split_part(item.value->>'sourceLotId',':',3)::bigint
+    FROM jsonb_array_elements(v_preview->'redistributionSources') AS item(value)
+    WHERE item.value->>'originKind'='harvested_unclaimed'
+  ) ORDER BY obligation.id FOR UPDATE OF obligation;
+  IF EXISTS(
+    SELECT 1 FROM (
+      SELECT obligation.id,sum((item.value->>'canonicalMinorCapacity')::numeric) harvest_minor
+      FROM jsonb_array_elements(v_preview->'redistributionSources') AS item(value)
+      JOIN public.payout_inventory_lots inventory ON inventory.id=split_part(item.value->>'sourceLotId',':',3)::bigint
+      JOIN public.user_withdrawal_obligations obligation ON obligation.id=inventory.obligation_id
+      WHERE item.value->>'originKind'='harvested_unclaimed' GROUP BY obligation.id
+    ) expected JOIN public.user_withdrawal_obligation_balances balance ON balance.id=expected.id
+    WHERE expected.harvest_minor>balance.available_minor
+  ) THEN RAISE EXCEPTION 'epoch_allocation_v2_harvest_balance_changed'; END IF;
+
+  FOR v_pool IN SELECT value FROM jsonb_array_elements(v_preview->'redistributionSources')
+  LOOP
+    IF v_pool->>'originKind'='harvested_unclaimed' THEN
+      INSERT INTO public.epoch_redistribution_pool_sources(source_lot_key,target_monthly_cycle_id,origin_monthly_cycle_id,origin_kind,
+        origin_obligation_id,origin_inventory_lot_id,origin_award_fill_id,project_id,rail_key,financial_asset_id,custody_account_id,
+        fx_snapshot_id,native_atomic_amount,exact_usd,canonical_minor,minor_unit_scale,source_order,evidence_hash)
+      SELECT v_pool->>'sourceLotKey',v_cycle.id,obligation.monthly_cycle_id,'harvested_unclaimed',obligation.id,inventory.id,inventory.source_fill_id,
+        inventory.project_id,inventory.rail_key,inventory.financial_asset_id,inventory.custody_account_id,inventory.fx_snapshot_id,
+        (v_pool->>'nativeAtomicAmount')::numeric,(v_pool->>'exactUsd')::numeric,
+        (v_pool->>'canonicalMinorCapacity')::numeric,2,(v_pool->>'sourceOrder')::numeric,v_pool->>'evidenceHash'
+      FROM public.payout_inventory_lots inventory JOIN public.user_withdrawal_obligations obligation ON obligation.id=inventory.obligation_id
+      WHERE inventory.id=split_part(v_pool->>'sourceLotId',':',3)::bigint
+      ON CONFLICT(target_monthly_cycle_id,origin_inventory_lot_id) WHERE origin_kind='harvested_unclaimed' DO NOTHING;
+    END IF;
+  END LOOP;
+
+  SELECT coalesce(sum((item.value->>'exactUsd')::numeric),0),coalesce(sum((item.value->>'canonicalMinorCapacity')::numeric),0)
+  INTO v_funded_exact,v_current_minor FROM jsonb_array_elements(v_preview->'projectSources') AS item(value);
+  SELECT coalesce(sum((item.value->>'canonicalMinorCapacity')::numeric) FILTER(WHERE item.value->>'originKind'='harvested_unclaimed'),0),
+    coalesce(sum((item.value->>'canonicalMinorCapacity')::numeric) FILTER(WHERE item.value->>'originKind'='carryforward_residue'),0)
+  INTO v_harvest_minor,v_carry_minor FROM jsonb_array_elements(v_preview->'redistributionSources') AS item(value);
+  v_funded_exact:=v_funded_exact+coalesce((SELECT sum((item.value->>'exactUsd')::numeric)
+    FROM jsonb_array_elements(v_preview->'redistributionSources') AS item(value)),0);
+  v_funded_minor:=v_current_minor+v_harvest_minor+v_carry_minor;
+  v_manifest:=(v_preview-'inputHash'-'originCycleKey')||jsonb_build_object('selectedPreviewHash',v_preview->>'inputHash');
+  v_hash:=encode(extensions.digest(convert_to(v_manifest::text,'UTF8'),'sha256'),'hex');
+  SELECT coalesce(max(version),0)+1 INTO v_version FROM public.epoch_allocation_manifests WHERE monthly_cycle_id=v_cycle.id;
+  INSERT INTO public.epoch_allocation_manifests(monthly_cycle_id,version,policy_key,minor_unit_scale,funded_exact_usd,funded_minor,
+    manifest,manifest_hash,actor_user_id,deployment_environment,cap_multiple,selected_preview_hash,current_funded_minor,
+    harvested_unclaimed_minor,carry_in_minor)
+  VALUES(v_cycle.id,v_version,'settled_cubid_redistribution_v2',2,v_funded_exact,v_funded_minor,v_manifest,v_hash,
+    (p_command->>'actorUserId')::uuid,lower(p_command->>'deploymentEnvironment'),(p_command->>'capMultiple')::numeric,
+    v_preview->>'inputHash',v_current_minor,v_harvest_minor,v_carry_minor) RETURNING id INTO v_manifest_id;
+
+  INSERT INTO public.epoch_allocation_manifest_sources(manifest_id,source_lot_id,source_lot_key,project_id,source_position,rail_key,
+    financial_asset_id,custody_account_id,native_atomic_amount,fx_snapshot_id,exact_usd,canonical_minor_capacity,source_order,evidence_hash)
+  SELECT v_manifest_id,lot.id,lot.source_lot_key,lot.project_id,lot.source_position,lot.rail_key,lot.financial_asset_id,lot.custody_account_id,
+    lot.native_atomic_amount,lot.fx_snapshot_id,lot.distributable_exact_usd,(item.value->>'canonicalMinorCapacity')::numeric,
+    lot.deterministic_source_order,lot.evidence_hash
+  FROM jsonb_array_elements(v_preview->'projectSources') AS item(value)
+  JOIN public.epoch_valuation_source_lots lot ON lot.source_lot_key=item.value->>'sourceLotKey';
+  INSERT INTO public.epoch_allocation_manifest_cohort(manifest_id,project_id,user_id,project_pseudonym,locked_cubid_score,locked_max_cubid_score,cubid_evidence_hash)
+  SELECT v_manifest_id,(item.value->>'projectId')::bigint,(item.value->>'userId')::uuid,item.value->>'projectPseudonym',
+    (item.value->>'lockedScore')::numeric,(item.value->>'lockedMaximumScore')::numeric,item.value->>'cubidEvidenceHash'
+  FROM jsonb_array_elements(v_preview->'cohort') AS item(value);
+  INSERT INTO public.epoch_allocation_manifest_pool_sources(manifest_id,pool_source_id,source_lot_key,project_id,origin_kind,origin_cycle_key,
+    rail_key,financial_asset_id,custody_account_id,fx_snapshot_id,native_atomic_amount,exact_usd,canonical_minor_capacity,source_order,evidence_hash)
+  SELECT v_manifest_id,pool.id,pool.source_lot_key,pool.project_id,pool.origin_kind,origin.cycle_key,pool.rail_key,pool.financial_asset_id,
+    pool.custody_account_id,pool.fx_snapshot_id,pool.native_atomic_amount,pool.exact_usd,pool.canonical_minor,pool.source_order,pool.evidence_hash
+  FROM public.epoch_redistribution_pool_sources pool JOIN public.monthly_cycles origin ON origin.id=pool.origin_monthly_cycle_id
+  WHERE pool.source_lot_key IN(SELECT item.value->>'sourceLotKey'
+    FROM jsonb_array_elements(v_preview->'redistributionSources') AS item(value));
+
+  UPDATE public.epoch_valuation_source_lots SET state='reserved',reserved_exact_usd=distributable_exact_usd
+  WHERE id IN(SELECT source_lot_id FROM public.epoch_allocation_manifest_sources WHERE manifest_id=v_manifest_id);
+  UPDATE public.epoch_redistribution_pool_sources SET state='reserved'
+  WHERE id IN(SELECT pool_source_id FROM public.epoch_allocation_manifest_pool_sources WHERE manifest_id=v_manifest_id);
+  WITH harvested AS (
+    SELECT source.origin_obligation_id,sum(source.canonical_minor) amount
+    FROM public.epoch_redistribution_pool_sources source
+    JOIN public.epoch_allocation_manifest_pool_sources manifest_source ON manifest_source.pool_source_id=source.id
+    WHERE manifest_source.manifest_id=v_manifest_id AND source.origin_kind='harvested_unclaimed'
+    GROUP BY source.origin_obligation_id
+  ) UPDATE public.user_withdrawal_obligations obligation
+    SET harvested_minor=obligation.harvested_minor+harvested.amount,claim_window_closed_at=clock_timestamp()
+  FROM harvested WHERE obligation.id=harvested.origin_obligation_id;
+  RETURN jsonb_build_object('manifestId',v_manifest_id,'manifestHash',v_hash,'manifest',v_manifest);
+END; $$;
+
+CREATE FUNCTION public.record_funded_epoch_allocation_v2(p_command jsonb) RETURNS bigint
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_manifest public.epoch_allocation_manifests%ROWTYPE; v_artifact jsonb:=p_command->'artifact'; v_run_id bigint;
+  v_existing public.epoch_allocation_runs%ROWTYPE; v_user jsonb; v_row jsonb; v_position integer:=0; v_next_cycle bigint;
+BEGIN
+  IF p_command->>'contractVersion'<>'epoch_funded_allocation_result.v2'
+    OR NOT public.epoch_allocation_runtime_enabled(p_command->>'deploymentEnvironment') THEN RAISE EXCEPTION 'epoch_allocation_runtime_disabled'; END IF;
+  SELECT * INTO v_manifest FROM public.epoch_allocation_manifests WHERE id=(p_command->>'manifestId')::bigint FOR UPDATE;
+  IF v_manifest.policy_key<>'settled_cubid_redistribution_v2' OR v_manifest.status<>'locked' THEN RAISE EXCEPTION 'epoch_allocation_v2_manifest_not_locked'; END IF;
+  SELECT * INTO v_existing FROM public.epoch_allocation_runs WHERE manifest_id=v_manifest.id;
+  IF FOUND THEN
+    IF v_existing.result_hash<>p_command->>'resultHash' THEN RAISE EXCEPTION 'epoch_allocation_result_conflict'; END IF;
+    RETURN v_existing.id;
+  END IF;
+  IF v_artifact->>'policy'<>'settled_cubid_redistribution_v2' OR v_artifact->>'manifestHash'<>v_manifest.manifest_hash
+    OR v_artifact->>'selectedPreviewHash'<>v_manifest.selected_preview_hash OR (v_artifact->>'capMultiple')::numeric<>v_manifest.cap_multiple
+    OR v_artifact->>'resultHash'<>p_command->>'resultHash'
+    OR EXISTS(SELECT 1 FROM jsonb_array_elements(v_artifact->'invariantChecks') check_row WHERE NOT (check_row->>'ok')::boolean)
+  THEN RAISE EXCEPTION 'epoch_allocation_v2_artifact_invalid'; END IF;
+  INSERT INTO public.epoch_allocation_runs(manifest_id,policy_key,result_hash,artifact,funded_minor,retained_initial_minor,score_pool_minor,
+    overlap_pool_minor,top_up_minor,returned_residue_minor,final_allocation_minor,actor_user_id,deployment_environment,cap_multiple,
+    current_funded_minor,harvested_unclaimed_minor,carry_in_minor)
+  VALUES(v_manifest.id,'settled_cubid_redistribution_v2',p_command->>'resultHash',v_artifact,
+    (v_artifact->'totals'->>'totalInputMinor')::numeric,(v_artifact->'totals'->>'initialClaimMinor')::numeric,
+    (v_artifact->'totals'->>'scorePoolMinor')::numeric,0,(v_artifact->'totals'->>'topUpMinor')::numeric,
+    (v_artifact->'totals'->>'carryOutResidueMinor')::numeric,(v_artifact->'totals'->>'finalAllocationMinor')::numeric,
+    (p_command->>'actorUserId')::uuid,lower(p_command->>'deploymentEnvironment'),v_manifest.cap_multiple,
+    (v_artifact->'totals'->>'currentFundedMinor')::numeric,(v_artifact->'totals'->>'harvestedUnclaimedMinor')::numeric,
+    (v_artifact->'totals'->>'carryInMinor')::numeric) RETURNING id INTO v_run_id;
+  FOR v_user IN SELECT value FROM jsonb_array_elements(v_artifact->'users') LOOP
+    INSERT INTO public.epoch_allocation_user_awards(run_id,user_id,aggregate_initial_exact_usd,baseline_exact_usd,exact_cap_usd,
+      minor_unit_cap,retained_initial_minor,top_up_minor,final_minor,project_claims,policy_key,cap_multiple,initial_claim_minor,top_up_capacity_minor)
+    VALUES(v_run_id,(v_user->>'userId')::uuid,(v_user->>'aggregateInitialExactUsd')::numeric,(v_user->>'baselineExactUsd')::numeric,
+      (v_user->>'redistributionCeilingExactUsd')::numeric,(v_user->>'redistributionCeilingMinor')::numeric,
+      (v_user->>'initialClaimMinor')::numeric,(v_user->>'topUpMinor')::numeric,(v_user->>'finalMinor')::numeric,v_user->'projectClaims',
+      'settled_cubid_redistribution_v2',v_manifest.cap_multiple,(v_user->>'initialClaimMinor')::numeric,(v_user->>'topUpCapacityMinor')::numeric);
+  END LOOP;
+  FOR v_row IN SELECT value FROM jsonb_array_elements(v_artifact->'sourceDispositions') LOOP
+    v_position:=v_position+1;
+    INSERT INTO public.epoch_allocation_source_dispositions(run_id,manifest_source_id,manifest_pool_source_id,user_id,disposition_kind,
+      canonical_minor,exact_usd,stable_position,policy_key)
+    SELECT v_run_id,project_source.id,NULL,nullif(v_row->>'userId','')::uuid,v_row->>'kind',(v_row->>'canonicalMinor')::numeric,
+      (v_row->>'exactUsd')::numeric,v_position,'settled_cubid_redistribution_v2'
+    FROM public.epoch_allocation_manifest_sources project_source
+    WHERE project_source.manifest_id=v_manifest.id AND project_source.source_lot_key=v_row->>'sourceLotKey'
+    UNION ALL
+    SELECT v_run_id,NULL,pool_source.id,nullif(v_row->>'userId','')::uuid,v_row->>'kind',(v_row->>'canonicalMinor')::numeric,
+      (v_row->>'exactUsd')::numeric,v_position,'settled_cubid_redistribution_v2'
+    FROM public.epoch_allocation_manifest_pool_sources pool_source
+    WHERE pool_source.manifest_id=v_manifest.id AND pool_source.source_lot_key=v_row->>'sourceLotKey';
+    IF NOT FOUND THEN RAISE EXCEPTION 'epoch_allocation_v2_source_unknown'; END IF;
+  END LOOP;
+  SELECT id INTO v_next_cycle FROM public.monthly_cycles WHERE period_start>(SELECT period_start FROM public.monthly_cycles WHERE id=v_manifest.monthly_cycle_id)
+  ORDER BY period_start LIMIT 1;
+  IF EXISTS(SELECT 1 FROM public.epoch_allocation_source_dispositions WHERE run_id=v_run_id AND disposition_kind='carryout_residue') AND v_next_cycle IS NULL
+  THEN RAISE EXCEPTION 'epoch_allocation_v2_carry_target_missing'; END IF;
+  INSERT INTO public.epoch_redistribution_pool_sources(source_lot_key,target_monthly_cycle_id,origin_monthly_cycle_id,origin_kind,
+    predecessor_pool_source_id,origin_disposition_id,project_id,rail_key,financial_asset_id,custody_account_id,fx_snapshot_id,native_atomic_amount,
+    exact_usd,canonical_minor,minor_unit_scale,source_order,evidence_hash)
+  SELECT 'carry:'||v_next_cycle::text||':'||disposition.id::text,v_next_cycle,v_manifest.monthly_cycle_id,'carryforward_residue',
+    manifest_pool.pool_source_id,disposition.id,coalesce(project_source.project_id,manifest_pool.project_id),coalesce(project_source.rail_key,manifest_pool.rail_key),
+    coalesce(project_source.financial_asset_id,manifest_pool.financial_asset_id),coalesce(project_source.custody_account_id,manifest_pool.custody_account_id),
+    coalesce(project_source.fx_snapshot_id,manifest_pool.fx_snapshot_id),greatest(1,floor(coalesce(project_source.native_atomic_amount,manifest_pool.native_atomic_amount)
+      *disposition.canonical_minor/greatest(1,coalesce(project_source.canonical_minor_capacity,manifest_pool.canonical_minor_capacity)))),
+    disposition.exact_usd,disposition.canonical_minor,2,900000000000000000::numeric+disposition.stable_position,
+    encode(extensions.digest(convert_to('carry:'||v_run_id::text||':'||disposition.id::text,'UTF8'),'sha256'),'hex')
+  FROM public.epoch_allocation_source_dispositions disposition
+  LEFT JOIN public.epoch_allocation_manifest_sources project_source ON project_source.id=disposition.manifest_source_id
+  LEFT JOIN public.epoch_allocation_manifest_pool_sources manifest_pool ON manifest_pool.id=disposition.manifest_pool_source_id
+  WHERE disposition.run_id=v_run_id AND disposition.disposition_kind='carryout_residue' AND disposition.exact_usd>0;
+  UPDATE public.epoch_allocation_manifests SET status='calculated',calculated_at=clock_timestamp() WHERE id=v_manifest.id;
+  RETURN v_run_id;
+END; $$;
+
+CREATE VIEW public.epoch_allocation_operator_view_v2 WITH(security_invoker=true) AS
+SELECT cycle.cycle_key,manifest.id manifest_id,manifest.status,manifest.manifest_hash,manifest.selected_preview_hash,manifest.cap_multiple,
+  manifest.current_funded_minor,manifest.harvested_unclaimed_minor,manifest.carry_in_minor,manifest.funded_minor,
+  run.id run_id,run.result_hash,run.retained_initial_minor initial_claim_minor,run.score_pool_minor,run.top_up_minor,
+  run.returned_residue_minor carry_out_residue_minor,run.final_allocation_minor,count(award.id) user_count,
+  bool_and(NOT manifest.production_enabled AND (run.id IS NULL OR NOT run.production_enabled)) provisional_only,
+  manifest.locked_at,manifest.calculated_at
+FROM public.epoch_allocation_manifests manifest JOIN public.monthly_cycles cycle ON cycle.id=manifest.monthly_cycle_id
+LEFT JOIN public.epoch_allocation_runs run ON run.manifest_id=manifest.id
+LEFT JOIN public.epoch_allocation_user_awards award ON award.run_id=run.id
+WHERE manifest.policy_key='settled_cubid_redistribution_v2'
+GROUP BY cycle.cycle_key,manifest.id,run.id;
+
+ALTER TABLE public.epoch_redistribution_pool_sources ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.epoch_allocation_manifest_pool_sources ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.epoch_redistribution_pool_sources,public.epoch_allocation_manifest_pool_sources,
+  public.epoch_allocation_operator_view_v2 FROM PUBLIC,anon,authenticated,service_role;
+GRANT SELECT ON TABLE public.epoch_redistribution_pool_sources,public.epoch_allocation_manifest_pool_sources,
+  public.epoch_allocation_operator_view_v2 TO service_role;
+REVOKE ALL ON FUNCTION public.epoch_allocation_v2_preview_input(text,numeric,text),public.lock_funded_epoch_allocation_v2(jsonb),
+  public.record_funded_epoch_allocation_v2(jsonb),public.prevent_harvested_obligation_claim() FROM PUBLIC,anon,authenticated,service_role;
+GRANT EXECUTE ON FUNCTION public.epoch_allocation_v2_preview_input(text,numeric,text),public.lock_funded_epoch_allocation_v2(jsonb),
+  public.record_funded_epoch_allocation_v2(jsonb) TO service_role;
+
+ALTER TABLE public.epoch_provisional_award_controls
+  ADD COLUMN policy_key text NOT NULL DEFAULT 'settled_cubid_redistribution_v1',
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN initial_claim_minor numeric(78,0),
+  ADD COLUMN redistribution_ceiling_minor numeric(78,0);
+ALTER TABLE public.epoch_provisional_award_controls DROP CONSTRAINT epoch_provisional_award_amounts;
+ALTER TABLE public.epoch_provisional_award_controls ADD CONSTRAINT epoch_provisional_award_amounts CHECK(
+  retained_initial_minor>=0 AND redistribution_top_up_minor>=0
+  AND final_award_minor=retained_initial_minor+redistribution_top_up_minor
+  AND (
+    (policy_key='settled_cubid_redistribution_v1' AND final_award_minor<=minor_unit_cap)
+    OR (policy_key='settled_cubid_redistribution_v2' AND cap_multiple BETWEEN 1 AND 10
+      AND initial_claim_minor=retained_initial_minor AND redistribution_ceiling_minor=minor_unit_cap
+      AND redistribution_top_up_minor<=greatest(redistribution_ceiling_minor-initial_claim_minor,0))
+  )
+);
+
+ALTER TABLE public.epoch_provisional_award_source_fills
+  ALTER COLUMN manifest_source_id DROP NOT NULL,
+  ADD COLUMN manifest_pool_source_id bigint REFERENCES public.epoch_allocation_manifest_pool_sources(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN policy_key text NOT NULL DEFAULT 'settled_cubid_redistribution_v1';
+ALTER TABLE public.epoch_provisional_award_source_fills DROP CONSTRAINT epoch_award_source_fill_kind;
+ALTER TABLE public.epoch_provisional_award_source_fills DROP CONSTRAINT epoch_award_source_fill_shape;
+ALTER TABLE public.epoch_provisional_award_source_fills ADD CONSTRAINT epoch_award_source_fill_one_source
+  CHECK((manifest_source_id IS NOT NULL) <> (manifest_pool_source_id IS NOT NULL));
+ALTER TABLE public.epoch_provisional_award_source_fills ADD CONSTRAINT epoch_award_source_fill_kind CHECK(
+  (policy_key='settled_cubid_redistribution_v1' AND fill_kind IN('initial_retained','top_up','returned_residue'))
+  OR (policy_key='settled_cubid_redistribution_v2' AND fill_kind IN('initial_claim','top_up','carryout_residue'))
+);
+ALTER TABLE public.epoch_provisional_award_source_fills ADD CONSTRAINT epoch_award_source_fill_shape CHECK(
+  (fill_kind IN('initial_retained','initial_claim','top_up') AND award_control_id IS NOT NULL AND user_id IS NOT NULL)
+  OR (fill_kind IN('returned_residue','carryout_residue') AND award_control_id IS NULL AND user_id IS NULL)
+);
+
+ALTER TABLE public.epoch_close_project_summaries
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN harvested_unclaimed_minor numeric(78,0) NOT NULL DEFAULT 0;
+ALTER TABLE public.epoch_close_packages
+  ADD COLUMN policy_key text NOT NULL DEFAULT 'settled_cubid_redistribution_v1',
+  ADD COLUMN cap_multiple numeric(4,2),
+  ADD COLUMN current_funded_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN harvested_unclaimed_minor numeric(78,0) NOT NULL DEFAULT 0,
+  ADD COLUMN carry_in_minor numeric(78,0) NOT NULL DEFAULT 0;
+ALTER TABLE public.epoch_close_packages DROP CONSTRAINT epoch_close_package_amounts;
+ALTER TABLE public.epoch_close_packages ADD CONSTRAINT epoch_close_package_amounts CHECK(
+  user_count>=0 AND funded_minor>=0 AND final_allocation_minor>=0 AND redistribution_pool_minor>=0
+  AND top_up_minor>=0 AND returned_residue_minor>=0 AND final_allocation_minor+returned_residue_minor=funded_minor
+  AND top_up_minor+returned_residue_minor=redistribution_pool_minor
+  AND (policy_key='settled_cubid_redistribution_v1' OR (policy_key='settled_cubid_redistribution_v2'
+    AND cap_multiple BETWEEN 1 AND 10 AND funded_minor=current_funded_minor+harvested_unclaimed_minor+carry_in_minor))
+);
+
+CREATE FUNCTION public.approve_epoch_allocation_close_v2(p_command jsonb) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_run public.epoch_allocation_runs%ROWTYPE; v_manifest public.epoch_allocation_manifests%ROWTYPE;
+  v_cycle public.monthly_cycles%ROWTYPE; v_state public.epoch_shadow_states%ROWTYPE; v_period public.accounting_periods%ROWTYPE;
+  v_approval public.epoch_allocation_approvals%ROWTYPE; v_existing public.epoch_close_packages%ROWTYPE; v_disposition record;
+  v_award_control_id bigint; v_ledger_id bigint; v_close_id bigint; v_artifact record; v_hash text; v_root_hash text;
+  v_environment text:=lower(p_command->>'deploymentEnvironment');
+BEGIN
+  IF p_command->>'contractVersion'<>'epoch_allocation_close.v2' OR NOT public.epoch_close_runtime_enabled(v_environment)
+    OR nullif(p_command->>'actorUserId','') IS NULL THEN RAISE EXCEPTION 'epoch_close_runtime_disabled'; END IF;
+  SELECT * INTO v_run FROM public.epoch_allocation_runs WHERE id=(p_command->>'runId')::bigint FOR UPDATE;
+  SELECT * INTO v_manifest FROM public.epoch_allocation_manifests WHERE id=v_run.manifest_id FOR UPDATE;
+  SELECT * INTO v_cycle FROM public.monthly_cycles WHERE id=v_manifest.monthly_cycle_id;
+  IF v_run.policy_key<>'settled_cubid_redistribution_v2' OR v_manifest.policy_key<>v_run.policy_key OR v_manifest.status<>'calculated'
+    OR v_manifest.manifest_hash<>p_command->>'manifestHash' OR v_run.result_hash<>p_command->>'resultHash'
+    OR v_run.result_hash<>p_command->>'rerunResultHash' OR v_run.production_enabled THEN RAISE EXCEPTION 'epoch_close_approved_result_mismatch'; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('epoch-close-v2:'||v_run.id::text,0));
+  SELECT package.* INTO v_existing FROM public.epoch_close_packages package
+  JOIN public.epoch_allocation_approvals approval ON approval.id=package.approval_id WHERE approval.run_id=v_run.id;
+  IF FOUND THEN RETURN jsonb_build_object('closePackageId',v_existing.id,'rootHash',v_existing.root_hash,'status',v_existing.status); END IF;
+  SELECT state.* INTO v_state FROM public.epoch_shadow_states state WHERE state.monthly_cycle_id=v_cycle.id FOR UPDATE;
+  SELECT * INTO v_period FROM public.accounting_periods WHERE id=v_state.accounting_period_id;
+  IF v_state.id IS NULL OR v_state.current_stage<>'reviewing' OR v_state.is_paused OR v_state.production_enabled
+    OR v_period.status<>'open' OR v_period.production_enabled THEN RAISE EXCEPTION 'epoch_close_state_not_reviewing'; END IF;
+  IF EXISTS(
+    SELECT 1 FROM public.epoch_allocation_manifest_sources source
+    LEFT JOIN public.epoch_allocation_source_dispositions disposition ON disposition.manifest_source_id=source.id
+      AND disposition.run_id=v_run.id AND disposition.disposition_kind IN('initial_claim','top_up','carryout_residue')
+    WHERE source.manifest_id=v_manifest.id GROUP BY source.id,source.exact_usd
+    HAVING coalesce(sum(disposition.exact_usd),0)<>source.exact_usd
+  ) OR EXISTS(
+    SELECT 1 FROM public.epoch_allocation_manifest_pool_sources source
+    LEFT JOIN public.epoch_allocation_source_dispositions disposition ON disposition.manifest_pool_source_id=source.id
+      AND disposition.run_id=v_run.id AND disposition.disposition_kind IN('top_up','carryout_residue')
+    WHERE source.manifest_id=v_manifest.id GROUP BY source.id,source.exact_usd
+    HAVING coalesce(sum(disposition.exact_usd),0)<>source.exact_usd
+  ) THEN RAISE EXCEPTION 'epoch_close_exact_source_conservation_failed'; END IF;
+
+  INSERT INTO public.epoch_allocation_approvals(run_id,manifest_hash,result_hash,rerun_result_hash,actor_user_id,deployment_environment)
+  VALUES(v_run.id,v_manifest.manifest_hash,v_run.result_hash,p_command->>'rerunResultHash',(p_command->>'actorUserId')::uuid,v_environment)
+  RETURNING * INTO v_approval;
+  INSERT INTO public.epoch_provisional_award_controls(approval_id,run_award_id,monthly_cycle_id,user_id,retained_initial_minor,
+    redistribution_top_up_minor,final_award_minor,minor_unit_cap,approved_result_hash,policy_key,cap_multiple,initial_claim_minor,
+    redistribution_ceiling_minor)
+  SELECT v_approval.id,award.id,v_cycle.id,award.user_id,award.initial_claim_minor,award.top_up_minor,award.final_minor,
+    award.minor_unit_cap,v_run.result_hash,v_run.policy_key,v_run.cap_multiple,award.initial_claim_minor,award.minor_unit_cap
+  FROM public.epoch_allocation_user_awards award WHERE award.run_id=v_run.id;
+
+  FOR v_disposition IN
+    SELECT disposition.*,coalesce(project_source.project_id,pool_source.project_id) project_id,
+      coalesce(project_source.source_lot_key,pool_source.source_lot_key) source_lot_key
+    FROM public.epoch_allocation_source_dispositions disposition
+    LEFT JOIN public.epoch_allocation_manifest_sources project_source ON project_source.id=disposition.manifest_source_id
+    LEFT JOIN public.epoch_allocation_manifest_pool_sources pool_source ON pool_source.id=disposition.manifest_pool_source_id
+    WHERE disposition.run_id=v_run.id AND disposition.disposition_kind IN('initial_claim','top_up','carryout_residue')
+      AND disposition.exact_usd>0 ORDER BY disposition.stable_position,disposition.id
+  LOOP
+    v_award_control_id:=NULL;
+    IF v_disposition.user_id IS NOT NULL THEN SELECT id INTO v_award_control_id FROM public.epoch_provisional_award_controls
+      WHERE approval_id=v_approval.id AND user_id=v_disposition.user_id; END IF;
+    v_hash:=encode(extensions.digest(convert_to(v_run.result_hash||':'||v_disposition.id::text||':'||v_disposition.disposition_kind,'UTF8'),'sha256'),'hex');
+    v_ledger_id:=public.post_neutral_ledger_transaction(jsonb_build_object(
+      'contractVersion','ledger_post.v1','deploymentEnvironment',v_environment,
+      'idempotencyKey','epoch-close-v2:'||v_run.id::text||':disposition:'||v_disposition.id::text,
+      'periodKey',v_period.period_key,'transactionType',CASE WHEN v_disposition.disposition_kind='carryout_residue'
+        THEN 'epoch_returned_residue' ELSE 'epoch_provisional_award' END,'evidenceHash',v_hash,'actorType','operator',
+      'actorUserId',p_command->>'actorUserId','effectiveAt',v_period.starts_at,
+      'postings',CASE WHEN v_disposition.disposition_kind='carryout_residue' THEN jsonb_build_array(
+        jsonb_build_object('accountKey','epoch_returned_residue_control','side','debit','functionalUsdAmount',v_disposition.exact_usd::text,'projectId',v_disposition.project_id),
+        jsonb_build_object('accountKey','epoch_allocated_source_control','side','credit','functionalUsdAmount',v_disposition.exact_usd::text,'projectId',v_disposition.project_id)
+      ) ELSE jsonb_build_array(
+        jsonb_build_object('accountKey','epoch_provisional_award_control','side','debit','functionalUsdAmount',v_disposition.exact_usd::text,'userId',v_disposition.user_id),
+        jsonb_build_object('accountKey','epoch_allocated_source_control','side','credit','functionalUsdAmount',v_disposition.exact_usd::text,'projectId',v_disposition.project_id)
+      ) END));
+    INSERT INTO public.epoch_provisional_award_source_fills(award_control_id,approval_id,manifest_source_id,manifest_pool_source_id,
+      disposition_id,project_id,user_id,fill_kind,canonical_minor,exact_usd,ledger_transaction_id,policy_key)
+    VALUES(v_award_control_id,v_approval.id,v_disposition.manifest_source_id,v_disposition.manifest_pool_source_id,v_disposition.id,
+      v_disposition.project_id,v_disposition.user_id,v_disposition.disposition_kind,v_disposition.canonical_minor,v_disposition.exact_usd,
+      v_ledger_id,'settled_cubid_redistribution_v2');
+  END LOOP;
+
+  INSERT INTO public.epoch_close_project_summaries(approval_id,monthly_cycle_id,project_id,funded_minor,cohort_count,
+    theoretical_share_exact_usd,initial_claim_exact_usd,score_pool_contribution_exact_usd,source_count,cap_multiple,harvested_unclaimed_minor)
+  SELECT v_approval.id,v_cycle.id,project.id,
+    coalesce((SELECT sum(source.canonical_minor_capacity) FROM public.epoch_allocation_manifest_sources source
+      WHERE source.manifest_id=v_manifest.id AND source.project_id=project.id),0),
+    (SELECT count(*) FROM public.epoch_allocation_manifest_cohort cohort WHERE cohort.manifest_id=v_manifest.id AND cohort.project_id=project.id),
+    coalesce((SELECT sum((claim->>'theoreticalShareExactUsd')::numeric) FROM public.epoch_allocation_user_awards award,
+      jsonb_array_elements(award.project_claims) claim WHERE award.run_id=v_run.id AND (claim->>'projectId')::bigint=project.id),0),
+    coalesce((SELECT sum((claim->>'initialClaimExactUsd')::numeric) FROM public.epoch_allocation_user_awards award,
+      jsonb_array_elements(award.project_claims) claim WHERE award.run_id=v_run.id AND (claim->>'projectId')::bigint=project.id),0),
+    coalesce((SELECT sum((claim->>'scorePoolContributionExactUsd')::numeric) FROM public.epoch_allocation_user_awards award,
+      jsonb_array_elements(award.project_claims) claim WHERE award.run_id=v_run.id AND (claim->>'projectId')::bigint=project.id),0),
+    (SELECT count(*) FROM public.epoch_allocation_manifest_sources source WHERE source.manifest_id=v_manifest.id AND source.project_id=project.id),
+    v_run.cap_multiple,v_run.harvested_unclaimed_minor
+  FROM public.projects project WHERE EXISTS(SELECT 1 FROM public.epoch_allocation_manifest_sources source
+    WHERE source.manifest_id=v_manifest.id AND source.project_id=project.id);
+
+  INSERT INTO public.epoch_close_packages(approval_id,monthly_cycle_id,shadow_state_id,manifest_hash,result_hash,root_hash,status,user_count,
+    funded_minor,final_allocation_minor,redistribution_pool_minor,top_up_minor,returned_residue_minor,policy_key,cap_multiple,
+    current_funded_minor,harvested_unclaimed_minor,carry_in_minor)
+  VALUES(v_approval.id,v_cycle.id,v_state.id,v_manifest.manifest_hash,v_run.result_hash,repeat('0',64),'root_review_required',
+    (SELECT count(*) FROM public.epoch_provisional_award_controls WHERE approval_id=v_approval.id),v_run.funded_minor,v_run.final_allocation_minor,
+    v_run.score_pool_minor+v_run.harvested_unclaimed_minor+v_run.carry_in_minor,v_run.top_up_minor,v_run.returned_residue_minor,
+    v_run.policy_key,v_run.cap_multiple,v_run.current_funded_minor,v_run.harvested_unclaimed_minor,v_run.carry_in_minor) RETURNING id INTO v_close_id;
+
+  FOR v_artifact IN SELECT * FROM (VALUES
+    ('trial_balance','operator',jsonb_build_object('runId',v_run.id,'provisionalOnly',true)),
+    ('custody','operator',jsonb_build_object('manifestHash',v_manifest.manifest_hash,'sourceCount',
+      (SELECT count(*) FROM public.epoch_allocation_manifest_sources WHERE manifest_id=v_manifest.id),
+      'poolSourceCount',(SELECT count(*) FROM public.epoch_allocation_manifest_pool_sources WHERE manifest_id=v_manifest.id))),
+    ('project_funds','project_aggregate',(SELECT coalesce(jsonb_agg(to_jsonb(summary)-'id'-'approval_id'-'created_at' ORDER BY summary.project_id),'[]'::jsonb)
+      FROM public.epoch_close_project_summaries summary WHERE summary.approval_id=v_approval.id)),
+    ('fees','operator',jsonb_build_object('currentFundedMinor',v_run.current_funded_minor::text)),
+    ('fx','operator',jsonb_build_object('manifestHash',v_manifest.manifest_hash)),
+    ('carryover','operator',jsonb_build_object('carryInMinor',v_run.carry_in_minor::text,'carryOutMinor',v_run.returned_residue_minor::text)),
+    ('initial_claims','user_private',(SELECT coalesce(jsonb_agg(jsonb_build_object('userId',award.user_id,
+      'initialClaimMinor',award.initial_claim_minor::text,'redistributionCeilingMinor',award.minor_unit_cap::text) ORDER BY award.user_id),'[]'::jsonb)
+      FROM public.epoch_allocation_user_awards award WHERE award.run_id=v_run.id)),
+    ('redistribution_pool','public_aggregate',jsonb_build_object('capMultiple',to_char(v_run.cap_multiple,'FM90.00'),
+      'scorePoolMinor',v_run.score_pool_minor::text,'harvestedUnclaimedMinor',v_run.harvested_unclaimed_minor::text,
+      'carryInMinor',v_run.carry_in_minor::text,'poolMinor',(v_run.score_pool_minor+v_run.harvested_unclaimed_minor+v_run.carry_in_minor)::text)),
+    ('top_ups','user_private',(SELECT coalesce(jsonb_agg(jsonb_build_object('userId',award.user_id,'topUpMinor',award.top_up_minor::text)
+      ORDER BY award.user_id),'[]'::jsonb) FROM public.epoch_allocation_user_awards award WHERE award.run_id=v_run.id)),
+    ('returned_residue','operator',jsonb_build_object('carryOutResidueMinor',v_run.returned_residue_minor::text)),
+    ('provisional_awards','user_private',(SELECT coalesce(jsonb_agg(jsonb_build_object('userId',control.user_id,
+      'finalAwardMinor',control.final_award_minor::text,'capMultiple',to_char(control.cap_multiple,'FM90.00')) ORDER BY control.user_id),'[]'::jsonb)
+      FROM public.epoch_provisional_award_controls control WHERE control.approval_id=v_approval.id)),
+    ('exceptions','operator',jsonb_build_object('overlapPoolMinor','0','productionValueFlow',false))
+  ) artifact_rows(artifact_key,audience,artifact)
+  LOOP
+    v_hash:=encode(extensions.digest(convert_to(v_artifact.artifact::text,'UTF8'),'sha256'),'hex');
+    INSERT INTO public.epoch_close_artifacts(close_package_id,artifact_key,audience,artifact,artifact_hash)
+    VALUES(v_close_id,v_artifact.artifact_key,v_artifact.audience,v_artifact.artifact,v_hash);
+  END LOOP;
+  SELECT encode(extensions.digest(convert_to(coalesce(jsonb_agg(jsonb_build_object('artifactKey',artifact_key,'artifactHash',artifact_hash)
+    ORDER BY artifact_key),'[]'::jsonb)::text,'UTF8'),'sha256'),'hex') INTO v_root_hash
+  FROM public.epoch_close_artifacts WHERE close_package_id=v_close_id;
+  UPDATE public.epoch_close_packages SET root_hash=v_root_hash WHERE id=v_close_id;
+  RETURN jsonb_build_object('closePackageId',v_close_id,'approvalId',v_approval.id,'rootHash',v_root_hash,'status','root_review_required');
+END; $$;
+
+CREATE OR REPLACE VIEW public.epoch_close_operator_view WITH(security_invoker=true) AS
+SELECT cycle.cycle_key,package.id close_package_id,package.status,package.root_hash,package.manifest_hash,package.result_hash,
+  package.user_count,package.funded_minor,package.final_allocation_minor,package.redistribution_pool_minor,package.top_up_minor,
+  package.returned_residue_minor,approval.actor_user_id,approval.approved_at,
+  count(artifact.id) artifact_count,bool_and(NOT package.production_enabled) provisional_only,root_approval.approved_at root_approved_at,
+  package.policy_key,package.cap_multiple,package.current_funded_minor,package.harvested_unclaimed_minor,package.carry_in_minor
+FROM public.epoch_close_packages package JOIN public.monthly_cycles cycle ON cycle.id=package.monthly_cycle_id
+JOIN public.epoch_allocation_approvals approval ON approval.id=package.approval_id
+LEFT JOIN public.epoch_close_root_approvals root_approval ON root_approval.close_package_id=package.id
+LEFT JOIN public.epoch_close_artifacts artifact ON artifact.close_package_id=package.id
+GROUP BY cycle.cycle_key,package.id,approval.id,root_approval.id;
+
+CREATE OR REPLACE VIEW public.epoch_close_public_view WITH(security_barrier=true) AS
+SELECT cycle.cycle_key,package.status,
+  CASE WHEN package.user_count>=3 THEN package.root_hash ELSE NULL END root_hash,
+  CASE WHEN package.user_count>=3 THEN package.funded_minor ELSE NULL END::numeric(78,0) funded_minor,
+  CASE WHEN package.user_count>=3 THEN package.final_allocation_minor ELSE NULL END::numeric(78,0) final_allocation_minor,
+  CASE WHEN package.user_count>=3 THEN package.redistribution_pool_minor ELSE NULL END::numeric(78,0) redistribution_pool_minor,
+  CASE WHEN package.user_count>=3 THEN package.top_up_minor ELSE NULL END::numeric(78,0) top_up_minor,
+  CASE WHEN package.user_count>=3 THEN package.returned_residue_minor ELSE NULL END::numeric(78,0) returned_residue_minor,
+  CASE WHEN package.user_count>=3 THEN package.user_count ELSE NULL END published_user_count,package.created_at,
+  CASE WHEN package.user_count>=3 THEN package.cap_multiple ELSE NULL END cap_multiple,
+  CASE WHEN package.user_count>=3 THEN package.harvested_unclaimed_minor ELSE NULL END::numeric(78,0) harvested_unclaimed_minor
+FROM public.epoch_close_packages package JOIN public.monthly_cycles cycle ON cycle.id=package.monthly_cycle_id
+WHERE NOT package.production_enabled AND package.status='payout_readying';
+
+CREATE OR REPLACE VIEW public.epoch_close_public_project_view WITH(security_barrier=true) AS
+SELECT cycle.cycle_key,project.slug project_slug,
+  CASE WHEN summary.cohort_count>=3 THEN package.root_hash ELSE NULL END root_hash,package.status,
+  CASE WHEN summary.cohort_count>=3 THEN summary.funded_minor ELSE NULL END::numeric(78,0) funded_minor,
+  CASE WHEN summary.cohort_count>=3 THEN summary.cohort_count ELSE NULL END published_cohort_count,
+  CASE WHEN summary.cohort_count>=3 THEN summary.source_count ELSE NULL END source_count,package.created_at,
+  CASE WHEN summary.cohort_count>=3 THEN summary.cap_multiple ELSE NULL END cap_multiple,
+  CASE WHEN summary.cohort_count>=3 THEN summary.harvested_unclaimed_minor ELSE NULL END::numeric(78,0) harvested_unclaimed_minor
+FROM public.epoch_close_project_summaries summary
+JOIN public.epoch_close_packages package ON package.approval_id=summary.approval_id
+JOIN public.monthly_cycles cycle ON cycle.id=summary.monthly_cycle_id
+JOIN public.projects project ON project.id=summary.project_id
+WHERE NOT package.production_enabled AND package.status='payout_readying';
+
+CREATE OR REPLACE FUNCTION public.read_epoch_close_scope(p_actor_user_id uuid,p_scope text,p_cycle_key text,p_project_id bigint DEFAULT NULL) RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_cycle_id bigint; v_result jsonb;
+BEGIN
+  SELECT id INTO v_cycle_id FROM public.monthly_cycles WHERE cycle_key=p_cycle_key;
+  IF p_scope='user' THEN
+    SELECT coalesce(jsonb_agg(jsonb_build_object('cycleKey',p_cycle_key,'rootHash',package.root_hash,'status',package.status,
+      'initialClaimMinor',control.initial_claim_minor::text,'topUpMinor',control.redistribution_top_up_minor::text,
+      'finalAwardMinor',control.final_award_minor::text,'redistributionCeilingMinor',control.redistribution_ceiling_minor::text,
+      'capMultiple',to_char(control.cap_multiple,'FM90.00'),'harvestedUnclaimedMinor',package.harvested_unclaimed_minor::text,
+      'payableStatus',control.payable_status,'ownershipStatus',control.ownership_status,'assetEligibilityStatus',control.asset_eligibility_status)),'[]'::jsonb)
+    INTO v_result FROM public.epoch_provisional_award_controls control
+    JOIN public.epoch_allocation_approvals approval ON approval.id=control.approval_id
+    JOIN public.epoch_close_packages package ON package.approval_id=approval.id
+    WHERE control.monthly_cycle_id=v_cycle_id AND control.user_id=p_actor_user_id;
+  ELSIF p_scope='project' THEN
+    IF p_project_id IS NULL OR NOT EXISTS(SELECT 1 FROM public.participants participant
+      WHERE participant.project_id=p_project_id AND participant.user_id=p_actor_user_id AND participant.is_admin)
+    THEN RAISE EXCEPTION 'epoch_close_project_forbidden'; END IF;
+    SELECT coalesce(jsonb_agg(jsonb_build_object('cycleKey',p_cycle_key,'projectId',summary.project_id,'rootHash',package.root_hash,
+      'status',package.status,'fundedMinor',summary.funded_minor::text,'cohortCount',summary.cohort_count,
+      'theoreticalShareExactUsd',summary.theoretical_share_exact_usd::text,'initialClaimExactUsd',summary.initial_claim_exact_usd::text,
+      'scorePoolContributionExactUsd',summary.score_pool_contribution_exact_usd::text,'sourceCount',summary.source_count,
+      'capMultiple',to_char(summary.cap_multiple,'FM90.00'),'harvestedUnclaimedMinor',summary.harvested_unclaimed_minor::text)),'[]'::jsonb)
+    INTO v_result FROM public.epoch_close_project_summaries summary
+    JOIN public.epoch_close_packages package ON package.approval_id=summary.approval_id
+    WHERE summary.monthly_cycle_id=v_cycle_id AND summary.project_id=p_project_id;
+  ELSE RAISE EXCEPTION 'epoch_close_scope_invalid'; END IF;
+  RETURN coalesce(v_result,'[]'::jsonb);
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.prepare_epoch_withdrawal_obligations(p_close_package_id bigint,p_actor_user_id uuid,p_environment text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path='' AS $$
+DECLARE v_close public.epoch_close_packages%ROWTYPE; v_obligations integer; v_inventory integer;
+BEGIN
+  IF NOT public.withdrawal_runtime_enabled(p_environment) THEN RAISE EXCEPTION 'withdrawal_runtime_disabled'; END IF;
+  IF p_actor_user_id IS NULL OR NOT EXISTS(SELECT 1 FROM public.users WHERE user_id=p_actor_user_id) THEN
+    RAISE EXCEPTION 'withdrawal_operator_actor_invalid';
+  END IF;
+  SELECT * INTO v_close FROM public.epoch_close_packages WHERE id=p_close_package_id FOR UPDATE;
+  IF v_close.id IS NULL OR v_close.status<>'payout_readying' OR v_close.production_enabled
+    OR NOT EXISTS(SELECT 1 FROM public.epoch_close_root_approvals root_approval WHERE root_approval.close_package_id=v_close.id)
+  THEN RAISE EXCEPTION 'withdrawal_close_package_unavailable'; END IF;
+  PERFORM pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended('withdrawal-prepare:'||v_close.id::text,0));
+
+  INSERT INTO public.user_withdrawal_obligations(source_award_control_id,monthly_cycle_id,user_id,total_minor,state,available_at,
+    source_expires_after_cycle_id,evidence_hash)
+  SELECT control.id,control.monthly_cycle_id,control.user_id,control.final_award_minor,'available',v_close.created_at,
+    CASE WHEN control.policy_key='settled_cubid_redistribution_v2' THEN (
+      SELECT expiry.id FROM public.monthly_cycles origin
+      JOIN public.monthly_cycles expiry ON expiry.period_start=(origin.period_start+interval '3 months')::date
+      WHERE origin.id=control.monthly_cycle_id
+    ) ELSE (
+      SELECT min(lot.expires_after_cycle_id) FROM public.epoch_provisional_award_source_fills fill
+      JOIN public.epoch_allocation_manifest_sources source ON source.id=fill.manifest_source_id
+      JOIN public.epoch_valuation_source_lots lot ON lot.id=source.source_lot_id
+      WHERE fill.award_control_id=control.id
+    ) END,
+    encode(extensions.digest(pg_catalog.convert_to(v_close.root_hash||':obligation:'||control.id::text,'UTF8'),'sha256'),'hex')
+  FROM public.epoch_provisional_award_controls control
+  WHERE control.approval_id=v_close.approval_id AND control.final_award_minor>0
+  ON CONFLICT(source_award_control_id) DO NOTHING;
+  GET DIAGNOSTICS v_obligations=ROW_COUNT;
+
+  INSERT INTO public.payout_inventory_lots(obligation_id,source_fill_id,project_id,user_id,monthly_cycle_id,rail_key,
+    financial_asset_id,custody_account_id,fx_snapshot_id,canonical_minor_total,native_atomic_total,deterministic_sequence,
+    expires_after_cycle_id,evidence_hash)
+  SELECT obligation.id,fill.id,fill.project_id,obligation.user_id,obligation.monthly_cycle_id,
+    CASE WHEN coalesce(project_source.rail_key,pool_source.rail_key) IN('stripe_bank_transfer','stripe_sandbox')
+      THEN 'stripe_bank_transfer' ELSE 'base_stablecoin' END,
+    coalesce(project_source.financial_asset_id,pool_source.financial_asset_id),
+    coalesce(project_source.custody_account_id,pool_source.custody_account_id),
+    coalesce(project_source.fx_snapshot_id,pool_source.fx_snapshot_id),fill.canonical_minor,
+    greatest(1,floor(coalesce(project_source.native_atomic_amount,pool_source.native_atomic_amount)
+      *fill.exact_usd/coalesce(project_source.exact_usd,pool_source.exact_usd)))::numeric(78,0),
+    coalesce(project_source.source_order,pool_source.source_order)*1000000+fill.id,
+    obligation.source_expires_after_cycle_id,
+    encode(extensions.digest(pg_catalog.convert_to(v_close.root_hash||':inventory:'||fill.id::text,'UTF8'),'sha256'),'hex')
+  FROM public.epoch_provisional_award_source_fills fill
+  JOIN public.user_withdrawal_obligations obligation ON obligation.source_award_control_id=fill.award_control_id
+  LEFT JOIN public.epoch_allocation_manifest_sources project_source ON project_source.id=fill.manifest_source_id
+  LEFT JOIN public.epoch_allocation_manifest_pool_sources pool_source ON pool_source.id=fill.manifest_pool_source_id
+  WHERE fill.approval_id=v_close.approval_id AND fill.fill_kind IN('initial_retained','initial_claim','top_up')
+    AND fill.canonical_minor>0
+  ON CONFLICT(source_fill_id) DO NOTHING;
+  GET DIAGNOSTICS v_inventory=ROW_COUNT;
+  RETURN jsonb_build_object('closePackageId',v_close.id,'obligationsCreated',v_obligations,
+    'inventoryLotsCreated',v_inventory,'noPayoutExecuted',true);
+END; $$;
+
+REVOKE ALL ON FUNCTION public.approve_epoch_allocation_close_v2(jsonb) FROM PUBLIC,anon,authenticated,service_role;
+GRANT EXECUTE ON FUNCTION public.approve_epoch_allocation_close_v2(jsonb) TO service_role;

--- a/tests/epoch-allocation-close-contract.test.ts
+++ b/tests/epoch-allocation-close-contract.test.ts
@@ -21,7 +21,9 @@ describe("epoch allocation close Edge contract", () => {
 
   it("reruns the trusted manifest and binds actor and runtime inside Edge", () => {
     const source = readFileSync("supabase/functions/epoch-allocation-close/index.ts", "utf8")
-    expect(source).toContain("calculateFundedRedistribution")
+    expect(source).toContain("calculateFundedRedistributionV2")
+    expect(source).toContain('"settled_cubid_redistribution_v2"')
+    expect(source).toContain('"approve_epoch_allocation_close_v2"')
     expect(source).toContain("rerun.resultHash !== run.data.result_hash")
     expect(source).toContain("actorUserId: auth.user.id")
     expect(source).toContain("confirm_epoch_allocation_close_root")

--- a/tests/epoch-allocation-v2-migration.test.ts
+++ b/tests/epoch-allocation-v2-migration.test.ts
@@ -27,6 +27,13 @@ describe("epoch allocation v2 migration", () => {
     expect(sql).toContain("ORDER BY deterministic_sequence DESC,inventory_lot_id DESC")
   })
 
+  it("excludes harvested value from withdrawal state and oldest-first allocation", () => {
+    expect(sql).toContain("v_claimed<v_total-v_harvested")
+    expect(sql).toContain("obligation.total_minor-obligation.harvested_minor-coalesce")
+    expect(sql).toContain("AS unclaimed_minor")
+    expect(sql).toContain("withdrawal_available_amount_insufficient")
+  })
+
   it("carries residue with provenance and exposes privacy-thresholded cap and harvest fields", () => {
     expect(sql).toContain("origin_disposition_id")
     expect(sql).toContain("carryforward_residue")

--- a/tests/epoch-allocation-v2-migration.test.ts
+++ b/tests/epoch-allocation-v2-migration.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const sql = readFileSync("supabase/migrations/20260811120000_epoch_allocation_policy_v2.sql", "utf8")
+
+describe("epoch allocation v2 migration", () => {
+  it("preserves v1 and binds a governed selected cap to immutable v2 artifacts", () => {
+    expect(sql).toContain("settled_cubid_redistribution_v1','settled_cubid_redistribution_v2")
+    expect(sql).toContain("epoch_allocation_v2_preview_input")
+    expect(sql).toContain("selected_preview_hash")
+    expect(sql).toContain("cap_multiple BETWEEN 1 AND 10")
+    expect(sql).toContain("approve_epoch_allocation_close_v2")
+  })
+
+  it("uses the cap only for top-ups and forbids a v2 overlap pool", () => {
+    expect(sql).toContain("top_up_capacity_minor=greatest(minor_unit_cap-initial_claim_minor,0)")
+    expect(sql).toContain("initial_claim_minor=retained_initial_minor")
+    expect(sql).toContain("overlap_pool_minor=0")
+    expect(sql).toContain("top_up_minor+returned_residue_minor=score_pool_minor+harvested_unclaimed_minor+carry_in_minor")
+  })
+
+  it("harvests exactly E minus three with claim and duplicate-harvest guards", () => {
+    expect(sql).toContain("v_target.period_start-interval '3 months'")
+    expect(sql).toContain("withdrawal_claim_harvest_guard")
+    expect(sql).toContain("claim.status<>'released'")
+    expect(sql).toContain("epoch_redistribution_harvest_once_idx")
+    expect(sql).toContain("ORDER BY deterministic_sequence DESC,inventory_lot_id DESC")
+  })
+
+  it("carries residue with provenance and exposes privacy-thresholded cap and harvest fields", () => {
+    expect(sql).toContain("origin_disposition_id")
+    expect(sql).toContain("carryforward_residue")
+    expect(sql).toContain("CASE WHEN package.user_count>=3 THEN package.cap_multiple ELSE NULL END")
+    expect(sql).toContain("CASE WHEN package.user_count>=3 THEN package.harvested_unclaimed_minor ELSE NULL END")
+    expect(sql).toContain("production_enabled=false")
+  })
+})

--- a/tests/epoch-funded-allocation-contract.test.ts
+++ b/tests/epoch-funded-allocation-contract.test.ts
@@ -3,12 +3,15 @@ import { describe, expect, it } from "vitest"
 import { validateEpochFundedAllocationInput } from "@/lib/edge-functions/epoch-funded-allocation-contract"
 
 describe("epoch funded allocation Edge contract", () => {
-  it("accepts only exact read, lock, and calculate inputs", () => {
+  it("accepts only exact read, preview, lock, and calculate inputs", () => {
     expect(validateEpochFundedAllocationInput({ action: "read" })).toMatchObject({ ok: true })
     expect(validateEpochFundedAllocationInput({ action: "read", cycleKey: "2026-08" })).toMatchObject({ ok: true })
-    expect(validateEpochFundedAllocationInput({ action: "lock", cycleKey: "2026-08" })).toMatchObject({ ok: true })
+    expect(validateEpochFundedAllocationInput({ action: "preview", cycleKey: "2026-08", capMultiple: "3.00" })).toMatchObject({ ok: true })
+    expect(validateEpochFundedAllocationInput({ action: "lock", cycleKey: "2026-08", capMultiple: "3.00", selectedPreviewHash: "a".repeat(64) })).toMatchObject({ ok: true })
     expect(validateEpochFundedAllocationInput({ action: "calculate", cycleKey: "2026-08" })).toMatchObject({ ok: true })
     expect(validateEpochFundedAllocationInput({ action: "calculate", cycleKey: "2026-8" })).toMatchObject({ ok: false })
+    expect(validateEpochFundedAllocationInput({ action: "preview", cycleKey: "2026-08", capMultiple: "3" })).toMatchObject({ ok: false })
+    expect(validateEpochFundedAllocationInput({ action: "preview", cycleKey: "2026-08", capMultiple: "10.01" })).toMatchObject({ ok: false })
   })
 
   it("rejects caller-owned actor, environment, artifact, and source inputs", () => {
@@ -24,7 +27,7 @@ describe("epoch funded allocation Edge contract", () => {
     expect(source).toContain("actorUserId: auth.user.id")
     expect(source).toContain("deploymentEnvironment: environment")
     expect(source).toContain('new Set(["local", "development", "dev", "preview", "test"])')
-    expect(source).toContain("calculateFundedRedistribution")
+    expect(source).toContain("calculateFundedRedistributionV2")
     expect(source).not.toContain('allowedEnvironments.add("production")')
   })
 })

--- a/tests/epoch-funded-allocation-ui.test.ts
+++ b/tests/epoch-funded-allocation-ui.test.ts
@@ -8,16 +8,19 @@ const readModel = readFileSync("lib/monthly-cycles/monthly-cycle-prep.ts", "utf8
 describe("epoch funded allocation operator review", () => {
   it("shows the score discount, redistribution, cap, provenance, and provisional boundary", () => {
     expect(page).toContain("Settled Cubid redistribution")
-    expect(page).toContain("Score shortfalls and overlap-cap overflow")
-    expect(page).toContain("preserved 3× cap")
-    expect(page).toContain("no payable, payout, provider call, or value movement")
+    expect(page).toContain("Score discounts, E−3 harvests, and carry-in residue")
+    expect(page).toContain("redistribution top-up ceiling")
+    expect(page).toContain("Selected cap")
+    expect(page).toContain("E−3 harvested")
+    expect(page).toContain("no provider or value flow is opened")
     expect(page).toContain("Manifest")
     expect(page).toContain("Result")
   })
 
   it("exposes explicit lock and calculate controls only through the typed Edge invoker", () => {
     expect(actions).toContain("invokeEpochFundedAllocationBrowser")
-    expect(actions).toContain("Lock funded inputs")
+    expect(actions).toContain("Preview scenario")
+    expect(actions).toContain("Lock selected scenario")
     expect(actions).toContain("Calculate provisional redistribution")
     expect(actions).not.toContain(".from(")
   })

--- a/tests/funded-redistribution-v2-calculator.test.ts
+++ b/tests/funded-redistribution-v2-calculator.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest"
+import {
+  calculateFundedRedistributionV2,
+  type FundedAllocationCohortV2Input,
+  type FundedProjectSourceInput,
+  type FundedRedistributionPoolSourceInput,
+} from "@/lib/monthly-cycles/funded-redistribution-v2-calculator"
+
+const manifestHash = "a".repeat(64)
+const selectedPreviewHash = "b".repeat(64)
+
+function canonicalMinor(exactUsd: string) {
+  const [whole, fraction = ""] = exactUsd.split(".")
+  return (BigInt(whole) * BigInt(100) + BigInt(fraction.padEnd(2, "0").slice(0, 2) || "0")).toString()
+}
+
+function source(projectId: number, exactUsd: string, sourceOrder = projectId.toString()): FundedProjectSourceInput {
+  return {
+    sourceLotId: `source-${projectId}-${sourceOrder}`,
+    sourceLotKey: `project:${projectId}:${sourceOrder}`,
+    projectId,
+    projectKey: `project-${projectId}`,
+    exactUsd,
+    canonicalMinorCapacity: canonicalMinor(exactUsd),
+    minorUnitScale: 2,
+    sourceOrder,
+    railKey: "base_stablecoin",
+    assetKey: "base:usdc",
+    custodyKey: "epoch-safe",
+    nativeAtomicAmount: "1000000",
+    fxSnapshotId: "fx-1",
+    evidenceHash: "c".repeat(64),
+  }
+}
+
+function pool(kind: "harvested_unclaimed" | "carryforward_residue", exactUsd: string, order: string): FundedRedistributionPoolSourceInput {
+  return {
+    ...source(90 + Number(order), exactUsd, order),
+    sourceLotKey: `${kind}:${order}`,
+    originKind: kind,
+    originCycleKey: kind === "harvested_unclaimed" ? "2026-01" : "2026-03",
+  }
+}
+
+function member(projectId: number, userId: string, score: string): FundedAllocationCohortV2Input {
+  return {
+    projectId,
+    projectKey: `project-${projectId}`,
+    userId,
+    projectPseudonym: "d".repeat(64),
+    lockedScore: score,
+    lockedMaximumScore: "20",
+    cubidEvidenceHash: "e".repeat(64),
+  }
+}
+
+function input(overrides: Partial<Parameters<typeof calculateFundedRedistributionV2>[0]> = {}) {
+  return {
+    cycleKey: "2026-04",
+    manifestHash,
+    selectedPreviewHash,
+    minorUnitScale: 2,
+    capMultiple: "3.00",
+    projectSources: [source(1, "300")],
+    redistributionSources: [],
+    cohort: [member(1, "user-a", "5"), member(1, "user-b", "10"), member(1, "user-c", "15")],
+    ...overrides,
+  }
+}
+
+describe("settled Cubid redistribution v2", () => {
+  it("preserves initial claims above the redistribution ceiling and gives them no top-up", async () => {
+    const result = await calculateFundedRedistributionV2(input({
+      capMultiple: "1.00",
+      projectSources: [source(1, "100"), source(2, "100"), source(3, "100"), source(4, "100")],
+      cohort: [1, 2, 3, 4].map((projectId) => member(projectId, "overlap-user", "20")),
+    }))
+
+    expect(result.users[0]).toMatchObject({
+      initialClaimMinor: "40000",
+      redistributionCeilingMinor: "10000",
+      topUpCapacityMinor: "0",
+      topUpMinor: "0",
+      finalMinor: "40000",
+    })
+    expect(result.totals).toMatchObject({ scorePoolMinor: "0", carryOutResidueMinor: "0", finalAllocationMinor: "40000" })
+    expect(result.sourceDispositions.some((row) => (row.kind as string) === "overlap_pool")).toBe(false)
+  })
+
+  it("uses the selected decimal multiple only to limit redistribution top-ups", async () => {
+    const result = await calculateFundedRedistributionV2(input({ capMultiple: "1.50" }))
+    expect(result.capMultiple).toBe("1.50")
+    expect(result.users).toEqual([
+      expect.objectContaining({ userId: "user-a", initialClaimMinor: "2500", redistributionCeilingMinor: "3750", topUpMinor: "1250", finalMinor: "3750" }),
+      expect.objectContaining({ userId: "user-b", initialClaimMinor: "5000", redistributionCeilingMinor: "7500", topUpMinor: "2500", finalMinor: "7500" }),
+      expect.objectContaining({ userId: "user-c", initialClaimMinor: "7500", redistributionCeilingMinor: "11250", topUpMinor: "3750", finalMinor: "11250" }),
+    ])
+    expect(result.totals).toMatchObject({ topUpMinor: "7500", carryOutResidueMinor: "7500" })
+  })
+
+  it("combines score discounts, E-3 harvest, and carry-in while preserving residue", async () => {
+    const result = await calculateFundedRedistributionV2(input({
+      capMultiple: "1.50",
+      redistributionSources: [pool("harvested_unclaimed", "30", "1"), pool("carryforward_residue", "20", "2")],
+    }))
+
+    expect(result.totals).toMatchObject({
+      currentFundedMinor: "30000",
+      harvestedUnclaimedMinor: "3000",
+      carryInMinor: "2000",
+      totalInputMinor: "35000",
+      initialClaimMinor: "15000",
+      scorePoolMinor: "15000",
+      topUpMinor: "7500",
+      carryOutResidueMinor: "12500",
+      finalAllocationMinor: "22500",
+    })
+    expect(result.invariantChecks.every((check) => check.ok)).toBe(true)
+  })
+
+  it.each(["1.00", "3.00", "10.00", "2.75"])("accepts the governed cap multiple %s", async (capMultiple) => {
+    await expect(calculateFundedRedistributionV2(input({ capMultiple }))).resolves.toMatchObject({ capMultiple })
+  })
+
+  it.each(["0.99", "10.01", "3", "3.000"])("rejects the invalid cap multiple %s", async (capMultiple) => {
+    await expect(calculateFundedRedistributionV2(input({ capMultiple }))).rejects.toThrow("funded_allocation_v2_cap_multiple_invalid")
+  })
+
+  it("is invariant to project, pool, and cohort input order", async () => {
+    const projectSources = [source(1, "100", "1"), source(2, "80", "2")]
+    const redistributionSources = [pool("harvested_unclaimed", "12.34", "3"), pool("carryforward_residue", "4.56", "4")]
+    const cohort = [member(1, "user-a", "7"), member(1, "user-b", "13"), member(2, "user-a", "10"), member(2, "user-c", "20")]
+    const first = await calculateFundedRedistributionV2(input({ projectSources, redistributionSources, cohort, capMultiple: "2.75" }))
+    const second = await calculateFundedRedistributionV2(input({
+      projectSources: [...projectSources].reverse(),
+      redistributionSources: [...redistributionSources].reverse(),
+      cohort: [...cohort].reverse(),
+      capMultiple: "2.75",
+    }))
+    expect(second.resultHash).toBe(first.resultHash)
+  })
+})

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -44,6 +44,13 @@ describe("i18n message loading", () => {
     expect(messages.home.heroTitle).toContain("économie")
     expect(messages.home.heroPrefixes).toHaveLength(19)
     expect(messages.home.heroPrefixes[0]).toBe("Un État-réseau")
+    expect(messages.home.monthlyLoop.stages).toHaveLength(7)
+    expect(messages.home.audiences.items.map((item) => item.id)).toEqual([
+      "people",
+      "projects",
+      "research",
+      "operators",
+    ])
     expect(messages.home.heroThesis).toContain("économie en réseau")
     expect(messages.home.theoryOfChange.ideas.pluralism.body).toContain("FundLoop")
     expect(messages.shell.nav.resources).toBe("Ressources")

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1257,6 +1257,13 @@ export type Database = {
             foreignKeyName: "epoch_allocation_approvals_run_id_fkey"
             columns: ["run_id"]
             isOneToOne: true
+            referencedRelation: "epoch_allocation_operator_view_v2"
+            referencedColumns: ["run_id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_approvals_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: true
             referencedRelation: "epoch_allocation_runs"
             referencedColumns: ["id"]
           },
@@ -1309,6 +1316,13 @@ export type Database = {
             referencedColumns: ["manifest_id"]
           },
           {
+            foreignKeyName: "epoch_allocation_manifest_cohort_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view_v2"
+            referencedColumns: ["manifest_id"]
+          },
+          {
             foreignKeyName: "epoch_allocation_manifest_cohort_project_id_fkey"
             columns: ["project_id"]
             isOneToOne: false
@@ -1321,6 +1335,120 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      epoch_allocation_manifest_pool_sources: {
+        Row: {
+          canonical_minor_capacity: number
+          custody_account_id: number
+          evidence_hash: string
+          exact_usd: number
+          financial_asset_id: number
+          fx_snapshot_id: number
+          id: number
+          manifest_id: number
+          native_atomic_amount: number
+          origin_cycle_key: string
+          origin_kind: string
+          pool_source_id: number
+          project_id: number
+          rail_key: string
+          source_lot_key: string
+          source_order: number
+        }
+        Insert: {
+          canonical_minor_capacity: number
+          custody_account_id: number
+          evidence_hash: string
+          exact_usd: number
+          financial_asset_id: number
+          fx_snapshot_id: number
+          id?: never
+          manifest_id: number
+          native_atomic_amount: number
+          origin_cycle_key: string
+          origin_kind: string
+          pool_source_id: number
+          project_id: number
+          rail_key: string
+          source_lot_key: string
+          source_order: number
+        }
+        Update: {
+          canonical_minor_capacity?: number
+          custody_account_id?: number
+          evidence_hash?: string
+          exact_usd?: number
+          financial_asset_id?: number
+          fx_snapshot_id?: number
+          id?: never
+          manifest_id?: number
+          native_atomic_amount?: number
+          origin_cycle_key?: string
+          origin_kind?: string
+          pool_source_id?: number
+          project_id?: number
+          rail_key?: string
+          source_lot_key?: string
+          source_order?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_custody_account_id_fkey"
+            columns: ["custody_account_id"]
+            isOneToOne: false
+            referencedRelation: "financial_custody_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_financial_asset_id_fkey"
+            columns: ["financial_asset_id"]
+            isOneToOne: false
+            referencedRelation: "financial_assets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_fx_snapshot_id_fkey"
+            columns: ["fx_snapshot_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_fx_snapshots"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_manifests"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view"
+            referencedColumns: ["manifest_id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view_v2"
+            referencedColumns: ["manifest_id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_pool_source_id_fkey"
+            columns: ["pool_source_id"]
+            isOneToOne: true
+            referencedRelation: "epoch_redistribution_pool_sources"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_manifest_pool_sources_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -1413,6 +1541,13 @@ export type Database = {
             referencedColumns: ["manifest_id"]
           },
           {
+            foreignKeyName: "epoch_allocation_manifest_sources_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view_v2"
+            referencedColumns: ["manifest_id"]
+          },
+          {
             foreignKeyName: "epoch_allocation_manifest_sources_project_id_fkey"
             columns: ["project_id"]
             isOneToOne: false
@@ -1446,9 +1581,13 @@ export type Database = {
         Row: {
           actor_user_id: string
           calculated_at: string | null
+          cap_multiple: number | null
+          carry_in_minor: number
+          current_funded_minor: number
           deployment_environment: string
           funded_exact_usd: number
           funded_minor: number
+          harvested_unclaimed_minor: number
           id: number
           locked_at: string
           manifest: Json
@@ -1457,15 +1596,20 @@ export type Database = {
           monthly_cycle_id: number
           policy_key: string
           production_enabled: boolean
+          selected_preview_hash: string | null
           status: string
           version: number
         }
         Insert: {
           actor_user_id: string
           calculated_at?: string | null
+          cap_multiple?: number | null
+          carry_in_minor?: number
+          current_funded_minor?: number
           deployment_environment: string
           funded_exact_usd: number
           funded_minor: number
+          harvested_unclaimed_minor?: number
           id?: never
           locked_at?: string
           manifest: Json
@@ -1474,15 +1618,20 @@ export type Database = {
           monthly_cycle_id: number
           policy_key?: string
           production_enabled?: boolean
+          selected_preview_hash?: string | null
           status?: string
           version: number
         }
         Update: {
           actor_user_id?: string
           calculated_at?: string | null
+          cap_multiple?: number | null
+          carry_in_minor?: number
+          current_funded_minor?: number
           deployment_environment?: string
           funded_exact_usd?: number
           funded_minor?: number
+          harvested_unclaimed_minor?: number
           id?: never
           locked_at?: string
           manifest?: Json
@@ -1491,6 +1640,7 @@ export type Database = {
           monthly_cycle_id?: number
           policy_key?: string
           production_enabled?: boolean
+          selected_preview_hash?: string | null
           status?: string
           version?: number
         }
@@ -1522,10 +1672,14 @@ export type Database = {
         Row: {
           actor_user_id: string
           artifact: Json
+          cap_multiple: number | null
+          carry_in_minor: number
           created_at: string
+          current_funded_minor: number
           deployment_environment: string
           final_allocation_minor: number
           funded_minor: number
+          harvested_unclaimed_minor: number
           id: number
           manifest_id: number
           overlap_pool_minor: number
@@ -1540,10 +1694,14 @@ export type Database = {
         Insert: {
           actor_user_id: string
           artifact: Json
+          cap_multiple?: number | null
+          carry_in_minor?: number
           created_at?: string
+          current_funded_minor?: number
           deployment_environment: string
           final_allocation_minor: number
           funded_minor: number
+          harvested_unclaimed_minor?: number
           id?: never
           manifest_id: number
           overlap_pool_minor: number
@@ -1558,10 +1716,14 @@ export type Database = {
         Update: {
           actor_user_id?: string
           artifact?: Json
+          cap_multiple?: number | null
+          carry_in_minor?: number
           created_at?: string
+          current_funded_minor?: number
           deployment_environment?: string
           final_allocation_minor?: number
           funded_minor?: number
+          harvested_unclaimed_minor?: number
           id?: never
           manifest_id?: number
           overlap_pool_minor?: number
@@ -1602,6 +1764,13 @@ export type Database = {
             referencedRelation: "epoch_allocation_operator_view"
             referencedColumns: ["manifest_id"]
           },
+          {
+            foreignKeyName: "epoch_allocation_runs_manifest_id_fkey"
+            columns: ["manifest_id"]
+            isOneToOne: true
+            referencedRelation: "epoch_allocation_operator_view_v2"
+            referencedColumns: ["manifest_id"]
+          },
         ]
       }
       epoch_allocation_runtime_controls: {
@@ -1639,7 +1808,9 @@ export type Database = {
           disposition_kind: string
           exact_usd: number
           id: number
-          manifest_source_id: number
+          manifest_pool_source_id: number | null
+          manifest_source_id: number | null
+          policy_key: string
           run_id: number
           stable_position: number
           user_id: string | null
@@ -1649,7 +1820,9 @@ export type Database = {
           disposition_kind: string
           exact_usd: number
           id?: never
-          manifest_source_id: number
+          manifest_pool_source_id?: number | null
+          manifest_source_id?: number | null
+          policy_key?: string
           run_id: number
           stable_position: number
           user_id?: string | null
@@ -1659,12 +1832,21 @@ export type Database = {
           disposition_kind?: string
           exact_usd?: number
           id?: never
-          manifest_source_id?: number
+          manifest_pool_source_id?: number | null
+          manifest_source_id?: number | null
+          policy_key?: string
           run_id?: number
           stable_position?: number
           user_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "epoch_allocation_source_dispositio_manifest_pool_source_id_fkey"
+            columns: ["manifest_pool_source_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_manifest_pool_sources"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "epoch_allocation_source_dispositions_manifest_source_id_fkey"
             columns: ["manifest_source_id"]
@@ -1677,6 +1859,13 @@ export type Database = {
             columns: ["run_id"]
             isOneToOne: false
             referencedRelation: "epoch_allocation_operator_view"
+            referencedColumns: ["run_id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_source_dispositions_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view_v2"
             referencedColumns: ["run_id"]
           },
           {
@@ -1699,39 +1888,51 @@ export type Database = {
         Row: {
           aggregate_initial_exact_usd: number
           baseline_exact_usd: number
+          cap_multiple: number | null
           exact_cap_usd: number
           final_minor: number
           id: number
+          initial_claim_minor: number | null
           minor_unit_cap: number
+          policy_key: string
           project_claims: Json
           retained_initial_minor: number
           run_id: number
+          top_up_capacity_minor: number | null
           top_up_minor: number
           user_id: string
         }
         Insert: {
           aggregate_initial_exact_usd: number
           baseline_exact_usd: number
+          cap_multiple?: number | null
           exact_cap_usd: number
           final_minor: number
           id?: never
+          initial_claim_minor?: number | null
           minor_unit_cap: number
+          policy_key?: string
           project_claims: Json
           retained_initial_minor: number
           run_id: number
+          top_up_capacity_minor?: number | null
           top_up_minor: number
           user_id: string
         }
         Update: {
           aggregate_initial_exact_usd?: number
           baseline_exact_usd?: number
+          cap_multiple?: number | null
           exact_cap_usd?: number
           final_minor?: number
           id?: never
+          initial_claim_minor?: number | null
           minor_unit_cap?: number
+          policy_key?: string
           project_claims?: Json
           retained_initial_minor?: number
           run_id?: number
+          top_up_capacity_minor?: number | null
           top_up_minor?: number
           user_id?: string
         }
@@ -1741,6 +1942,13 @@ export type Database = {
             columns: ["run_id"]
             isOneToOne: false
             referencedRelation: "epoch_allocation_operator_view"
+            referencedColumns: ["run_id"]
+          },
+          {
+            foreignKeyName: "epoch_allocation_user_awards_run_id_fkey"
+            columns: ["run_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_operator_view_v2"
             referencedColumns: ["run_id"]
           },
           {
@@ -1915,13 +2123,18 @@ export type Database = {
       epoch_close_packages: {
         Row: {
           approval_id: number
+          cap_multiple: number | null
+          carry_in_minor: number
           created_at: string
+          current_funded_minor: number
           final_allocation_minor: number
           funded_minor: number
+          harvested_unclaimed_minor: number
           id: number
           manifest_hash: string
           monthly_cycle_id: number
           package_version: number
+          policy_key: string
           production_enabled: boolean
           redistribution_pool_minor: number
           result_hash: string
@@ -1935,13 +2148,18 @@ export type Database = {
         }
         Insert: {
           approval_id: number
+          cap_multiple?: number | null
+          carry_in_minor?: number
           created_at?: string
+          current_funded_minor?: number
           final_allocation_minor: number
           funded_minor: number
+          harvested_unclaimed_minor?: number
           id?: never
           manifest_hash: string
           monthly_cycle_id: number
           package_version?: number
+          policy_key?: string
           production_enabled?: boolean
           redistribution_pool_minor: number
           result_hash: string
@@ -1955,13 +2173,18 @@ export type Database = {
         }
         Update: {
           approval_id?: number
+          cap_multiple?: number | null
+          carry_in_minor?: number
           created_at?: string
+          current_funded_minor?: number
           final_allocation_minor?: number
           funded_minor?: number
+          harvested_unclaimed_minor?: number
           id?: never
           manifest_hash?: string
           monthly_cycle_id?: number
           package_version?: number
+          policy_key?: string
           production_enabled?: boolean
           redistribution_pool_minor?: number
           result_hash?: string
@@ -2021,9 +2244,11 @@ export type Database = {
       epoch_close_project_summaries: {
         Row: {
           approval_id: number
+          cap_multiple: number | null
           cohort_count: number
           created_at: string
           funded_minor: number
+          harvested_unclaimed_minor: number
           id: number
           initial_claim_exact_usd: number
           monthly_cycle_id: number
@@ -2034,9 +2259,11 @@ export type Database = {
         }
         Insert: {
           approval_id: number
+          cap_multiple?: number | null
           cohort_count: number
           created_at?: string
           funded_minor: number
+          harvested_unclaimed_minor?: number
           id?: never
           initial_claim_exact_usd: number
           monthly_cycle_id: number
@@ -2047,9 +2274,11 @@ export type Database = {
         }
         Update: {
           approval_id?: number
+          cap_multiple?: number | null
           cohort_count?: number
           created_at?: string
           funded_minor?: number
+          harvested_unclaimed_minor?: number
           id?: never
           initial_claim_exact_usd?: number
           monthly_cycle_id?: number
@@ -3097,13 +3326,17 @@ export type Database = {
           approval_id: number
           approved_result_hash: string
           asset_eligibility_status: string
+          cap_multiple: number | null
           created_at: string
           final_award_minor: number
           id: number
+          initial_claim_minor: number | null
           minor_unit_cap: number
           monthly_cycle_id: number
           ownership_status: string
           payable_status: string
+          policy_key: string
+          redistribution_ceiling_minor: number | null
           redistribution_top_up_minor: number
           retained_initial_minor: number
           run_award_id: number
@@ -3114,13 +3347,17 @@ export type Database = {
           approval_id: number
           approved_result_hash: string
           asset_eligibility_status?: string
+          cap_multiple?: number | null
           created_at?: string
           final_award_minor: number
           id?: never
+          initial_claim_minor?: number | null
           minor_unit_cap: number
           monthly_cycle_id: number
           ownership_status?: string
           payable_status?: string
+          policy_key?: string
+          redistribution_ceiling_minor?: number | null
           redistribution_top_up_minor: number
           retained_initial_minor: number
           run_award_id: number
@@ -3131,13 +3368,17 @@ export type Database = {
           approval_id?: number
           approved_result_hash?: string
           asset_eligibility_status?: string
+          cap_multiple?: number | null
           created_at?: string
           final_award_minor?: number
           id?: never
+          initial_claim_minor?: number | null
           minor_unit_cap?: number
           monthly_cycle_id?: number
           ownership_status?: string
           payable_status?: string
+          policy_key?: string
+          redistribution_ceiling_minor?: number | null
           redistribution_top_up_minor?: number
           retained_initial_minor?: number
           run_award_id?: number
@@ -3186,7 +3427,9 @@ export type Database = {
           fill_kind: string
           id: number
           ledger_transaction_id: number
-          manifest_source_id: number
+          manifest_pool_source_id: number | null
+          manifest_source_id: number | null
+          policy_key: string
           project_id: number
           user_id: string | null
         }
@@ -3200,7 +3443,9 @@ export type Database = {
           fill_kind: string
           id?: never
           ledger_transaction_id: number
-          manifest_source_id: number
+          manifest_pool_source_id?: number | null
+          manifest_source_id?: number | null
+          policy_key?: string
           project_id: number
           user_id?: string | null
         }
@@ -3214,11 +3459,20 @@ export type Database = {
           fill_kind?: string
           id?: never
           ledger_transaction_id?: number
-          manifest_source_id?: number
+          manifest_pool_source_id?: number | null
+          manifest_source_id?: number | null
+          policy_key?: string
           project_id?: number
           user_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "epoch_provisional_award_source_fil_manifest_pool_source_id_fkey"
+            columns: ["manifest_pool_source_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_allocation_manifest_pool_sources"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "epoch_provisional_award_source_fills_approval_id_fkey"
             columns: ["approval_id"]
@@ -3274,6 +3528,186 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["user_id"]
+          },
+        ]
+      }
+      epoch_redistribution_pool_sources: {
+        Row: {
+          canonical_minor: number
+          created_at: string
+          custody_account_id: number
+          evidence_hash: string
+          exact_usd: number
+          financial_asset_id: number
+          fx_snapshot_id: number
+          id: number
+          minor_unit_scale: number
+          native_atomic_amount: number
+          origin_award_fill_id: number | null
+          origin_disposition_id: number | null
+          origin_inventory_lot_id: number | null
+          origin_kind: string
+          origin_monthly_cycle_id: number
+          origin_obligation_id: number | null
+          predecessor_pool_source_id: number | null
+          production_enabled: boolean
+          project_id: number
+          rail_key: string
+          source_lot_key: string
+          source_order: number
+          state: string
+          target_monthly_cycle_id: number
+        }
+        Insert: {
+          canonical_minor: number
+          created_at?: string
+          custody_account_id: number
+          evidence_hash: string
+          exact_usd: number
+          financial_asset_id: number
+          fx_snapshot_id: number
+          id?: never
+          minor_unit_scale?: number
+          native_atomic_amount: number
+          origin_award_fill_id?: number | null
+          origin_disposition_id?: number | null
+          origin_inventory_lot_id?: number | null
+          origin_kind: string
+          origin_monthly_cycle_id: number
+          origin_obligation_id?: number | null
+          predecessor_pool_source_id?: number | null
+          production_enabled?: boolean
+          project_id: number
+          rail_key: string
+          source_lot_key: string
+          source_order: number
+          state?: string
+          target_monthly_cycle_id: number
+        }
+        Update: {
+          canonical_minor?: number
+          created_at?: string
+          custody_account_id?: number
+          evidence_hash?: string
+          exact_usd?: number
+          financial_asset_id?: number
+          fx_snapshot_id?: number
+          id?: never
+          minor_unit_scale?: number
+          native_atomic_amount?: number
+          origin_award_fill_id?: number | null
+          origin_disposition_id?: number | null
+          origin_inventory_lot_id?: number | null
+          origin_kind?: string
+          origin_monthly_cycle_id?: number
+          origin_obligation_id?: number | null
+          predecessor_pool_source_id?: number | null
+          production_enabled?: boolean
+          project_id?: number
+          rail_key?: string
+          source_lot_key?: string
+          source_order?: number
+          state?: string
+          target_monthly_cycle_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "epoch_redistribution_pool_sourc_predecessor_pool_source_id_fkey"
+            columns: ["predecessor_pool_source_id"]
+            isOneToOne: true
+            referencedRelation: "epoch_redistribution_pool_sources"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_custody_account_id_fkey"
+            columns: ["custody_account_id"]
+            isOneToOne: false
+            referencedRelation: "financial_custody_accounts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_financial_asset_id_fkey"
+            columns: ["financial_asset_id"]
+            isOneToOne: false
+            referencedRelation: "financial_assets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_fx_snapshot_id_fkey"
+            columns: ["fx_snapshot_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_fx_snapshots"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_award_fill_id_fkey"
+            columns: ["origin_award_fill_id"]
+            isOneToOne: false
+            referencedRelation: "epoch_provisional_award_source_fills"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_disposition_id_fkey"
+            columns: ["origin_disposition_id"]
+            isOneToOne: true
+            referencedRelation: "epoch_allocation_source_dispositions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_inventory_lot_id_fkey"
+            columns: ["origin_inventory_lot_id"]
+            isOneToOne: false
+            referencedRelation: "payout_inventory_lots"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_monthly_cycle_id_fkey"
+            columns: ["origin_monthly_cycle_id"]
+            isOneToOne: false
+            referencedRelation: "monthly_cycles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_obligation_id_fkey"
+            columns: ["origin_obligation_id"]
+            isOneToOne: false
+            referencedRelation: "financial_cutover_canonical_credit_reads"
+            referencedColumns: ["canonical_obligation_id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_obligation_id_fkey"
+            columns: ["origin_obligation_id"]
+            isOneToOne: false
+            referencedRelation: "financial_cutover_compatibility_positions"
+            referencedColumns: ["canonical_obligation_id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_obligation_id_fkey"
+            columns: ["origin_obligation_id"]
+            isOneToOne: false
+            referencedRelation: "user_withdrawal_obligation_balances"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_origin_obligation_id_fkey"
+            columns: ["origin_obligation_id"]
+            isOneToOne: false
+            referencedRelation: "user_withdrawal_obligations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "epoch_redistribution_pool_sources_target_monthly_cycle_id_fkey"
+            columns: ["target_monthly_cycle_id"]
+            isOneToOne: false
+            referencedRelation: "monthly_cycles"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -11077,8 +11511,10 @@ export type Database = {
       user_withdrawal_obligations: {
         Row: {
           available_at: string
+          claim_window_closed_at: string | null
           created_at: string
           evidence_hash: string
+          harvested_minor: number
           id: number
           monthly_cycle_id: number
           production_enabled: boolean
@@ -11091,8 +11527,10 @@ export type Database = {
         }
         Insert: {
           available_at?: string
+          claim_window_closed_at?: string | null
           created_at?: string
           evidence_hash: string
+          harvested_minor?: number
           id?: never
           monthly_cycle_id: number
           production_enabled?: boolean
@@ -11105,8 +11543,10 @@ export type Database = {
         }
         Update: {
           available_at?: string
+          claim_window_closed_at?: string | null
           created_at?: string
           evidence_hash?: string
+          harvested_minor?: number
           id?: never
           monthly_cycle_id?: number
           production_enabled?: boolean
@@ -12625,16 +13065,47 @@ export type Database = {
         }
         Relationships: []
       }
+      epoch_allocation_operator_view_v2: {
+        Row: {
+          calculated_at: string | null
+          cap_multiple: number | null
+          carry_in_minor: number | null
+          carry_out_residue_minor: number | null
+          current_funded_minor: number | null
+          cycle_key: string | null
+          final_allocation_minor: number | null
+          funded_minor: number | null
+          harvested_unclaimed_minor: number | null
+          initial_claim_minor: number | null
+          locked_at: string | null
+          manifest_hash: string | null
+          manifest_id: number | null
+          provisional_only: boolean | null
+          result_hash: string | null
+          run_id: number | null
+          score_pool_minor: number | null
+          selected_preview_hash: string | null
+          status: string | null
+          top_up_minor: number | null
+          user_count: number | null
+        }
+        Relationships: []
+      }
       epoch_close_operator_view: {
         Row: {
           actor_user_id: string | null
           approved_at: string | null
           artifact_count: number | null
+          cap_multiple: number | null
+          carry_in_minor: number | null
           close_package_id: number | null
+          current_funded_minor: number | null
           cycle_key: string | null
           final_allocation_minor: number | null
           funded_minor: number | null
+          harvested_unclaimed_minor: number | null
           manifest_hash: string | null
+          policy_key: string | null
           provisional_only: boolean | null
           redistribution_pool_minor: number | null
           result_hash: string | null
@@ -12657,9 +13128,11 @@ export type Database = {
       }
       epoch_close_public_project_view: {
         Row: {
+          cap_multiple: number | null
           created_at: string | null
           cycle_key: string | null
           funded_minor: number | null
+          harvested_unclaimed_minor: number | null
           project_slug: string | null
           published_cohort_count: number | null
           root_hash: string | null
@@ -12670,10 +13143,12 @@ export type Database = {
       }
       epoch_close_public_view: {
         Row: {
+          cap_multiple: number | null
           created_at: string | null
           cycle_key: string | null
           final_allocation_minor: number | null
           funded_minor: number | null
+          harvested_unclaimed_minor: number | null
           published_user_count: number | null
           redistribution_pool_minor: number | null
           returned_residue_minor: number | null
@@ -13478,7 +13953,9 @@ export type Database = {
       user_withdrawal_obligation_balances: {
         Row: {
           available_minor: number | null
+          claim_window_closed_at: string | null
           closed_minor: number | null
+          harvested_minor: number | null
           held_minor: number | null
           id: number | null
           monthly_cycle_id: number | null
@@ -13580,6 +14057,10 @@ export type Database = {
         Returns: number
       }
       approve_epoch_allocation_close: {
+        Args: { p_command: Json }
+        Returns: Json
+      }
+      approve_epoch_allocation_close_v2: {
         Args: { p_command: Json }
         Returns: Json
       }
@@ -13695,6 +14176,14 @@ export type Database = {
       epoch_allocation_runtime_enabled: {
         Args: { p_environment: string }
         Returns: boolean
+      }
+      epoch_allocation_v2_preview_input: {
+        Args: {
+          p_cap_multiple: number
+          p_cycle_key: string
+          p_environment: string
+        }
+        Returns: Json
       }
       epoch_close_runtime_enabled: {
         Args: { p_environment: string }
@@ -13999,6 +14488,10 @@ export type Database = {
         }
       }
       lock_funded_epoch_allocation: { Args: { p_command: Json }; Returns: Json }
+      lock_funded_epoch_allocation_v2: {
+        Args: { p_command: Json }
+        Returns: Json
+      }
       manage_user_withdrawal_request: {
         Args: {
           p_action: string
@@ -14173,6 +14666,10 @@ export type Database = {
         Returns: number
       }
       record_funded_epoch_allocation: {
+        Args: { p_command: Json }
+        Returns: number
+      }
+      record_funded_epoch_allocation_v2: {
         Args: { p_command: Json }
         Returns: number
       }


### PR DESCRIPTION
## Summary

- Reframes the multilingual public home around FundLoop's monthly coordination loop.
- Implements `settled_cubid_redistribution_v2`, preserving full initial claims while limiting redistribution top-ups with an epoch-selected cap multiple.
- Adds exactly E−3 unclaimed-award harvesting, carry-forward residue, immutable scenario selection, close controls, and scoped reporting.
- Corrects the durable allocation, treasury, operational, architecture, sprint, and issue-tree documentation.

## Objective

Make the public monthly story accurate and implement the corrected allocation policy: the selected cap multiple limits redistribution top-ups only, while the redistribution pool is funded by Cubid score discounts, exactly E−3 unclaimed awards, and prior carry-in residue.

## Changes

- Added a responsive English, Spanish, and French monthly-loop public experience with private-by-default reporting language.
- Added a deterministic v2 calculator, read-only `1.00`–`10.00` scenario previews, selected-preview locking, independent close reruns, and immutable result inputs.
- Added a forward-only migration for harvested and carried redistribution sources, claim/harvest concurrency controls, newest-lot-first partial harvest, withdrawal inventory preparation, and conservation constraints.
- Added the selected cap multiple and aggregate harvested amount to operator, project, private-user, and privacy-thresholded public reports and root artifacts.
- Regenerated local Supabase types and added focused calculator, migration, contract, UI, and multilingual tests.

## Validation

- Node 22 `CI=1 pnpm check`: lint, 171 test files / 773 tests, typecheck, and 165-page production build passed.
- Fresh local Supabase migration chain and seed passed with Vector excluded; schema lint passed at error level.
- Final focused v2 suite passed 22 tests after the canonical-capacity correction.
- `git diff --check` passed.
- The repository-wide SQL harness remains non-TAP and has two older fixture failures documented in the session log; neither failure reaches the new v2 path.

## Reviewer Notes

- Review the commits in order: public story (`1d5b0ad`), policy contract (`ab0c32d`), then implementation (`2214068`).
- The v1 database artifacts remain reproducible and unchanged; v2 is additive.
- Production value flow remains disabled. No remote Supabase mutation or production activation is included.
- Copilot review is intentionally skipped per the publishing instruction. Codex review is required and will be requested exactly once.

## Follow-ups

- Convert the repository SQL harness into a reliable TAP gate and add a fixture-backed four-epoch v2 lifecycle test.
- Production activation, remote Supabase rollout, and hosted value-flow verification remain separately governed work.
