### PR TITLE
fix(supabase): bind inline-type module edges (#160)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -825,6 +825,51 @@ syntax impossible to silently ignore.
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
 
+### session v19: Bind inline-type module edges retained by Supabase (#160)
+
+- Timestamp: 2026-08-12T17:01:05-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-inline-type-module-recovery`
+- Head: `b10c0db3d2d0a8cf6589ad3a47b68b5ddd3765ba`
+
+#### Objective
+
+Match Supabase's observed bundle closure by retaining ordinary module declarations
+whose named bindings are all inline `type`, without restoring erased whole-declaration
+type imports.
+
+#### Actions Taken
+
+- Narrowed exclusion to `ImportClause.isTypeOnly` and `ExportDeclaration.isTypeOnly`,
+  the AST representation of whole `import type` and `export type` declarations.
+- Kept every ordinary import/export declaration bound even when all named specifiers
+  use inline `type`, while preserving all prior runtime, dynamic, JSON, and fail-closed
+  behavior.
+- Updated the synthetic graph so inline-only import and re-export modules are included
+  while whole-declaration type-only modules remain omitted.
+- Proved all 62 closures derive and admin reconciliation includes reviewed
+  `lib/onchain/payment-submissions.ts` but excludes whole-declaration-only
+  `types/supabase.ts`. Updated the deployment runbook.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused source-readback and delivery-parity suites, 41/41 tests.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse,
+  and `git diff --check`.
+- No remote request or mutation, workflow, push, PR, Project status change, Production
+  action, #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+Supabase's bundle preserves module edges from ordinary declarations even when their
+bindings are inline types. The verifier must follow observed compiler semantics at
+the declaration level rather than infer erasure from individual specifiers.
+
+#### Suggested Next Steps
+
+- Return this commit to independent validation, then require CI-owned all-function
+  read-back and safe Dev smoke before advancing #160.
+
 ### session v18: Fail closed on ambiguous dynamic imports (#160)
 
 - Timestamp: 2026-08-12T16:45:15-04:00

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -198,9 +198,10 @@ history and zero normalized schema drift.
 The expected function closure is derived with the repo-pinned TypeScript compiler
 API after `pnpm install --frozen-lockfile`. It follows side-effect imports, dynamic
 imports, value imports/re-exports, mixed clauses containing any value binding, and
-runtime JSON assets. Whole `import type` / `export type` clauses and named clauses
-whose bindings are all explicitly `type` are excluded because Deno erases those
-modules from the deployed runtime bundle. Parse diagnostics fail closed, and the Deno
+runtime JSON assets. Only declarations using the whole-declaration `import type` or
+`export type` form are excluded. Ordinary import/export
+declarations remain bound even when every named specifier uses inline `type`, matching
+the Supabase bundle's retained module closure. Parse diagnostics fail closed, and the Deno
 module-graph preflight still runs before migration or function mutation. This is a
 language-semantic graph rule, not a path or remote-content allowlist.
 Dynamic imports accept the standard string-literal one-argument form and two-argument

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -65,19 +65,9 @@ export function expectedSourceClosure(functionName, root = repoRoot) {
     const visitNode = (node) => {
       if (ts.isImportDeclaration(node)) {
         const clause = node.importClause
-        const onlyInlineTypes = clause
-          && !clause.name
-          && clause.namedBindings
-          && ts.isNamedImports(clause.namedBindings)
-          && clause.namedBindings.elements.length > 0
-          && clause.namedBindings.elements.every((element) => element.isTypeOnly)
-        if (!clause?.isTypeOnly && !onlyInlineTypes) addModuleSpecifier(node.moduleSpecifier)
+        if (!clause?.isTypeOnly) addModuleSpecifier(node.moduleSpecifier)
       } else if (ts.isExportDeclaration(node)) {
-        const onlyInlineTypes = node.exportClause
-          && ts.isNamedExports(node.exportClause)
-          && node.exportClause.elements.length > 0
-          && node.exportClause.elements.every((element) => element.isTypeOnly)
-        if (!node.isTypeOnly && !onlyInlineTypes) addModuleSpecifier(node.moduleSpecifier)
+        if (!node.isTypeOnly) addModuleSpecifier(node.moduleSpecifier)
       } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
         if (node.arguments.length < 1 || node.arguments.length > 2) throw new Error(`Dynamic import must have one or two arguments: ${path.relative(root, file)}`)
         if (!ts.isStringLiteralLike(node.arguments[0])) throw new Error(`Dynamic import specifier must be a string literal: ${path.relative(root, file)}`)

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -45,6 +45,7 @@ describe("Supabase Management API function source read-back", () => {
           'import { type MixedType, mixedValue } from "../../../lib/mixed.ts"',
           'import "../../../lib/side-effect.ts"',
           'export type { ReExportType } from "../../../lib/re-export-type.ts"',
+          'export { type InlineReExportOnly } from "../../../lib/re-export-inline-only.ts"',
           'export { type MixedExportType, reExportValue } from "../../../lib/re-export-mixed.ts"',
           'export * from "../../../lib/re-export-all.ts"',
           'void import("../../../lib/dynamic.ts")',
@@ -56,6 +57,7 @@ describe("Supabase Management API function source read-back", () => {
         "lib/mixed.ts": "export type MixedType = string; export const mixedValue = 1\n",
         "lib/side-effect.ts": "globalThis.runtimeSideEffect = true\n",
         "lib/re-export-type.ts": "export type ReExportType = string\n",
+        "lib/re-export-inline-only.ts": "export type InlineReExportOnly = string\n",
         "lib/re-export-mixed.ts": "export type MixedExportType = string; export const reExportValue = 1\n",
         "lib/re-export-all.ts": "export const reExportAllValue = 1\n",
         "lib/dynamic.ts": "export const dynamicValue = 1\n",
@@ -68,8 +70,10 @@ describe("Supabase Management API function source read-back", () => {
       expect(expectedSourceClosure("example", root)).toEqual([
         "lib/dynamic-json.json",
         "lib/dynamic.ts",
+        "lib/inline-only.ts",
         "lib/mixed.ts",
         "lib/re-export-all.ts",
+        "lib/re-export-inline-only.ts",
         "lib/re-export-mixed.ts",
         "lib/side-effect.ts",
         "supabase/functions/example/index.ts",
@@ -112,6 +116,7 @@ describe("Supabase Management API function source read-back", () => {
     for (const name of names) expect(expectedSourceClosure(name).length).toBeGreaterThan(0)
     const adminClosure = expectedSourceClosure("admin-onchain-payment-reconciliation-run")
     expect(adminClosure).not.toContain("types/supabase.ts")
+    expect(adminClosure).toContain("lib/onchain/payment-submissions.ts")
     expect(adminClosure).toContain("lib/onchain/payment-reconciliation.ts")
     expect(adminClosure).toContain("lib/payments/admin-payment-operations-command.ts")
   })


### PR DESCRIPTION
## Summary

- Aligns expected Edge Function source closures with the Supabase bundler handling of inline type specifiers.
- Keeps modules referenced by ordinary import/export declarations, even when every named specifier is inline `type`.
- Continues to omit only whole-declaration `import type` and `export type` edges.

## Objective

Complete Task #160 after merge run 31639741059 proved exact schema and 62-function inventory parity but returned reviewed `lib/onchain/payment-submissions.ts` as an extra. That module is referenced by an ordinary inline-type-only import, which Supabase preserves in its source bundle; whole-declaration type imports remain omitted.

## Changes

- Removes the incorrect all-inline-type omission from the TypeScript AST graph.
- Retains ordinary inline-only import and export module edges for exact path/byte binding.
- Keeps whole-declaration type-only omission, runtime imports, dynamic imports, JSON leaves, and fail-closed parsing unchanged.
- Updates focused fixtures, the deployment runbook, and Sprint #155 session log.

## Validation

- Independent issue-validator verdict: PASS at `bb940f2e303ee7a8390cc4ae2d205fd57f63e218`.
- Node 22 focused source-readback and delivery-parity suites: 41/41 passed.
- All 62 closures derive; admin reconciliation includes `lib/onchain/payment-submissions.ts` and excludes `types/supabase.ts`.
- Focused ESLint, full typecheck, Node syntax, workflow YAML parse, and diff-check passed.
- Independent disposable AST matrix covered whole type-only omission, inline-only inclusion, all runtime import/export forms, dynamic JSON attributes, and fail-closed dynamic imports.

## Reviewer Notes

- This is a one-condition correction backed by two sequential hosted observations; there is no path allowlist or remote concession.
- Every included module remains exact path- and byte-compared.
- No migrations, function source, deployment target, Production control, payout/cutover control, or real-value-flow behavior changes.

## Follow-ups

- After green review and merge, require exact CI-owned Dev schema/migration/all-62 source parity and safe unauthorized smoke.
- Do not start #161 until that hosted evidence passes.

Closes no issue; advances #160.
