### PR TITLE
fix(edge): enforce authenticated epoch close smoke (#160)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -825,6 +825,59 @@ syntax impossible to silently ignore.
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
 
+### session v20: Enforce authenticated Edge smoke semantics (#160)
+
+- Timestamp: 2026-08-12T17:28:03-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-safe-auth-smoke-recovery`
+- Head: `5e2a5fef76575c9cac08af440acb5b21656491aa`
+
+#### Objective
+
+Make the safe unauthenticated Dev smoke prove the function's own authorization
+boundary with HTTP `401`, without exposing payload validation or changing gateway JWT
+mode.
+
+#### Actions Taken
+
+- Added a repo-owned authenticated POST HTTP boundary used by
+  `epoch-allocation-close`: OPTIONS remains public, then authentication runs before
+  method and command-body handling.
+- Returned fixed, non-provider-controlled envelopes with `401` for unauthenticated
+  requests, `405` plus `Allow: POST` for authenticated non-POST requests, and `400`
+  for authenticated invalid JSON/command payloads. Authentication infrastructure
+  failures return a generic `500`.
+- Made authenticated non-admin operator actions explicitly `403`; preserved all
+  existing downstream domain/RPC failure envelope status behavior to minimize scope.
+- Added injected-auth tests of the actual shared HTTP handler used by the Edge wrapper,
+  including an unauthenticated malformed POST whose downstream parser spy remains
+  untouched. Added wrapper ordering/status contract assertions and documented why
+  `verify_jwt=false` remains intentional.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused HTTP, epoch-close contract, and delivery-parity suites,
+  21/21 tests; focused ESLint and TypeScript typecheck.
+- Passed: Deno check of `epoch-allocation-close`, workflow YAML parse, and
+  `git diff --check`.
+- Tests prove unauthenticated GET and malformed POST return `401`, authenticated GET
+  returns `405`, authenticated malformed POST returns `400`, OPTIONS skips auth,
+  forbidden returns `403`, and provider-controlled auth error text is never echoed.
+- No remote request or mutation, workflow, push, PR, Project status change, Production
+  action, #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+An auth smoke is meaningful only when the application handler—not merely the gateway—
+returns an explicit denial. Authenticating before parsing also prevents unauthenticated
+callers from using validation differences as a command-shape oracle.
+
+#### Suggested Next Steps
+
+- Return this commit to independent validation, then require the CI-owned Dev deploy
+  to complete exact parity and observe the unauthenticated `401` smoke.
+- Keep #160 In Progress until that hosted run passes.
+
 ### session v19: Bind inline-type module edges retained by Supabase (#160)
 
 - Timestamp: 2026-08-12T17:01:05-04:00

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -216,6 +216,14 @@ call to `epoch-allocation-close`; only the expected `401` denial counts as the
 remote-safe smoke. Workflow success without these read-backs and smoke is not Dev
 parity.
 
+`epoch-allocation-close` intentionally retains `verify_jwt = false` because its
+repo-owned handler authenticates the supported bearer token formats. Except for
+`OPTIONS`, authentication runs before method and payload handling: unauthenticated
+GET or POST receives `401` without revealing payload validation, authenticated
+non-POST receives `405` with `Allow: POST`, malformed authenticated JSON/input receives
+`400`, and authenticated non-admin operator actions receive `403`. Existing domain and
+RPC failure envelope status behavior is otherwise unchanged.
+
 FundLoop no longer keeps a function-local CUBID mirror under `supabase/functions/_vendor/`. CUBID server and Edge code imports the runtime-agnostic `@cubid/core` package, and the Supabase Deno import map resolves it through `jsr:@cubid/core@0.1.0`. Browser-only CUBID compatibility helpers may still depend on local vendored tarballs, but Edge Functions must not depend on `node_modules/@cubid/api/dist/index.mjs`.
 
 The workflow pins Supabase CLI `2.113.0` instead of using `latest`. Any future pin

--- a/lib/edge-functions/authenticated-command-http.ts
+++ b/lib/edge-functions/authenticated-command-http.ts
@@ -1,0 +1,36 @@
+import { edgeCommandFailure } from "./result.ts"
+
+const corsHeaders = {
+  "content-type": "application/json",
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST, OPTIONS",
+  "access-control-allow-headers": "authorization,apikey,content-type",
+}
+
+export function commandFailure(code: string, message: string, status: number, headers?: HeadersInit) {
+  return new Response(JSON.stringify(edgeCommandFailure(code, message)), {
+    status,
+    headers: { ...corsHeaders, ...(headers ?? {}) },
+  })
+}
+
+export async function handleRequest(
+  request: Request,
+  authenticate: (request: Request) => Promise<any>,
+  handle: (auth: any) => Promise<Response>,
+) {
+  if (request.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
+  let auth
+  try {
+    auth = await authenticate(request)
+  } catch {
+    return commandFailure("authentication_failed", "Authentication could not be completed.", 500)
+  }
+  if (!auth.ok || !auth.user) {
+    const code = auth.code ?? "authentication_failed"
+    const message = code === "not_authenticated" ? "User not authenticated." : "Authentication could not be completed."
+    return commandFailure(code, message, code === "not_authenticated" ? 401 : 500)
+  }
+  if (request.method !== "POST") return commandFailure("method_not_allowed", "POST required.", 405, { Allow: "POST" })
+  return handle(auth)
+}

--- a/supabase/functions/epoch-allocation-close/index.ts
+++ b/supabase/functions/epoch-allocation-close/index.ts
@@ -1,5 +1,6 @@
 import { calculateFundedRedistributionV2, type FundedRedistributionV2Input } from "../../../lib/monthly-cycles/funded-redistribution-v2-calculator.ts"
 import { validateEpochAllocationCloseInput } from "../../../lib/edge-functions/epoch-allocation-close-contract.ts"
+import { handleRequest as handleAuthenticatedHttpRequest, commandFailure } from "../../../lib/edge-functions/authenticated-command-http.ts"
 import { edgeCommandFailure, edgeCommandSuccess } from "../../../lib/edge-functions/result.ts"
 import { isInternalAdminEmail } from "../../../lib/internal-admin-emails.ts"
 import { authenticateRequest, getEnv, json, parseJsonBody, serve } from "../_shared/command-runtime.ts"
@@ -9,78 +10,79 @@ function environment() { return (getEnv("FUNDLOOP_DEPLOYMENT_ENV") ?? "productio
 function errorCode(message: string) {
   return message.match(/epoch_close_[a-z0-9_]+/)?.[0] ?? message.match(/funded_allocation_v2_[a-z0-9_]+/)?.[0] ?? "epoch_close_failed"
 }
+function failure(code: string, message: string, status: number, headers?: HeadersInit) {
+  return commandFailure(code, message, status, headers)
+}
 
-async function handleRequest(request: Request) {
-  if (request.method === "OPTIONS") return new Response("ok", { headers: { "access-control-allow-origin": "*", "access-control-allow-headers": "authorization,apikey,content-type" } })
-  if (request.method !== "POST") return json(edgeCommandFailure("method_not_allowed", "POST required."))
-  const parsed = await parseJsonBody(request)
-  if (!parsed.ok) return json(edgeCommandFailure("invalid_payload", parsed.error ?? "Request body must be valid JSON."))
-  const validated = validateEpochAllocationCloseInput(parsed.body)
-  if (!validated.ok) return json(validated)
-  const auth = await authenticateRequest(request)
-  if (!auth.ok || !auth.user) return json(edgeCommandFailure(auth.code ?? "not_authenticated", auth.error))
-  const deploymentEnvironment = environment()
-  if (!allowedEnvironments.has(deploymentEnvironment)) return json(edgeCommandFailure("epoch_close_runtime_disabled", "Epoch close posting is unavailable in production."))
-  const input = validated.data
-  const internalAdmin = isInternalAdminEmail(auth.user.email ?? null, getEnv("FUNDLOOP_INTERNAL_ADMIN_EMAILS"))
-  if (input.action === "read") {
-    if (input.scope === "operator") {
-      if (!internalAdmin) return json(edgeCommandFailure("forbidden", "Internal operator access is required."))
-      const { data, error } = await auth.adminClient.from("epoch_close_operator_view").select("*").eq("cycle_key", input.cycleKey)
-      if (error) return json(edgeCommandFailure("epoch_close_read_failed", error.message))
-      return json(edgeCommandSuccess({ action: "read", scope: input.scope, rows: data ?? [] }))
+async function handleRequest(request: Request, dependencies = { authenticateRequest }) {
+  return handleAuthenticatedHttpRequest(request, dependencies.authenticateRequest, async (auth) => {
+    const parsed = await parseJsonBody(request)
+    if (!parsed.ok) return failure("invalid_payload", parsed.error ?? "Request body must be valid JSON.", 400)
+    const validated = validateEpochAllocationCloseInput(parsed.body)
+    if (!validated.ok) return json(validated, { status: 400 })
+    const deploymentEnvironment = environment()
+    if (!allowedEnvironments.has(deploymentEnvironment)) return json(edgeCommandFailure("epoch_close_runtime_disabled", "Epoch close posting is unavailable in production."))
+    const input = validated.data
+    const internalAdmin = isInternalAdminEmail(auth.user.email ?? null, getEnv("FUNDLOOP_INTERNAL_ADMIN_EMAILS"))
+    if (input.action === "read") {
+      if (input.scope === "operator") {
+        if (!internalAdmin) return failure("forbidden", "Internal operator access is required.", 403)
+        const { data, error } = await auth.adminClient.from("epoch_close_operator_view").select("*").eq("cycle_key", input.cycleKey)
+        if (error) return json(edgeCommandFailure("epoch_close_read_failed", error.message))
+        return json(edgeCommandSuccess({ action: "read", scope: input.scope, rows: data ?? [] }))
+      }
+      let projectId: number | null = null
+      if (input.scope === "project") {
+        const project = await auth.adminClient.from("projects").select("id").eq("slug", input.projectSlug).maybeSingle()
+        if (project.error || !project.data) return json(edgeCommandFailure("epoch_close_project_unavailable", "Project not found."))
+        projectId = project.data.id
+      }
+      const result = await auth.adminClient.rpc("read_epoch_close_scope", { p_actor_user_id: auth.user.id, p_scope: input.scope, p_cycle_key: input.cycleKey, p_project_id: projectId })
+      if (result.error) return json(edgeCommandFailure(errorCode(result.error.message), result.error.message))
+      return json(edgeCommandSuccess({ action: "read", scope: input.scope, rows: Array.isArray(result.data) ? result.data : [] }))
     }
-    let projectId: number | null = null
-    if (input.scope === "project") {
-      const project = await auth.adminClient.from("projects").select("id").eq("slug", input.projectSlug).maybeSingle()
-      if (project.error || !project.data) return json(edgeCommandFailure("epoch_close_project_unavailable", "Project not found."))
-      projectId = project.data.id
+    if (!internalAdmin) return failure("forbidden", "Internal operator access is required.", 403)
+    if (input.action === "confirm_root") {
+      const confirmed = await auth.adminClient.rpc("confirm_epoch_allocation_close_root", { p_command: {
+        contractVersion: "epoch_allocation_close_root.v1", deploymentEnvironment, actorUserId: auth.user.id,
+        closePackageId: input.closePackageId, rootHash: input.rootHash,
+      } })
+      if (confirmed.error) return json(edgeCommandFailure(errorCode(confirmed.error.message), confirmed.error.message))
+      return json(edgeCommandSuccess({ action: "confirm_root", ...(confirmed.data as Record<string, unknown>) }))
     }
-    const result = await auth.adminClient.rpc("read_epoch_close_scope", { p_actor_user_id: auth.user.id, p_scope: input.scope, p_cycle_key: input.cycleKey, p_project_id: projectId })
-    if (result.error) return json(edgeCommandFailure(errorCode(result.error.message), result.error.message))
-    return json(edgeCommandSuccess({ action: "read", scope: input.scope, rows: Array.isArray(result.data) ? result.data : [] }))
-  }
-  if (!internalAdmin) return json(edgeCommandFailure("forbidden", "Internal operator access is required."))
-  if (input.action === "confirm_root") {
-    const confirmed = await auth.adminClient.rpc("confirm_epoch_allocation_close_root", { p_command: {
-      contractVersion: "epoch_allocation_close_root.v1", deploymentEnvironment, actorUserId: auth.user.id,
-      closePackageId: input.closePackageId, rootHash: input.rootHash,
-    } })
-    if (confirmed.error) return json(edgeCommandFailure(errorCode(confirmed.error.message), confirmed.error.message))
-    return json(edgeCommandSuccess({ action: "confirm_root", ...(confirmed.data as Record<string, unknown>) }))
-  }
-  const cycle = await auth.adminClient.from("monthly_cycles").select("id").eq("cycle_key", input.cycleKey).maybeSingle()
-  if (cycle.error || !cycle.data) return json(edgeCommandFailure("epoch_close_cycle_invalid", "Cycle not found."))
-  const locked = await auth.adminClient.from("epoch_allocation_manifests")
-    .select("id,manifest_hash,manifest,status")
-    .eq("monthly_cycle_id", cycle.data.id)
-    .eq("policy_key", "settled_cubid_redistribution_v2")
-    .order("version", { ascending: false })
-    .limit(1)
-    .maybeSingle()
-  if (locked.error || !locked.data || !["locked", "calculated"].includes(locked.data.status)) {
-    return json(edgeCommandFailure("epoch_close_v2_manifest_unavailable", "A selected and calculated v2 allocation manifest is required."))
-  }
-  const manifest = {
-    manifestId: locked.data.id,
-    manifestHash: locked.data.manifest_hash,
-    manifest: locked.data.manifest as Omit<FundedRedistributionV2Input, "manifestHash">,
-  }
-  const run = await auth.adminClient.from("epoch_allocation_runs").select("id,result_hash").eq("manifest_id", manifest.manifestId).maybeSingle()
-  if (run.error || !run.data) return json(edgeCommandFailure("epoch_close_run_unavailable", "A persisted allocation result is required."))
-  try {
-    const rerun = await calculateFundedRedistributionV2({ ...manifest.manifest, manifestHash: manifest.manifestHash })
-    if (rerun.resultHash !== run.data.result_hash) return json(edgeCommandFailure("epoch_close_deterministic_rerun_mismatch", "The independent deterministic rerun did not match the persisted result."))
-    const approved = await auth.adminClient.rpc("approve_epoch_allocation_close_v2", { p_command: {
-      contractVersion: "epoch_allocation_close.v2", deploymentEnvironment, actorUserId: auth.user.id, runId: run.data.id,
-      manifestHash: manifest.manifestHash, resultHash: run.data.result_hash, rerunResultHash: rerun.resultHash,
-    } })
-    if (approved.error) return json(edgeCommandFailure(errorCode(approved.error.message), approved.error.message))
-    return json(edgeCommandSuccess({ action: "approve", ...(approved.data as Record<string, unknown>) }))
-  } catch (error) {
-    const message = error instanceof Error ? error.message : "Epoch close approval failed."
-    return json(edgeCommandFailure(errorCode(message), message))
-  }
+    const cycle = await auth.adminClient.from("monthly_cycles").select("id").eq("cycle_key", input.cycleKey).maybeSingle()
+    if (cycle.error || !cycle.data) return json(edgeCommandFailure("epoch_close_cycle_invalid", "Cycle not found."))
+    const locked = await auth.adminClient.from("epoch_allocation_manifests")
+      .select("id,manifest_hash,manifest,status")
+      .eq("monthly_cycle_id", cycle.data.id)
+      .eq("policy_key", "settled_cubid_redistribution_v2")
+      .order("version", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (locked.error || !locked.data || !["locked", "calculated"].includes(locked.data.status)) {
+      return json(edgeCommandFailure("epoch_close_v2_manifest_unavailable", "A selected and calculated v2 allocation manifest is required."))
+    }
+    const manifest = {
+      manifestId: locked.data.id,
+      manifestHash: locked.data.manifest_hash,
+      manifest: locked.data.manifest as Omit<FundedRedistributionV2Input, "manifestHash">,
+    }
+    const run = await auth.adminClient.from("epoch_allocation_runs").select("id,result_hash").eq("manifest_id", manifest.manifestId).maybeSingle()
+    if (run.error || !run.data) return json(edgeCommandFailure("epoch_close_run_unavailable", "A persisted allocation result is required."))
+    try {
+      const rerun = await calculateFundedRedistributionV2({ ...manifest.manifest, manifestHash: manifest.manifestHash })
+      if (rerun.resultHash !== run.data.result_hash) return json(edgeCommandFailure("epoch_close_deterministic_rerun_mismatch", "The independent deterministic rerun did not match the persisted result."))
+      const approved = await auth.adminClient.rpc("approve_epoch_allocation_close_v2", { p_command: {
+        contractVersion: "epoch_allocation_close.v2", deploymentEnvironment, actorUserId: auth.user.id, runId: run.data.id,
+        manifestHash: manifest.manifestHash, resultHash: run.data.result_hash, rerunResultHash: rerun.resultHash,
+      } })
+      if (approved.error) return json(edgeCommandFailure(errorCode(approved.error.message), approved.error.message))
+      return json(edgeCommandSuccess({ action: "approve", ...(approved.data as Record<string, unknown>) }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Epoch close approval failed."
+      return json(edgeCommandFailure(errorCode(message), message))
+    }
+  })
 }
 
 serve(handleRequest)

--- a/tests/epoch-allocation-close-contract.test.ts
+++ b/tests/epoch-allocation-close-contract.test.ts
@@ -30,5 +30,8 @@ describe("epoch allocation close Edge contract", () => {
     expect(source).toContain("deploymentEnvironment")
     expect(source).toContain('["local", "development", "dev", "preview", "test"]')
     expect(source).not.toContain('allowedEnvironments.add("production")')
+    expect(source.indexOf("handleAuthenticatedHttpRequest")).toBeLessThan(source.indexOf("parseJsonBody(request)"))
+    expect(source).toContain('failure("forbidden", "Internal operator access is required.", 403)')
+    expect(source).toContain('failure("invalid_payload", parsed.error ?? "Request body must be valid JSON.", 400)')
   })
 })

--- a/tests/epoch-allocation-close-http.test.ts
+++ b/tests/epoch-allocation-close-http.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest"
+import { commandFailure, handleRequest } from "@/lib/edge-functions/authenticated-command-http"
+
+function dependencies(auth: unknown) {
+  return { authenticateRequest: vi.fn().mockResolvedValue(auth) }
+}
+
+function adminAuth(email = "person@example.com") {
+  return { ok: true, user: { id: "user-1", email }, adminClient: {} }
+}
+
+const accepted = () => Promise.resolve(new Response("accepted", { status: 200 }))
+
+describe("epoch-allocation-close HTTP boundary", () => {
+  it("authenticates unauthenticated GET before method handling", async () => {
+    const auth = dependencies({ ok: false, code: "not_authenticated", error: "provider secret detail", user: null })
+    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(401)
+    expect(response.headers.get("allow")).toBeNull()
+    expect(auth.authenticateRequest).toHaveBeenCalledOnce()
+    expect(await response.clone().text()).not.toContain("provider secret detail")
+  })
+
+  it("does not parse or validate an unauthenticated POST body", async () => {
+    const auth = dependencies({ ok: false, code: "not_authenticated", error: "User not authenticated.", user: null })
+    const parsePayload = vi.fn().mockResolvedValue(commandFailure("invalid_payload", "invalid", 400))
+    const response = await handleRequest(new Request("https://example.test", { method: "POST", body: "not-json" }), auth.authenticateRequest, parsePayload)
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "not_authenticated" } })
+    expect(parsePayload).not.toHaveBeenCalled()
+  })
+
+  it("returns 405 with Allow only after authentication", async () => {
+    const auth = dependencies(adminAuth())
+    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(405)
+    expect(response.headers.get("allow")).toBe("POST")
+  })
+
+  it("preserves unauthenticated OPTIONS and rejects invalid authenticated payloads", async () => {
+    const auth = dependencies(adminAuth())
+    const options = await handleRequest(new Request("https://example.test", { method: "OPTIONS" }), auth.authenticateRequest, accepted)
+    expect(options.status).toBe(200)
+    expect(auth.authenticateRequest).not.toHaveBeenCalled()
+    const invalid = await handleRequest(new Request("https://example.test", { method: "POST", body: "not-json" }), auth.authenticateRequest, async () => commandFailure("invalid_payload", "invalid", 400))
+    expect(invalid.status).toBe(400)
+  })
+
+  it("supports an explicit 403 response from the authenticated authorization handler", async () => {
+    const auth = dependencies(adminAuth())
+    const response = await handleRequest(new Request("https://example.test", { method: "POST" }), auth.authenticateRequest,
+      async () => commandFailure("forbidden", "Internal operator access is required.", 403))
+    expect(response.status).toBe(403)
+  })
+
+  it("returns 500 when authentication infrastructure fails", async () => {
+    const auth = { authenticateRequest: vi.fn().mockRejectedValue(new Error("provider failure")) }
+    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "authentication_failed" } })
+  })
+
+  it("does not expose provider-controlled authentication failures", async () => {
+    const auth = dependencies({ ok: false, code: "provider_failure", error: "sensitive provider detail", user: null })
+    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(500)
+    expect(await response.text()).not.toContain("sensitive provider detail")
+  })
+})


### PR DESCRIPTION
## Summary
- Authenticate the `epoch-allocation-close` Edge command before method or payload handling.
- Return an exact unauthenticated HTTP 401 for the CI-owned safe Dev smoke.
- Preserve OPTIONS and existing downstream domain/RPC envelope behavior.

## Objective
Recover Task #160 after the latest Dev deployment proved exact migration, schema, inventory, and source parity but failed because the unauthenticated safe smoke received HTTP 200 instead of 401.

## Changes
- Add a repo-owned authenticated POST boundary used by the actual Edge handler.
- Return explicit 401/400/403/405 statuses at authentication, payload, authorization, and method boundaries.
- Sanitize provider-controlled authentication failures.
- Add focused ordering and response-contract tests plus deployment runbook evidence.

## Validation
- Independent issue-validator verdict: PASS.
- Node 22 focused Vitest: 21/21.
- Focused ESLint and full typecheck.
- Deno check/dependency graph for the Edge wrapper.
- Workflow YAML parse and git diff check.

## Reviewer Notes
Review the shared HTTP boundary first, then the small wrapper change in `epoch-allocation-close`. `verify_jwt=false` is intentional: the safe smoke must reach and certify the repo-owned bearer-authentication boundary. Production remains excluded by the existing runtime environment guard.

## Follow-ups
- CI-owned Dev deployment must re-prove exact 95-migration/schema parity and all 62 active function source closures.
- The safe unauthenticated hosted smoke must return exactly 401 before #160 can complete.
- This PR does not start #161, touch Production, or enable any payout/value-flow control.

Contributes to #160.
