### PR TITLE
fix(supabase): derive runtime function closures (#160)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -824,3 +824,52 @@ syntax impossible to silently ignore.
 - Return this follow-up to independent validation, then let the orchestrator publish
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
+
+### session v17: Derive runtime-only Edge Function source closures (#160)
+
+- Timestamp: 2026-08-12T16:42:06-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-runtime-source-closure-recovery`
+- Head: `064b64730ee562b516be605a8e0ec3abd85439fa`
+
+#### Objective
+
+Match the reviewed expected source closure to Deno's deployed runtime graph without
+allowlisting the missing `types/supabase.ts` module or conceding any remote content.
+
+#### Actions Taken
+
+- Replaced regex import discovery with the repo-pinned TypeScript 5.9 compiler API.
+- Excluded only erased whole `import type` / `export type` edges and named clauses
+  whose specifiers are all inline `type`; mixed clauses with a value remain runtime
+  dependencies.
+- Preserved value imports/re-exports, export-star edges, side-effect imports, dynamic
+  imports, and runtime JSON assets. Invalid TypeScript parse diagnostics fail closed.
+- Added a synthetic runtime graph covering pure type-only, inline type-only, mixed,
+  side-effect, dynamic, value re-export, type re-export, and export-star cases.
+- Proved all 62 function closures derive and the admin reconciliation closure omits
+  `types/supabase.ts` while retaining its reviewed value-bearing modules. Documented
+  the compiler dependency and retained pre-mutation Deno graph guard.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused source-readback and delivery-parity suites, 39/39 tests,
+  including all-62 closure derivation and fail-closed invalid syntax.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse,
+  and `git diff --check`.
+- Full `CI=1 pnpm check` was not repeated; the focused all-function graph plus
+  typecheck is proportionate, and the full check passed in session v15.
+- No remote API call or mutation, workflow, push, PR, status change, Production
+  action, #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+Expected parity must model the runtime compiler graph rather than textual references.
+Using language semantics removes erased type edges precisely while continuing to bind
+every deployed value-bearing source byte.
+
+#### Suggested Next Steps
+
+- Return the commit to independent validation, then let the orchestrator publish and
+  require CI-owned read-back of all 62 functions plus the safe Dev smoke.
+- Keep #160 In Progress until that hosted evidence passes.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -825,6 +825,48 @@ syntax impossible to silently ignore.
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
 
+### session v18: Fail closed on ambiguous dynamic imports (#160)
+
+- Timestamp: 2026-08-12T16:45:15-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-runtime-source-closure-recovery`
+- Head: `95ecd23be0947e63eb1c675923dac7c58fa0352b`
+
+#### Objective
+
+Address independent validation by covering standard two-argument dynamic imports and
+refusing any dynamic dependency that cannot be derived exactly.
+
+#### Actions Taken
+
+- Accepted string-literal dynamic imports with either one argument or the standard
+  second import-attributes/options argument.
+- Continued deriving the first literal source for two-argument JSON imports so the
+  runtime asset remains byte-bound.
+- Made nonliteral dynamic import specifiers and invalid arity fail closed instead of
+  silently omitting a possible repository dependency.
+- Added positive one-/two-argument and negative nonliteral/over-arity coverage and
+  documented the exact dynamic-import contract.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused source-readback and delivery-parity suites, 41/41 tests.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse,
+  and `git diff --check`.
+- No network request, remote mutation, workflow, push, PR, Production action, #161
+  work, or value-flow activation occurred.
+
+#### Reflections
+
+Dynamic import options do not change the dependency identity, but a nonliteral first
+argument makes that identity unknowable. Closure verification must accept the former
+and reject the latter.
+
+#### Suggested Next Steps
+
+- Return this follow-up to independent validation, then require CI-owned all-function
+  read-back and the safe Dev smoke before #160 progresses.
+
 ### session v17: Derive runtime-only Edge Function source closures (#160)
 
 - Timestamp: 2026-08-12T16:42:06-04:00

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -203,6 +203,9 @@ whose bindings are all explicitly `type` are excluded because Deno erases those
 modules from the deployed runtime bundle. Parse diagnostics fail closed, and the Deno
 module-graph preflight still runs before migration or function mutation. This is a
 language-semantic graph rule, not a path or remote-content allowlist.
+Dynamic imports accept the standard string-literal one-argument form and two-argument
+form with import attributes/options. Nonliteral specifiers and any other arity fail
+closed rather than risking an underived repository dependency.
 
 The two sanitized `fundloop.public-schema-parity/v1` and
 `fundloop.edge-function-parity/v1` JSON records are uploaded as one 30-day Actions

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -163,8 +163,8 @@ Supabase Management API with the CI-only bearer token and
 `Accept: multipart/form-data`. This matches the pinned CLI 2.113.0 response contract
 without using its filesystem extractor, which cannot safely retain legitimate
 monorepo-root closure members outside `supabase/functions`. The repo-owned reader
-compares the multipart path set against a separately derived
-transitive checkout closure before comparing every byte plus the canonical closure
+compares the multipart path set against a separately derived transitive runtime
+checkout closure before comparing every byte plus the canonical closure
 SHA-256 against the reviewed checkout. It records the remote bundle digest, version,
 status, project ref, environment, candidate Git SHA, and observation time. The
 reader rejects redirects and non-200 responses without logging response bodies,
@@ -194,6 +194,15 @@ signature, the remote migration history is the byte-bound reviewed prefix, the r
 is the sole pending migration, and production value flow remains disabled. The
 post-deploy verifier has no repair exception: it requires the complete migration
 history and zero normalized schema drift.
+
+The expected function closure is derived with the repo-pinned TypeScript compiler
+API after `pnpm install --frozen-lockfile`. It follows side-effect imports, dynamic
+imports, value imports/re-exports, mixed clauses containing any value binding, and
+runtime JSON assets. Whole `import type` / `export type` clauses and named clauses
+whose bindings are all explicitly `type` are excluded because Deno erases those
+modules from the deployed runtime bundle. Parse diagnostics fail closed, and the Deno
+module-graph preflight still runs before migration or function mutation. This is a
+language-semantic graph rule, not a path or remote-content allowlist.
 
 The two sanitized `fundloop.public-schema-parity/v1` and
 `fundloop.edge-function-parity/v1` JSON records are uploaded as one 30-day Actions

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -78,9 +78,9 @@ export function expectedSourceClosure(functionName, root = repoRoot) {
           && node.exportClause.elements.length > 0
           && node.exportClause.elements.every((element) => element.isTypeOnly)
         if (!node.isTypeOnly && !onlyInlineTypes) addModuleSpecifier(node.moduleSpecifier)
-      } else if (ts.isCallExpression(node)
-        && node.expression.kind === ts.SyntaxKind.ImportKeyword
-        && node.arguments.length === 1) {
+      } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        if (node.arguments.length < 1 || node.arguments.length > 2) throw new Error(`Dynamic import must have one or two arguments: ${path.relative(root, file)}`)
+        if (!ts.isStringLiteralLike(node.arguments[0])) throw new Error(`Dynamic import specifier must be a string literal: ${path.relative(root, file)}`)
         addModuleSpecifier(node.arguments[0])
       }
       ts.forEachChild(node, visitNode)

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process"
 import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
+import ts from "typescript"
 
 const repoRoot = process.cwd()
 const managementApiOrigin = "https://api.supabase.com"
@@ -53,8 +54,38 @@ export function expectedSourceClosure(functionName, root = repoRoot) {
   const visit = (file) => {
     if (visited.has(file)) return
     visited.add(file)
+    if (path.extname(file) === ".json") return
     const source = readFileSync(file, "utf8")
-    const imports = [...source.matchAll(/(?:from\s*|import\s*|import\s*\(\s*)["']([^"']+)["']/g)].map((match) => match[1])
+    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS)
+    if (sourceFile.parseDiagnostics.length) throw new Error(`Unable to derive runtime source closure from invalid syntax: ${path.relative(root, file)}`)
+    const imports = []
+    const addModuleSpecifier = (node) => {
+      if (node && ts.isStringLiteralLike(node)) imports.push(node.text)
+    }
+    const visitNode = (node) => {
+      if (ts.isImportDeclaration(node)) {
+        const clause = node.importClause
+        const onlyInlineTypes = clause
+          && !clause.name
+          && clause.namedBindings
+          && ts.isNamedImports(clause.namedBindings)
+          && clause.namedBindings.elements.length > 0
+          && clause.namedBindings.elements.every((element) => element.isTypeOnly)
+        if (!clause?.isTypeOnly && !onlyInlineTypes) addModuleSpecifier(node.moduleSpecifier)
+      } else if (ts.isExportDeclaration(node)) {
+        const onlyInlineTypes = node.exportClause
+          && ts.isNamedExports(node.exportClause)
+          && node.exportClause.elements.length > 0
+          && node.exportClause.elements.every((element) => element.isTypeOnly)
+        if (!node.isTypeOnly && !onlyInlineTypes) addModuleSpecifier(node.moduleSpecifier)
+      } else if (ts.isCallExpression(node)
+        && node.expression.kind === ts.SyntaxKind.ImportKeyword
+        && node.arguments.length === 1) {
+        addModuleSpecifier(node.arguments[0])
+      }
+      ts.forEachChild(node, visitNode)
+    }
+    visitNode(sourceFile)
     for (const specifier of imports) {
       const dependency = resolveRepoImport(file, specifier, root)
       if (dependency) visit(dependency)

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -48,6 +48,7 @@ describe("Supabase Management API function source read-back", () => {
           'export { type MixedExportType, reExportValue } from "../../../lib/re-export-mixed.ts"',
           'export * from "../../../lib/re-export-all.ts"',
           'void import("../../../lib/dynamic.ts")',
+          'void import("../../../lib/dynamic-json.json", { with: { type: "json" } })',
           "void mixedValue",
         ].join("\n"),
         "lib/pure.ts": "export type Pure = string\n",
@@ -58,12 +59,14 @@ describe("Supabase Management API function source read-back", () => {
         "lib/re-export-mixed.ts": "export type MixedExportType = string; export const reExportValue = 1\n",
         "lib/re-export-all.ts": "export const reExportAllValue = 1\n",
         "lib/dynamic.ts": "export const dynamicValue = 1\n",
+        "lib/dynamic-json.json": "{\"runtime\":true}\n",
       }
       for (const [relative, contents] of Object.entries(files)) {
         mkdirSync(path.dirname(path.join(root, relative)), { recursive: true })
         writeFileSync(path.join(root, relative), contents)
       }
       expect(expectedSourceClosure("example", root)).toEqual([
+        "lib/dynamic-json.json",
         "lib/dynamic.ts",
         "lib/mixed.ts",
         "lib/re-export-all.ts",
@@ -83,6 +86,21 @@ describe("Supabase Management API function source read-back", () => {
       mkdirSync(path.dirname(entrypoint), { recursive: true })
       writeFileSync(entrypoint, 'import { broken from "../../../lib/value.ts"\n')
       expect(() => expectedSourceClosure("example", root)).toThrow("invalid syntax")
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    ["nonliteral", "const specifier = '../../../lib/value.ts'; void import(specifier)", /string literal/],
+    ["over-arity", "void import('../../../lib/value.ts', {}, {})", /invalid syntax|one or two arguments/],
+  ])("fails closed on %s dynamic imports", (_label, source, expectedError) => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fundloop-runtime-dynamic-invalid-"))
+    try {
+      const entrypoint = path.join(root, "supabase/functions/example/index.ts")
+      mkdirSync(path.dirname(entrypoint), { recursive: true })
+      writeFileSync(entrypoint, source)
+      expect(() => expectedSourceClosure("example", root)).toThrow(expectedError)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -1,6 +1,8 @@
-import { readFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
 import { describe, expect, it, vi } from "vitest"
-import { expectedSourceClosure, parseFunctionSourceResponse, verifyDownloadedSource } from "../scripts/verify-supabase-function-parity.mjs"
+import { expectedFunctionNames, expectedSourceClosure, parseFunctionSourceResponse, verifyDownloadedSource } from "../scripts/verify-supabase-function-parity.mjs"
 
 type Part = { headers: Record<string, string>, body: string | Buffer }
 
@@ -31,6 +33,71 @@ function file(path: string, body: string | Buffer = "export {}\n", extraHeaders:
 }
 
 describe("Supabase Management API function source read-back", () => {
+  it("derives runtime-only TypeScript dependency edges without concessions", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fundloop-runtime-closure-"))
+    try {
+      const functionDir = path.join(root, "supabase/functions/example")
+      mkdirSync(functionDir, { recursive: true })
+      const files: Record<string, string> = {
+        "supabase/functions/example/index.ts": [
+          'import type { Pure } from "../../../lib/pure.ts"',
+          'import { type InlineOnly } from "../../../lib/inline-only.ts"',
+          'import { type MixedType, mixedValue } from "../../../lib/mixed.ts"',
+          'import "../../../lib/side-effect.ts"',
+          'export type { ReExportType } from "../../../lib/re-export-type.ts"',
+          'export { type MixedExportType, reExportValue } from "../../../lib/re-export-mixed.ts"',
+          'export * from "../../../lib/re-export-all.ts"',
+          'void import("../../../lib/dynamic.ts")',
+          "void mixedValue",
+        ].join("\n"),
+        "lib/pure.ts": "export type Pure = string\n",
+        "lib/inline-only.ts": "export type InlineOnly = string\n",
+        "lib/mixed.ts": "export type MixedType = string; export const mixedValue = 1\n",
+        "lib/side-effect.ts": "globalThis.runtimeSideEffect = true\n",
+        "lib/re-export-type.ts": "export type ReExportType = string\n",
+        "lib/re-export-mixed.ts": "export type MixedExportType = string; export const reExportValue = 1\n",
+        "lib/re-export-all.ts": "export const reExportAllValue = 1\n",
+        "lib/dynamic.ts": "export const dynamicValue = 1\n",
+      }
+      for (const [relative, contents] of Object.entries(files)) {
+        mkdirSync(path.dirname(path.join(root, relative)), { recursive: true })
+        writeFileSync(path.join(root, relative), contents)
+      }
+      expect(expectedSourceClosure("example", root)).toEqual([
+        "lib/dynamic.ts",
+        "lib/mixed.ts",
+        "lib/re-export-all.ts",
+        "lib/re-export-mixed.ts",
+        "lib/side-effect.ts",
+        "supabase/functions/example/index.ts",
+      ])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it("fails closed when a reviewed module cannot be parsed", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "fundloop-runtime-closure-invalid-"))
+    try {
+      const entrypoint = path.join(root, "supabase/functions/example/index.ts")
+      mkdirSync(path.dirname(entrypoint), { recursive: true })
+      writeFileSync(entrypoint, 'import { broken from "../../../lib/value.ts"\n')
+      expect(() => expectedSourceClosure("example", root)).toThrow("invalid syntax")
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it("derives runtime closures for all functions and omits erased Supabase types from admin reconciliation", () => {
+    const names = expectedFunctionNames()
+    expect(names).toHaveLength(62)
+    for (const name of names) expect(expectedSourceClosure(name).length).toBeGreaterThan(0)
+    const adminClosure = expectedSourceClosure("admin-onchain-payment-reconciliation-run")
+    expect(adminClosure).not.toContain("types/supabase.ts")
+    expect(adminClosure).toContain("lib/onchain/payment-reconciliation.ts")
+    expect(adminClosure).toContain("lib/payments/admin-payment-operations-command.ts")
+  })
+
   it("accepts the official multipart response and strips only the known monorepo root", async () => {
     const expected = ["lib/edge-functions/result.ts", "supabase/functions/example/index.ts"]
     const parsed = await parseFunctionSourceResponse(multipart([


### PR DESCRIPTION
## Summary

- Derives expected Edge Function sources from the TypeScript runtime dependency graph rather than lexical import matching.
- Excludes only compile-time-erased type-only edges while retaining every supported runtime import and re-export form.
- Fails closed on invalid syntax and ambiguous/nonliteral dynamic imports.

## Objective

Complete Task #160 after merge run 31638236632 proved exact schema and 62-function inventory parity but showed the verifier incorrectly expected `types/supabase.ts`, referenced only by erased `import type` edges and correctly absent from Supabase runtime bundles.

## Changes

- Uses the pinned TypeScript AST to classify import/export edges.
- Omits whole type-only and all-inline-type import/export declarations.
- Includes default, namespace, mixed type/value, side-effect, value/mixed re-export, export-star, one-argument dynamic, and two-argument dynamic imports with runtime attributes.
- Treats JSON dependencies as byte-bound runtime leaves.
- Rejects parse diagnostics, nonliteral dynamic specifiers, and unsupported dynamic-import arity.
- Updates focused fixtures, deployment documentation, and Sprint #155 session logs.

## Validation

- Independent issue-validator verdict: PASS at `8bf7a26e52b902b78615bcff181fcbaf3bfde88e`.
- Node 22 focused source-readback and delivery-parity suites: 41/41 passed.
- All 62 real function closures derive; admin reconciliation has 17 runtime files, excludes `types/supabase.ts`, and retains the reviewed runtime payment modules.
- Focused ESLint, full typecheck, Node syntax, workflow YAML parse, and branch diff-check passed.

## Reviewer Notes

- Review `95ecd23` for the AST runtime graph, then `8bf7a26` for the validator-requested dynamic import-attributes coverage.
- There is no filename allowlist or remote-source concession; every derived runtime file remains path- and byte-compared.
- No migrations, function source, deployment target, Production control, payout control, cutover control, or real-value-flow behavior changes.

## Follow-ups

- After green review and merge, require the CI-owned Dev run to verify exact migration/schema parity, all 62 runtime source closures, and the safe unauthorized smoke.
- Do not start #161 until that hosted evidence passes.

Closes no issue; advances #160.
