### PR TITLE
[codex] confirm reviewed Dev function prune

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -328,7 +328,7 @@ jobs:
           set -euo pipefail
 
           node scripts/verify-supabase-function-parity.mjs predeploy
-          supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF" --prune --jobs 1
+          supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF" --prune --jobs 1 --yes
           SUPABASE_PARITY_OUTPUT="${RUNNER_TEMP}/supabase-function-parity.json" \
             node scripts/verify-supabase-function-parity.mjs postdeploy
 

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -674,3 +674,48 @@ only a literal true value may authorize the repair path.
 - Let the parent inspect and push this focused fix, then reply to and resolve the
   review thread after the pushed commit is available.
 - Keep #160 In Progress until the CI-owned Dev deploy proves strict zero drift.
+
+### session v14: Confirm reviewed Edge Function prune in CI (#160)
+
+- Timestamp: 2026-08-12T14:21:06-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-function-prune-recovery`
+- Head: `c840ec9421486cc48aa5d28d48614ccbafc7861b`
+
+#### Objective
+
+Allow the noninteractive CI-owned Dev deployment to delete the one exact reviewed
+retired Edge Function only after the existing parity guard authorizes that inventory.
+
+#### Actions Taken
+
+- Added the Supabase CLI global `--yes` flag to the existing all-function deploy and
+  prune command so GitHub-hosted CI confirms the reviewed deletion without a prompt.
+- Strengthened the workflow contract test to require the predeploy inventory guard,
+  confirmed prune, and postdeploy read-back in that exact order, and to reject the
+  former unconfirmed command.
+- Documented that confirmation derives solely from the due, environment-scoped
+  retirement manifest; unexplained extras still fail before any prune.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused Supabase delivery parity suite, 11/11 tests, and focused
+  ESLint.
+- Passed: workflow YAML parse and `git diff --check`.
+- Passed: local pinned Supabase CLI help contract exposes `--prune`, `--jobs`, and the
+  global `--yes` flag accepted by the deploy command.
+- No Supabase project was linked or mutated; no workflow, push, PR, Production action,
+  function deletion, or value-flow activation occurred.
+
+#### Reflections
+
+Noninteractive confirmation is safe only after a separately tested verifier narrows
+the destructive set to reviewed retirements. Ordering that verifier before mutation
+and retaining postdeploy read-back keeps the operation fail closed.
+
+#### Suggested Next Steps
+
+- Let the orchestrator independently validate and publish this branch, then require
+  the CI-owned Dev run to prune the retired function and complete exact postdeploy
+  read-back plus the safe runtime smoke.
+- Keep #160 In Progress and do not start #161 until that hosted evidence passes.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -134,8 +134,14 @@ remote name is not a due, environment-scoped entry in
 all current functions and prunes only the reviewed retirement:
 
 ```bash
-supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF" --prune --jobs 1
+supabase functions deploy --project-ref "$SUPABASE_PROJECT_REF" --prune --jobs 1 --yes
 ```
+
+`--yes` confirms the reviewed prune noninteractively only after the predeploy parity
+guard has rejected every unexplained extra and limited deletion to due,
+environment-scoped entries in `supabase/retired-functions.json`. The command remains
+fail closed: removing or reordering that guard is covered by the workflow contract
+test, and postdeploy read-back must still prove the exact resulting inventory.
 
 Before bundling functions on deploy runs, the workflow installs repo dependencies
 with `pnpm install --frozen-lockfile` so package dependencies remain available to the

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -158,11 +158,18 @@ describe("Supabase delivery parity", () => {
   })
 
   it("deploys atomically with prune, verifies exact sources/schema, smokes Dev, and uploads evidence", () => {
+    const predeployGuard = "node scripts/verify-supabase-function-parity.mjs predeploy"
+    const confirmedPrune = "supabase functions deploy --project-ref \"$SUPABASE_PROJECT_REF\" --prune --jobs 1 --yes"
+    const postdeployReadback = "node scripts/verify-supabase-function-parity.mjs postdeploy"
+
     expect(workflow).toContain("verify-supabase-schema-parity.mjs")
     expect(workflow).toContain("deno cache --no-check --frozen --config supabase/functions/deno.json")
-    expect(workflow).toContain("verify-supabase-function-parity.mjs predeploy")
-    expect(workflow).toContain("supabase functions deploy --project-ref \"$SUPABASE_PROJECT_REF\" --prune --jobs 1")
-    expect(workflow).toContain("verify-supabase-function-parity.mjs postdeploy")
+    expect(workflow).toContain(predeployGuard)
+    expect(workflow).toContain(confirmedPrune)
+    expect(workflow).not.toContain("supabase functions deploy --project-ref \"$SUPABASE_PROJECT_REF\" --prune --jobs 1\n")
+    expect(workflow).toContain(postdeployReadback)
+    expect(workflow.indexOf(predeployGuard)).toBeLessThan(workflow.indexOf(confirmedPrune))
+    expect(workflow.indexOf(confirmedPrune)).toBeLessThan(workflow.indexOf(postdeployReadback))
     expect(workflow).toContain("epoch-allocation-close")
     expect(workflow).toContain('status_code}" != "401"')
     expect(workflow).toContain("actions/upload-artifact@v4")


### PR DESCRIPTION
## Summary

- Confirms the already guarded Supabase Edge Function prune non-interactively in CI.
- Preserves the exact predeploy retirement allowlist, postdeploy inventory/source read-back, and safe Dev smoke ordering.
- Repairs the sole failure from merge run 31626456974 without manually mutating Dev or changing Production/value-flow controls.

## Objective

Finish Task #160 after PR #192 merged and migration/schema parity succeeded, but the function deployment stopped at an interactive confirmation prompt for the one reviewed retired Dev function.

## Changes

- Adds global `--yes` to the existing `supabase functions deploy --prune --jobs 1` command.
- Keeps `verify-supabase-function-parity.mjs predeploy` immediately before the confirmed prune; any unexplained extra fails first under `set -euo pipefail`.
- Keeps exact postdeploy function inventory, ACTIVE status, bundle/source digest comparison, and safe unauthenticated Dev smoke after the prune.
- Strengthens focused tests to require `predeploy guard < confirmed prune < postdeploy read-back` and reject the former unconfirmed command.
- Documents why confirmation is authorized only by the reviewed retired-function contract and records session v14.

## Validation

- Independent issue-validator: PASS, no findings.
- Node 22 focused Supabase delivery parity suite: 11/11.
- Focused ESLint, workflow YAML parsing, and `git diff --check` passed.
- Supabase CLI 2.113.0 help/parse confirms `--prune`, `--jobs`, and global `--yes`.
- Merge run 31626456974 evidence: migration 95 applied; schema parity hash `f5ee78f4...` matched with zero object drift; all 14 value-flow tables disabled; all 62 expected functions deployed; only `monthly-cycle-payout-intents-create` remained as the exact reviewed Dev retirement before the prompt canceled.

## Reviewer Notes

Review the one-line workflow change first, then the ordering assertions. `--yes` is not an allowlist: the predeploy verifier remains the fail-closed authorization boundary and permits this retired function only on Dev. Main/Production cannot borrow that retirement.

## Follow-ups

- After reviewed merge, require the CI-owned Dev run to prune the retired function, produce exact postdeploy function parity evidence, and pass the safe Dev smoke.
- Keep #160 In Progress and do not start #161 until that outcome is independently validated.

Relates to #155
Parent Goal: #158
Continues #160
Predecessor PR: #192
