### PR TITLE
fix(supabase): secure function source read-back (#160)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -719,3 +719,63 @@ and retaining postdeploy read-back keeps the operation fail closed.
   the CI-owned Dev run to prune the retired function and complete exact postdeploy
   read-back plus the safe runtime smoke.
 - Keep #160 In Progress and do not start #161 until that hosted evidence passes.
+
+### session v15: Secure Management API function source read-back (#160)
+
+- Timestamp: 2026-08-12T16:14:48-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-function-source-readback-recovery`
+- Head: `6868db96e31cab9bf3f711b224347296b3825924`
+
+#### Objective
+
+Replace the pinned CLI's filesystem extraction failure with a repo-owned, read-only
+source verifier that preserves exact closure and byte parity for all reviewed Edge
+Functions.
+
+#### Actions Taken
+
+- Reproduced the pinned Supabase CLI 2.113.0 Management API contract from its tagged
+  Go source: authenticated GET of the function body with an
+  `Accept: multipart/form-data` response, `Supabase-Path` precedence, and
+  Content-Disposition filename fallback.
+- Replaced `supabase functions download --use-api` with a bounded multipart reader
+  against the same official endpoint. It validates project refs and slugs, rejects
+  redirects/non-200 responses and sanitizes transport failures without exposing
+  tokens, bodies, or unreviewed remote paths.
+- Enforced response, part-count, and per-file limits; exact terminal framing; regular
+  file-only entries; safe relative paths; duplicate/case/Unicode collision rejection;
+  and normalization of only the known `fundloop-website/` archive prefix.
+- Preserved independently derived checkout closures, exact missing/extra comparison,
+  byte-for-byte checks, canonical source digests, and remote deployment bindings.
+  Unknown extra paths are reported only by count and opaque SHA-256.
+- Added a synthetic Management API fixture matrix and documented that this is direct
+  multipart source read-back rather than ZIP extraction.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused source-readback and delivery-parity suites, 28/28 tests;
+  focused ESLint and TypeScript typecheck.
+- Passed: synthetic good monorepo closure and negative probes for traversal, absolute
+  paths, symlink/non-regular markers, duplicate/colliding paths, missing/extra paths,
+  changed bytes, response/file/count limits, malformed/truncated/trailing multipart,
+  `Supabase-Path` precedence, non-200/redirect/auth/transport failures, and identifier
+  validation. Secret-like unknown paths and provider/token/body text remained absent
+  from errors.
+- Passed: script syntax, workflow YAML parse, and `git diff --check`.
+- Passed: Node 22 `CI=1 pnpm check`, including lint, the full test suite, typecheck,
+  and Next production build with 165 generated pages.
+- No Management API or Supabase project was called or mutated; no workflow, push, PR,
+  Production action, #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+Remote bundle metadata is untrusted even when it comes from the deployment provider.
+Parsing the official multipart contract in memory avoids the CLI extractor's shared
+filesystem assumptions while keeping every reviewed closure byte covered.
+
+#### Suggested Next Steps
+
+- Let the orchestrator independently validate and publish the branch, then require
+  CI-owned postdeploy read-back across all 62 active functions and the safe Dev smoke.
+- Keep #160 In Progress until that hosted evidence passes; do not start #161.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -779,3 +779,48 @@ filesystem assumptions while keeping every reviewed closure byte covered.
 - Let the orchestrator independently validate and publish the branch, then require
   CI-owned postdeploy read-back across all 62 active functions and the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes; do not start #161.
+
+### session v16: Fully validate multipart MIME parameters (#160)
+
+- Timestamp: 2026-08-12T16:22:43-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-function-source-readback-recovery`
+- Head: `ef3fbaf18878914b31f08e18b4afe5fd5cc5cce5`
+
+#### Objective
+
+Address independent validator findings by making the function source reader reject
+ambiguous or partially parsed multipart MIME parameters before trusting any path.
+
+#### Actions Taken
+
+- Replaced permissive Content-Disposition and boundary parsing with one strict parser
+  that consumes the complete type and parameter grammar, accepts valid token and
+  quoted-string values, and rejects duplicate names, malformed escapes, unterminated
+  quotes, empty values, and all unconsumed trailing syntax.
+- Preserved official `Supabase-Path` precedence while requiring Content-Disposition
+  itself to be valid before either path source is used.
+- Added adversarial coverage for duplicate `name`/`filename`, trailing junk,
+  malformed/duplicate boundary and charset parameters, and legal quoted escapes.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused source-readback and delivery-parity suites, 36/36 tests;
+  focused ESLint and TypeScript typecheck.
+- Passed: script syntax, workflow YAML parse, and `git diff --check`.
+- Full `CI=1 pnpm check` was not repeated for this localized parser follow-up; it
+  passed in session v15 before the validator fix.
+- No network request, remote Supabase mutation, workflow, push, PR, Production action,
+  #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+Security-sensitive MIME parsing must reject ambiguity, not merely extract the fields
+it recognizes. Full consumption makes duplicate or trailing attacker-controlled
+syntax impossible to silently ignore.
+
+#### Suggested Next Steps
+
+- Return this follow-up to independent validation, then let the orchestrator publish
+  and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
+- Keep #160 In Progress until that hosted evidence passes.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -158,11 +158,24 @@ fingerprint. Missing, extra, inactive, or unverifiable functions block parity.
 
 After deployment, the workflow lists the remote inventory again, requires exactly
 the derived local names with `ACTIVE` status, downloads every deployed source closure
-through the management API, and compares its path set against a separately derived
+through `GET /v1/projects/{project-ref}/functions/{slug}/body` on the official
+Supabase Management API with the CI-only bearer token and
+`Accept: multipart/form-data`. This matches the pinned CLI 2.113.0 response contract
+without using its filesystem extractor, which cannot safely retain legitimate
+monorepo-root closure members outside `supabase/functions`. The repo-owned reader
+compares the multipart path set against a separately derived
 transitive checkout closure before comparing every byte plus the canonical closure
 SHA-256 against the reviewed checkout. It records the remote bundle digest, version,
 status, project ref, environment, candidate Git SHA, and observation time. The
-database verifier independently replays all tracked migrations into a randomized
+reader rejects redirects and non-200 responses without logging response bodies,
+validates project/function identifiers, bounds the response, file count, and each
+file, and rejects absolute/traversal paths, symlink/non-regular markers, duplicate or
+case/Unicode-colliding paths, and missing/extra closure members. Only the known
+`fundloop-website/` archive prefix is stripped; no source path or byte is allowlisted
+out of comparison. The contract follows Supabase CLI tag `v2.113.0`,
+`apps/cli-go/internal/functions/download/download.go` (`readForm` and `getPartPath`).
+This is multipart source read-back, not ZIP extraction. The database verifier
+independently replays all tracked migrations into a randomized
 Postgres 17 local stack and requires exact remote migration-version equality. Before
 `db push`, the deploy run persists the sorted per-file SHA-256 inventory with the
 candidate Git SHA, Actions run/attempt, environment, and project ref in the repo-owned

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -1,11 +1,15 @@
 import { createHash } from "node:crypto"
 import { execFileSync } from "node:child_process"
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
-import os from "node:os"
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 
 const repoRoot = process.cwd()
+const managementApiOrigin = "https://api.supabase.com"
+const maxResponseBytes = 16 * 1024 * 1024
+const maxFileBytes = 2 * 1024 * 1024
+const maxFileCount = 256
+const knownRepoRootPrefix = "fundloop-website/"
 
 export function expectedFunctionNames(root = repoRoot) {
   return readdirSync(path.join(root, "supabase/functions"), { withFileTypes: true })
@@ -16,24 +20,19 @@ export function expectedFunctionNames(root = repoRoot) {
     .sort()
 }
 
-function filesUnder(root) {
-  const files = []
-  const visit = (directory) => {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const fullPath = path.join(directory, entry.name)
-      if (entry.isDirectory()) visit(fullPath)
-      else if (entry.isFile()) files.push(fullPath)
-    }
-  }
-  visit(root)
-  return files.sort()
-}
-
 function digestFiles(root, files) {
   const hash = createHash("sha256")
   for (const file of files) {
     const relative = path.relative(root, file).split(path.sep).join("/")
     hash.update(relative).update("\0").update(createHash("sha256").update(readFileSync(file)).digest("hex")).update("\n")
+  }
+  return hash.digest("hex")
+}
+
+function digestSourceMap(files) {
+  const hash = createHash("sha256")
+  for (const [relative, contents] of [...files].sort(([left], [right]) => left.localeCompare(right))) {
+    hash.update(relative).update("\0").update(createHash("sha256").update(contents).digest("hex")).update("\n")
   }
   return hash.digest("hex")
 }
@@ -96,32 +95,146 @@ function remoteFunctions(projectRef) {
   return JSON.parse(execFileSync("supabase", ["functions", "list", "--project-ref", projectRef, "--output", "json"], { encoding: "utf8" }))
 }
 
-function verifyDownloadedSource(projectRef, functionName) {
-  const tempRoot = mkdtempSync(path.join(os.tmpdir(), `fundloop-function-${functionName}-`))
-  try {
-    mkdirSync(path.join(tempRoot, "supabase"), { recursive: true })
-    cpSync(path.join(repoRoot, "supabase/config.toml"), path.join(tempRoot, "supabase/config.toml"), { recursive: true })
-    execFileSync("supabase", ["functions", "download", functionName, "--project-ref", projectRef, "--workdir", tempRoot, "--use-api"], { stdio: "pipe" })
-    const downloadedFiles = filesUnder(tempRoot).filter((file) => !file.includes(`${path.sep}supabase${path.sep}.temp${path.sep}`) && !file.endsWith("supabase/config.toml"))
-    if (downloadedFiles.length === 0) throw new Error(`Downloaded function ${functionName} has no source files`)
-    const expectedPaths = expectedSourceClosure(functionName)
-    const observedPaths = downloadedFiles.map((file) => path.relative(tempRoot, file).split(path.sep).join("/")).sort()
-    const { missingPaths, extraPaths } = compareClosurePaths(expectedPaths, observedPaths)
-    if (missingPaths.length || extraPaths.length) throw new Error(`Remote ${functionName} closure mismatch: missing=${missingPaths.join(",")} extra=${extraPaths.join(",")}`)
-    const localFiles = expectedPaths.map((relative) => path.join(repoRoot, relative))
-    for (const relative of expectedPaths) {
-      if (!readFileSync(path.join(tempRoot, relative)).equals(readFileSync(path.join(repoRoot, relative)))) throw new Error(`Remote ${functionName} source differs: ${relative}`)
-    }
-    const observedSourceSha256 = digestFiles(tempRoot, downloadedFiles)
-    const expectedSourceSha256 = digestFiles(repoRoot, localFiles)
-    if (expectedSourceSha256 !== observedSourceSha256) throw new Error(`Remote ${functionName} source digest differs from reviewed source`)
-    return { expectedSourceSha256, observedSourceSha256 }
-  } finally {
-    rmSync(tempRoot, { recursive: true, force: true })
+function parseDisposition(value) {
+  if (!value?.startsWith("form-data;")) return null
+  const params = new Map()
+  for (const match of value.matchAll(/;\s*([a-zA-Z0-9_-]+)="((?:[^"\\]|\\.)*)"/g)) {
+    params.set(match[1].toLowerCase(), match[2].replace(/\\(["\\])/g, "$1"))
   }
+  return params
 }
 
-function main() {
+function safeArchivePath(rawPath) {
+  if (!rawPath || rawPath.includes("\0") || rawPath.includes("\\") || rawPath.startsWith("/") || /^[a-zA-Z]:/.test(rawPath)) {
+    throw new Error("Remote function archive contains an unsafe path")
+  }
+  const segments = rawPath.split("/")
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) throw new Error("Remote function archive contains an unsafe path")
+  const relative = rawPath.startsWith(knownRepoRootPrefix) ? rawPath.slice(knownRepoRootPrefix.length) : rawPath
+  return relative
+}
+
+function multipartBoundary(contentType) {
+  const segments = contentType.split(";")
+  if (segments.shift()?.trim().toLowerCase() !== "multipart/form-data") return null
+  const params = new Map()
+  for (const segment of segments) {
+    const separator = segment.indexOf("=")
+    if (separator <= 0) return null
+    const name = segment.slice(0, separator).trim().toLowerCase()
+    let value = segment.slice(separator + 1).trim()
+    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1).replace(/\\(["\\])/g, "$1")
+    if (!name || !value || params.has(name)) return null
+    params.set(name, value)
+  }
+  return params.get("boundary") ?? null
+}
+
+async function readBoundedBody(response) {
+  const declared = Number(response.headers.get("content-length"))
+  if (Number.isFinite(declared) && declared > maxResponseBytes) throw new Error("Remote function response exceeds size limit")
+  if (!response.body) throw new Error("Remote function response has no body")
+  const chunks = []
+  let total = 0
+  for await (const chunk of response.body) {
+    total += chunk.byteLength
+    if (total > maxResponseBytes) throw new Error("Remote function response exceeds size limit")
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks, total)
+}
+
+export async function parseFunctionSourceResponse(response, functionName, expectedPaths) {
+  if (response.redirected || response.status >= 300 && response.status < 400) throw new Error("Remote function download refused redirect")
+  if (response.status !== 200) throw new Error(`Remote function download failed with status ${response.status}`)
+  const contentType = response.headers.get("content-type") ?? ""
+  const boundary = multipartBoundary(contentType)
+  if (!boundary || boundary.length > 70 || /[^\x21-\x7e]/.test(boundary)) throw new Error("Remote function response has invalid multipart content type")
+  const body = await readBoundedBody(response)
+  const delimiter = Buffer.from(`--${boundary}`)
+  const files = new Map()
+  const collisionKeys = new Set()
+  let cursor = 0
+  if (!body.subarray(0, delimiter.length).equals(delimiter)) throw new Error("Remote function response has invalid multipart framing")
+  cursor = delimiter.length
+  while (true) {
+    if (body.subarray(cursor, cursor + 2).toString() === "--") {
+      cursor += 2
+      if (body.subarray(cursor).toString() !== "\r\n") throw new Error("Remote function response has invalid multipart trailer")
+      break
+    }
+    if (body.subarray(cursor, cursor + 2).toString() !== "\r\n") throw new Error("Remote function response has invalid multipart framing")
+    cursor += 2
+    const headerEnd = body.indexOf("\r\n\r\n", cursor)
+    if (headerEnd < 0 || headerEnd - cursor > 16 * 1024) throw new Error("Remote function response has invalid multipart headers")
+    const headerLines = body.subarray(cursor, headerEnd).toString("utf8").split("\r\n")
+    const headers = new Map()
+    for (const line of headerLines) {
+      if (/^[ \t]/.test(line)) throw new Error("Remote function response contains folded headers")
+      const separator = line.indexOf(":")
+      if (separator <= 0) throw new Error("Remote function response has invalid multipart headers")
+      const name = line.slice(0, separator).toLowerCase()
+      if (headers.has(name)) throw new Error("Remote function response has duplicate multipart headers")
+      headers.set(name, line.slice(separator + 1).trim())
+    }
+    const next = body.indexOf(Buffer.from(`\r\n--${boundary}`), headerEnd + 4)
+    if (next < 0) throw new Error("Remote function response has invalid multipart framing")
+    const contents = body.subarray(headerEnd + 4, next)
+    cursor = next + 2 + delimiter.length
+    const disposition = parseDisposition(headers.get("content-disposition"))
+    if (!disposition) throw new Error("Remote function response has invalid content disposition")
+    const rawPath = headers.get("supabase-path") ?? disposition.get("filename")
+    if (!rawPath) {
+      if (disposition.get("name") !== "metadata" || contents.byteLength > 64 * 1024) throw new Error("Remote function response contains a non-file entry")
+      continue
+    }
+    const entryType = (headers.get("supabase-file-type") ?? "file").toLowerCase()
+    const partType = (headers.get("content-type") ?? "").toLowerCase()
+    if (!["file", "regular"].includes(entryType) || partType.includes("symlink") || partType.includes("directory")) throw new Error("Remote function archive contains a non-regular entry")
+    if (contents.byteLength > maxFileBytes) throw new Error("Remote function archive file exceeds size limit")
+    if (files.size >= maxFileCount) throw new Error("Remote function archive exceeds file count limit")
+    const relative = safeArchivePath(rawPath)
+    const collisionKey = relative.normalize("NFC").toLowerCase()
+    if (files.has(relative) || collisionKeys.has(collisionKey)) throw new Error("Remote function archive contains duplicate or colliding paths")
+    collisionKeys.add(collisionKey)
+    files.set(relative, Buffer.from(contents))
+  }
+  if (!files.size) throw new Error(`Remote ${functionName} has no source files`)
+  const observedPaths = [...files.keys()].sort()
+  const { missingPaths, extraPaths } = compareClosurePaths(expectedPaths, observedPaths)
+  if (missingPaths.length || extraPaths.length) {
+    const extraPathSha256 = extraPaths.map((relative) => createHash("sha256").update(relative).digest("hex")).sort()
+    throw new Error(`Remote ${functionName} closure mismatch: missing=${missingPaths.join(",")} extraCount=${extraPaths.length} extraPathSha256=${extraPathSha256.join(",")}`)
+  }
+  return files
+}
+
+export async function verifyDownloadedSource(projectRef, functionName, accessToken, fetchImpl = fetch) {
+  if (!/^[a-z0-9]{20}$/.test(projectRef)) throw new Error("Invalid Supabase project ref")
+  if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(functionName)) throw new Error("Invalid Edge Function slug")
+  if (!accessToken) throw new Error("SUPABASE_ACCESS_TOKEN is required for source read-back")
+  const expectedPaths = expectedSourceClosure(functionName)
+  let response
+  try {
+    response = await fetchImpl(`${managementApiOrigin}/v1/projects/${projectRef}/functions/${functionName}/body`, {
+      headers: { accept: "multipart/form-data", authorization: `Bearer ${accessToken}` },
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+    })
+  } catch {
+    throw new Error("Remote function source read-back transport failed")
+  }
+  const files = await parseFunctionSourceResponse(response, functionName, expectedPaths)
+  for (const relative of expectedPaths) {
+    if (!files.get(relative).equals(readFileSync(path.join(repoRoot, relative)))) throw new Error(`Remote ${functionName} source differs: ${relative}`)
+  }
+  const expectedSourceSha256 = digestFiles(repoRoot, expectedPaths.map((relative) => path.join(repoRoot, relative)))
+  const observedSourceSha256 = digestSourceMap(files)
+  if (expectedSourceSha256 !== observedSourceSha256) throw new Error(`Remote ${functionName} source digest differs from reviewed source`)
+  return { expectedSourceSha256, observedSourceSha256 }
+}
+
+async function main() {
   const phase = process.argv[2]
   const projectRef = process.env.SUPABASE_PROJECT_REF
   const environment = process.env.TARGET_ENVIRONMENT
@@ -142,17 +255,18 @@ function main() {
   if (inventory.missing.length || inventory.extras.length) {
     throw new Error(`Function inventory mismatch: missing=${inventory.missing.join(",")} extra=${inventory.extras.join(",")}`)
   }
-  const functions = observed.sort((left, right) => left.name.localeCompare(right.name)).map((entry) => {
+  const functions = []
+  for (const entry of observed.sort((left, right) => left.name.localeCompare(right.name))) {
     if (entry.status !== "ACTIVE" || !entry.ezbr_sha256) throw new Error(`Remote function is not verifiable and active: ${entry.name}`)
-    const source = verifyDownloadedSource(projectRef, entry.name)
-    return {
+    const source = await verifyDownloadedSource(projectRef, entry.name, process.env.SUPABASE_ACCESS_TOKEN)
+    functions.push({
       name: entry.name,
       ...source,
       deployedBundleSha256: entry.ezbr_sha256,
       remoteVersion: entry.version,
       remoteStatus: entry.status,
-    }
-  })
+    })
+  }
   const manifest = {
     contractVersion: "fundloop.edge-function-parity/v1",
     candidateGitSha: process.env.GITHUB_SHA ?? "local-unbound",
@@ -166,4 +280,4 @@ function main() {
   console.log(`Verified ${functions.length} active Edge Functions with exact downloaded source parity.`)
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main()
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) await main()

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -95,13 +95,66 @@ function remoteFunctions(projectRef) {
   return JSON.parse(execFileSync("supabase", ["functions", "list", "--project-ref", projectRef, "--output", "json"], { encoding: "utf8" }))
 }
 
-function parseDisposition(value) {
-  if (!value?.startsWith("form-data;")) return null
-  const params = new Map()
-  for (const match of value.matchAll(/;\s*([a-zA-Z0-9_-]+)="((?:[^"\\]|\\.)*)"/g)) {
-    params.set(match[1].toLowerCase(), match[2].replace(/\\(["\\])/g, "$1"))
+function parseMimeParameters(value, expectedType) {
+  if (typeof value !== "string") return null
+  let cursor = 0
+  const skipWhitespace = () => {
+    while (value[cursor] === " " || value[cursor] === "\t") cursor += 1
   }
-  return params
+  const readToken = () => {
+    const start = cursor
+    while (cursor < value.length && /[!#$%&'*+.^_`|~0-9A-Za-z-]/.test(value[cursor])) cursor += 1
+    return value.slice(start, cursor)
+  }
+  skipWhitespace()
+  const typeStart = cursor
+  while (cursor < value.length && /[!#$%&'*+.^_`|~0-9A-Za-z\/-]/.test(value[cursor])) cursor += 1
+  const mediaType = value.slice(typeStart, cursor).toLowerCase()
+  if (mediaType !== expectedType) return null
+  const params = new Map()
+  while (true) {
+    skipWhitespace()
+    if (cursor === value.length) return params
+    if (value[cursor] !== ";") return null
+    cursor += 1
+    skipWhitespace()
+    const name = readToken().toLowerCase()
+    if (!name || params.has(name)) return null
+    skipWhitespace()
+    if (value[cursor] !== "=") return null
+    cursor += 1
+    skipWhitespace()
+    let parameterValue = ""
+    if (value[cursor] === '"') {
+      cursor += 1
+      let closed = false
+      while (cursor < value.length) {
+        const character = value[cursor]
+        cursor += 1
+        if (character === '"') {
+          closed = true
+          break
+        }
+        if (character === "\\") {
+          if (cursor >= value.length || /[\x00-\x08\x0a-\x1f\x7f]/.test(value[cursor])) return null
+          parameterValue += value[cursor]
+          cursor += 1
+          continue
+        }
+        if (/[^\x20-\x21\x23-\x7e]/.test(character)) return null
+        parameterValue += character
+      }
+      if (!closed) return null
+    } else {
+      parameterValue = readToken()
+      if (!parameterValue) return null
+    }
+    params.set(name, parameterValue)
+  }
+}
+
+function parseDisposition(value) {
+  return parseMimeParameters(value, "form-data")
 }
 
 function safeArchivePath(rawPath) {
@@ -115,19 +168,8 @@ function safeArchivePath(rawPath) {
 }
 
 function multipartBoundary(contentType) {
-  const segments = contentType.split(";")
-  if (segments.shift()?.trim().toLowerCase() !== "multipart/form-data") return null
-  const params = new Map()
-  for (const segment of segments) {
-    const separator = segment.indexOf("=")
-    if (separator <= 0) return null
-    const name = segment.slice(0, separator).trim().toLowerCase()
-    let value = segment.slice(separator + 1).trim()
-    if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1).replace(/\\(["\\])/g, "$1")
-    if (!name || !value || params.has(name)) return null
-    params.set(name, value)
-  }
-  return params.get("boundary") ?? null
+  const params = parseMimeParameters(contentType, "multipart/form-data")
+  return params?.get("boundary") ?? null
 }
 
 async function readBoundedBody(response) {
@@ -149,7 +191,7 @@ export async function parseFunctionSourceResponse(response, functionName, expect
   if (response.status !== 200) throw new Error(`Remote function download failed with status ${response.status}`)
   const contentType = response.headers.get("content-type") ?? ""
   const boundary = multipartBoundary(contentType)
-  if (!boundary || boundary.length > 70 || /[^\x21-\x7e]/.test(boundary)) throw new Error("Remote function response has invalid multipart content type")
+  if (!boundary || !/^[0-9A-Za-z'()+_,./:=?-]{1,70}$/.test(boundary)) throw new Error("Remote function response has invalid multipart content type")
   const body = await readBoundedBody(response)
   const delimiter = Buffer.from(`--${boundary}`)
   const files = new Map()

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -168,6 +168,8 @@ describe("Supabase delivery parity", () => {
     expect(workflow).toContain(confirmedPrune)
     expect(workflow).not.toContain("supabase functions deploy --project-ref \"$SUPABASE_PROJECT_REF\" --prune --jobs 1\n")
     expect(workflow).toContain(postdeployReadback)
+    expect(workflow).toContain("SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}")
+    expect(schemaVerifier).not.toContain("functions download")
     expect(workflow.indexOf(predeployGuard)).toBeLessThan(workflow.indexOf(confirmedPrune))
     expect(workflow.indexOf(confirmedPrune)).toBeLessThan(workflow.indexOf(postdeployReadback))
     expect(workflow).toContain("epoch-allocation-close")

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -50,6 +50,28 @@ describe("Supabase Management API function source read-back", () => {
   })
 
   it.each([
+    ["duplicate filename", "form-data; name=\"file\"; filename=\"safe.ts\"; filename=\"other.ts\""],
+    ["duplicate name", "form-data; name=\"file\"; name=\"other\"; filename=\"safe.ts\""],
+    ["trailing junk", "form-data; name=\"file\"; filename=\"safe.ts\" junk"],
+    ["unterminated quote", "form-data; name=\"file\"; filename=\"safe.ts"],
+  ])("rejects malformed Content-Disposition: %s", async (_label, disposition) => {
+    const response = multipart([file("ignored.ts", "safe\n", {
+      "Content-Disposition": disposition,
+      "Supabase-Path": "safe.ts",
+    })])
+    await expect(parseFunctionSourceResponse(response, "example", ["safe.ts"]))
+      .rejects.toThrow("invalid content disposition")
+  })
+
+  it("accepts valid quoted escapes in MIME parameters", async () => {
+    const response = multipart([file("ignored.ts", "safe\n", {
+      "Content-Disposition": "form-data; name=\"fi\\\"le\"; filename=\"safe.ts\"",
+    })])
+    const parsed = await parseFunctionSourceResponse(response, "example", ["safe.ts"])
+    expect(parsed.get("safe.ts")?.toString()).toBe("safe\n")
+  })
+
+  it.each([
     ["traversal", "../secret.ts"],
     ["absolute POSIX", "/etc/passwd"],
     ["absolute Windows", "C:/secret.ts"],
@@ -105,6 +127,9 @@ describe("Supabase Management API function source read-back", () => {
     ["trailing bytes", rawResponse("--fundloop-source-boundary--\r\ntrailing")],
     ["malformed header", rawResponse("--fundloop-source-boundary\r\nnot-a-header\r\n\r\nsafe\r\n--fundloop-source-boundary--\r\n")],
     ["duplicate boundary parameter", rawResponse("--one--\r\n", "multipart/form-data; boundary=one; boundary=two")],
+    ["boundary trailing junk", rawResponse("--one--\r\n", "multipart/form-data; boundary=one junk")],
+    ["boundary unterminated quote", rawResponse("--one--\r\n", "multipart/form-data; boundary=\"one")],
+    ["boundary duplicate charset", rawResponse("--one--\r\n", "multipart/form-data; boundary=one; charset=utf-8; charset=ascii")],
   ])("rejects %s", async (_label, response) => {
     await expect(parseFunctionSourceResponse(response, "example", ["safe.ts"]))
       .rejects.toThrow(/multipart/)

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it, vi } from "vitest"
+import { expectedSourceClosure, parseFunctionSourceResponse, verifyDownloadedSource } from "../scripts/verify-supabase-function-parity.mjs"
+
+type Part = { headers: Record<string, string>, body: string | Buffer }
+
+function multipart(parts: Part[], boundary = "fundloop-source-boundary") {
+  const chunks: Buffer[] = []
+  for (const part of parts) {
+    chunks.push(Buffer.from(`--${boundary}\r\n`))
+    for (const [name, value] of Object.entries(part.headers)) chunks.push(Buffer.from(`${name}: ${value}\r\n`))
+    chunks.push(Buffer.from("\r\n"), Buffer.isBuffer(part.body) ? part.body : Buffer.from(part.body), Buffer.from("\r\n"))
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`))
+  return new Response(Buffer.concat(chunks), { status: 200, headers: { "content-type": `multipart/form-data; boundary=${boundary}` } })
+}
+
+function rawResponse(body: Buffer | string, contentType = "multipart/form-data; boundary=fundloop-source-boundary") {
+  return new Response(typeof body === "string" ? body : new Uint8Array(body), { status: 200, headers: { "content-type": contentType } })
+}
+
+function file(path: string, body: string | Buffer = "export {}\n", extraHeaders: Record<string, string> = {}): Part {
+  return {
+    headers: {
+      "Content-Disposition": `form-data; name="file"; filename="${path}"`,
+      "Content-Type": "application/typescript",
+      ...extraHeaders,
+    },
+    body,
+  }
+}
+
+describe("Supabase Management API function source read-back", () => {
+  it("accepts the official multipart response and strips only the known monorepo root", async () => {
+    const expected = ["lib/edge-functions/result.ts", "supabase/functions/example/index.ts"]
+    const parsed = await parseFunctionSourceResponse(multipart([
+      { headers: { "Content-Disposition": "form-data; name=\"metadata\"" }, body: "{\"deno2_entrypoint_path\":\"fundloop-website/supabase/functions/example/index.ts\"}" },
+      file("fundloop-website/lib/edge-functions/result.ts", "result\n"),
+      file("fundloop-website/supabase/functions/example/index.ts", "entry\n"),
+    ]), "example", expected)
+    expect([...parsed.keys()].sort()).toEqual(expected)
+    expect(parsed.get(expected[0])?.toString()).toBe("result\n")
+  })
+
+  it("accepts legal multipart parameter ordering and gives Supabase-Path precedence", async () => {
+    const response = multipart([file("wrong.ts", "right\n", { "Supabase-Path": "fundloop-website/safe.ts" })])
+    response.headers.set("content-type", "multipart/form-data; charset=utf-8; boundary=\"fundloop-source-boundary\"")
+    const parsed = await parseFunctionSourceResponse(response, "example", ["safe.ts"])
+    expect(parsed.get("safe.ts")?.toString()).toBe("right\n")
+  })
+
+  it.each([
+    ["traversal", "../secret.ts"],
+    ["absolute POSIX", "/etc/passwd"],
+    ["absolute Windows", "C:/secret.ts"],
+  ])("rejects %s paths", async (_label, unsafePath) => {
+    await expect(parseFunctionSourceResponse(multipart([file(unsafePath)]), "example", ["safe.ts"]))
+      .rejects.toThrow("unsafe path")
+  })
+
+  it("rejects symlink and other non-regular parts", async () => {
+    await expect(parseFunctionSourceResponse(multipart([file("safe.ts", "target", { "Supabase-File-Type": "symlink" })]), "example", ["safe.ts"]))
+      .rejects.toThrow("non-regular entry")
+  })
+
+  it("rejects duplicate and normalized-path collisions", async () => {
+    await expect(parseFunctionSourceResponse(multipart([file("safe.ts"), file("safe.ts")]), "example", ["safe.ts"]))
+      .rejects.toThrow("duplicate or colliding paths")
+    await expect(parseFunctionSourceResponse(multipart([file("Safe.ts"), file("safe.ts")]), "example", ["Safe.ts", "safe.ts"]))
+      .rejects.toThrow("duplicate or colliding paths")
+  })
+
+  it("rejects unknown prefixes plus missing and extra closure paths", async () => {
+    const secretLikePath = "other-repo/person@example.com-secret.ts"
+    const unknownError = await parseFunctionSourceResponse(multipart([file(secretLikePath)]), "example", ["safe.ts"])
+      .catch((caught) => String(caught))
+    expect(unknownError).toContain("missing=safe.ts extraCount=1 extraPathSha256=")
+    expect(unknownError).not.toContain(secretLikePath)
+    expect(unknownError).not.toContain("person@example.com")
+    await expect(parseFunctionSourceResponse(multipart([file("safe.ts"), file("extra.ts")]), "example", ["safe.ts"]))
+      .rejects.toThrow("extraCount=1 extraPathSha256=")
+    await expect(parseFunctionSourceResponse(multipart([file("other.ts")]), "example", ["safe.ts", "other.ts"]))
+      .rejects.toThrow("missing=safe.ts")
+  })
+
+  it("rejects oversized files before comparison", async () => {
+    await expect(parseFunctionSourceResponse(multipart([file("safe.ts", Buffer.alloc(2 * 1024 * 1024 + 1))]), "example", ["safe.ts"]))
+      .rejects.toThrow("file exceeds size limit")
+  })
+
+  it("enforces total response and file-count bounds", async () => {
+    const declaredOversize = multipart([file("safe.ts")])
+    declaredOversize.headers.set("content-length", String(16 * 1024 * 1024 + 1))
+    await expect(parseFunctionSourceResponse(declaredOversize, "example", ["safe.ts"]))
+      .rejects.toThrow("response exceeds size limit")
+    const paths = Array.from({ length: 257 }, (_, index) => `file-${index}.ts`)
+    await expect(parseFunctionSourceResponse(multipart(paths.map((relative) => file(relative))), "example", paths))
+      .rejects.toThrow("file count limit")
+    await expect(parseFunctionSourceResponse(rawResponse(Buffer.alloc(16 * 1024 * 1024 + 1)), "example", ["safe.ts"]))
+      .rejects.toThrow("response exceeds size limit")
+  })
+
+  it.each([
+    ["missing terminal boundary", rawResponse("--fundloop-source-boundary\r\nContent-Disposition: form-data; name=\"file\"; filename=\"safe.ts\"\r\n\r\nsafe")],
+    ["trailing bytes", rawResponse("--fundloop-source-boundary--\r\ntrailing")],
+    ["malformed header", rawResponse("--fundloop-source-boundary\r\nnot-a-header\r\n\r\nsafe\r\n--fundloop-source-boundary--\r\n")],
+    ["duplicate boundary parameter", rawResponse("--one--\r\n", "multipart/form-data; boundary=one; boundary=two")],
+  ])("rejects %s", async (_label, response) => {
+    await expect(parseFunctionSourceResponse(response, "example", ["safe.ts"]))
+      .rejects.toThrow(/multipart/)
+  })
+
+  it("fails closed on redirects, auth errors, and untrusted response bodies", async () => {
+    const redirected = multipart([file("safe.ts")])
+    Object.defineProperty(redirected, "redirected", { value: true })
+    await expect(parseFunctionSourceResponse(redirected, "example", ["safe.ts"]))
+      .rejects.toThrow("refused redirect")
+
+    const secret = "sbp_secret_token"
+    const body = "untrusted provider body"
+    const request = vi.fn().mockResolvedValue(new Response(body, { status: 401 }))
+    await expect(verifyDownloadedSource("a".repeat(20), "epoch-allocation-close", secret, request))
+      .rejects.toThrow("status 401")
+    expect(request).toHaveBeenCalledWith(
+      "https://api.supabase.com/v1/projects/aaaaaaaaaaaaaaaaaaaa/functions/epoch-allocation-close/body",
+      expect.objectContaining({
+        headers: { accept: "multipart/form-data", authorization: `Bearer ${secret}` },
+        redirect: "error",
+      }),
+    )
+    const error = await verifyDownloadedSource("a".repeat(20), "epoch-allocation-close", secret, request).catch((caught) => String(caught))
+    expect(error).not.toContain(secret)
+    expect(error).not.toContain(body)
+
+    const transport = vi.fn().mockRejectedValue(new Error(`provider leaked ${secret} ${body}`))
+    const transportError = await verifyDownloadedSource("a".repeat(20), "epoch-allocation-close", secret, transport).catch((caught) => String(caught))
+    expect(transportError).toContain("source read-back transport failed")
+    expect(transportError).not.toContain(secret)
+    expect(transportError).not.toContain(body)
+  })
+
+  it("validates project refs, slugs, and token presence before network access", async () => {
+    const request = vi.fn()
+    await expect(verifyDownloadedSource("bad", "example", "token", request)).rejects.toThrow("Invalid Supabase project ref")
+    await expect(verifyDownloadedSource("a".repeat(20), "../example", "token", request)).rejects.toThrow("Invalid Edge Function slug")
+    await expect(verifyDownloadedSource("a".repeat(20), "example", "", request)).rejects.toThrow("SUPABASE_ACCESS_TOKEN")
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it("matches every byte and digest in a local synthetic Management API response", async () => {
+    const functionName = "epoch-allocation-close"
+    const expected = expectedSourceClosure(functionName)
+    const response = multipart(expected.map((relative) => file(`fundloop-website/${relative}`, readFileSync(relative))))
+    const request = vi.fn().mockResolvedValue(response)
+    const result = await verifyDownloadedSource("a".repeat(20), functionName, "fixture-token", request)
+    expect(result.observedSourceSha256).toBe(result.expectedSourceSha256)
+
+    const changed = multipart(expected.map((relative, index) => file(`fundloop-website/${relative}`, index === 0 ? "changed\n" : readFileSync(relative))))
+    await expect(verifyDownloadedSource("a".repeat(20), functionName, "fixture-token", vi.fn().mockResolvedValue(changed)))
+      .rejects.toThrow("source differs")
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces the failing Supabase CLI filesystem extraction step with bounded, in-memory multipart source read-back from the official Management API.
- Preserves exact independently derived Edge Function closure, byte, digest, inventory, and active-status verification.
- Fails closed on ambiguous MIME metadata, unsafe paths, response limits, non-regular entries, redirects, and untrusted provider errors.

## Objective

Complete Task #160 post-deploy verification after PR #193 successfully deployed all 62 expected functions and pruned the reviewed retirement, but its CI verifier rejected legitimate monorepo-root source paths during CLI extraction.

## Changes

- Reads `GET /v1/projects/{ref}/functions/{slug}/body` with the CI-only Supabase access token and `Accept: multipart/form-data`.
- Parses the response without filesystem extraction under explicit response, file-count, and per-file limits.
- Normalizes only the reviewed `fundloop-website/` prefix and rejects traversal, absolute paths, non-regular entries, duplicate/case/Unicode collisions, and missing or extra closure members.
- Strictly consumes Content-Disposition and Content-Type parameters, rejects duplicates and malformed suffixes, and keeps `Supabase-Path` precedence only after valid disposition parsing.
- Reports unknown paths only as count and opaque SHA-256; response bodies, transport details, and tokens are never emitted.
- Updates the deployment runbook and Sprint #155 Goal 1 session log.

## Validation

- Independent issue-validator verdict: PASS at `2d35cd807549c4fb47043e8104f9d3618da1dba5`.
- Node 22 focused source-readback and delivery-parity tests: 36/36 passed.
- Focused ESLint, full typecheck, Node syntax, workflow YAML parse, and `git diff --check` passed.
- The primary implementation commit also passed `CI=1 pnpm check`, including the full test suite and Next production build.
- Synthetic adversarial cases cover duplicate MIME parameters, malformed/trailing syntax, traversal/absolute paths, non-regular entries, collisions, missing/extra/changed sources, bounds, redirects, non-2xx, transport failures, and secret/body/path opacity.

## Reviewer Notes

- Review `ef3fbaf` first for the Management API reader, then `2d35cd8` for the validator-requested strict MIME hardening.
- This PR does not change deployment targets, migration behavior, function source, runtime behavior, Production, payout controls, cutover controls, or real value flow.
- The CI-owned Dev merge run must still prove all 62 function sources and the safe unauthorized smoke before #160 is outcome-complete.

## Follow-ups

- After green review and merge to `dev`, inspect the merge-triggered Supabase Deploy artifact for exact schema/migration/function parity and the safe 401 smoke.
- Do not start #161 until that hosted evidence passes.

Closes no issue; advances #160.
