### PR TITLE
fix(edge): reject missing Bearer credentials (#160)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -825,6 +825,44 @@ syntax impossible to silently ignore.
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
 
+### session v22: Reject control whitespace in Bearer credentials (#160)
+
+- Timestamp: 2026-08-12T17:49:39-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-missing-bearer-recovery`
+- Head: `95f66e2adac5a8e8328f508c12a7a0395a87ed8a`
+
+#### Objective
+
+Address independent validation by preventing tab/control whitespace from satisfying
+the local Bearer credential syntax gate.
+
+#### Actions Taken
+
+- Restricted the scheme/credential separator to one or more literal ASCII spaces.
+- Added adversarial cases for a tab separator and an embedded tab; both return `401`
+  before provider authentication.
+- Proved multiple literal spaces remain accepted and proceed to the provider auth
+  boundary.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused HTTP, epoch-close contract, and delivery-parity suites,
+  29/29 tests; focused ESLint and TypeScript typecheck.
+- Passed: Deno check of `epoch-allocation-close` and `git diff --check`.
+- No remote request or mutation, workflow, push, PR, Production action, #161 work, or
+  value-flow activation occurred.
+
+#### Reflections
+
+Credential grammar should accept deliberate compatibility choices, such as repeated
+literal spaces, without treating control whitespace as equivalent syntax.
+
+#### Suggested Next Steps
+
+- Return this commit to independent validation, then require CI-owned exact parity and
+  the hosted unauthenticated `401` smoke before advancing #160.
+
 ### session v21: Reject missing credentials before provider auth (#160)
 
 - Timestamp: 2026-08-12T17:44:55-04:00

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -825,6 +825,50 @@ syntax impossible to silently ignore.
   and require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
 
+### session v21: Reject missing credentials before provider auth (#160)
+
+- Timestamp: 2026-08-12T17:44:55-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-safe-auth-smoke-recovery`
+- Head: `ba6a7ae97833b3ba947bedf453b9a6fb54a59447`
+
+#### Objective
+
+Make the hosted unauthenticated GET smoke return `401` even when the Supabase auth
+client throws on a missing Authorization header.
+
+#### Actions Taken
+
+- Added a local Authorization syntax gate after OPTIONS and before provider auth.
+- Absent, blank/whitespace, non-Bearer, or Bearer-without-credentials headers now
+  return the fixed `not_authenticated` `401` envelope without calling the auth client.
+- Valid Bearer token syntax continues to provider authentication; a provider throw on
+  such a request remains a sanitized infrastructure `500`.
+- Added direct adversarial spy coverage and documented the credential/provider failure
+  distinction.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused HTTP, epoch-close contract, and delivery-parity suites,
+  26/26 tests; focused ESLint and TypeScript typecheck.
+- Passed: Deno check of `epoch-allocation-close`, workflow YAML parse, and
+  `git diff --check`.
+- Tests prove all malformed/missing credential forms return `401` with the provider
+  spy untouched, valid Bearer reaches it, and a provider throw remains sanitized.
+- No remote request or mutation, workflow, push, PR, Project status change, Production
+  action, #161 work, or value-flow activation occurred.
+
+#### Reflections
+
+Missing credentials are an authentication denial, not provider infrastructure
+failure. Classifying them before the SDK makes the hosted smoke deterministic and
+keeps operational failures distinguishable.
+
+#### Suggested Next Steps
+
+- Return this commit to independent validation, then require CI-owned exact parity and
+  the unauthenticated `401` Dev smoke before advancing #160.
+
 ### session v20: Enforce authenticated Edge smoke semantics (#160)
 
 - Timestamp: 2026-08-12T17:28:03-04:00

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -223,6 +223,10 @@ GET or POST receives `401` without revealing payload validation, authenticated
 non-POST receives `405` with `Allow: POST`, malformed authenticated JSON/input receives
 `400`, and authenticated non-admin operator actions receive `403`. Existing domain and
 RPC failure envelope status behavior is otherwise unchanged.
+Absent, blank, malformed, or non-Bearer Authorization headers are rejected locally as
+`401` before the Supabase auth client is called. Only a syntactically valid Bearer
+credential reaches provider authentication; provider transport failures remain a
+sanitized `500`, distinct from missing credentials.
 
 FundLoop no longer keeps a function-local CUBID mirror under `supabase/functions/_vendor/`. CUBID server and Edge code imports the runtime-agnostic `@cubid/core` package, and the Supabase Deno import map resolves it through `jsr:@cubid/core@0.1.0`. Browser-only CUBID compatibility helpers may still depend on local vendored tarballs, but Edge Functions must not depend on `node_modules/@cubid/api/dist/index.mjs`.
 

--- a/lib/edge-functions/authenticated-command-http.ts
+++ b/lib/edge-functions/authenticated-command-http.ts
@@ -21,7 +21,7 @@ export async function handleRequest(
 ) {
   if (request.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
   const authorization = request.headers.get("authorization")
-  if (!authorization || !/^Bearer[ \t]+[A-Za-z0-9\-._~+/]+=*$/i.test(authorization)) {
+  if (!authorization || !/^Bearer +[A-Za-z0-9\-._~+/]+=*$/i.test(authorization)) {
     return commandFailure("not_authenticated", "User not authenticated.", 401)
   }
   let auth

--- a/lib/edge-functions/authenticated-command-http.ts
+++ b/lib/edge-functions/authenticated-command-http.ts
@@ -20,6 +20,10 @@ export async function handleRequest(
   handle: (auth: any) => Promise<Response>,
 ) {
   if (request.method === "OPTIONS") return new Response("ok", { headers: corsHeaders })
+  const authorization = request.headers.get("authorization")
+  if (!authorization || !/^Bearer[ \t]+[A-Za-z0-9\-._~+/]+=*$/i.test(authorization)) {
+    return commandFailure("not_authenticated", "User not authenticated.", 401)
+  }
   let auth
   try {
     auth = await authenticate(request)

--- a/tests/epoch-allocation-close-http.test.ts
+++ b/tests/epoch-allocation-close-http.test.ts
@@ -10,11 +10,16 @@ function adminAuth(email = "person@example.com") {
 }
 
 const accepted = () => Promise.resolve(new Response("accepted", { status: 200 }))
+const request = (method: string, body?: string) => new Request("https://example.test", {
+  method,
+  body,
+  headers: { authorization: "Bearer header.payload.signature" },
+})
 
 describe("epoch-allocation-close HTTP boundary", () => {
   it("authenticates unauthenticated GET before method handling", async () => {
     const auth = dependencies({ ok: false, code: "not_authenticated", error: "provider secret detail", user: null })
-    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
     expect(response.status).toBe(401)
     expect(response.headers.get("allow")).toBeNull()
     expect(auth.authenticateRequest).toHaveBeenCalledOnce()
@@ -24,7 +29,7 @@ describe("epoch-allocation-close HTTP boundary", () => {
   it("does not parse or validate an unauthenticated POST body", async () => {
     const auth = dependencies({ ok: false, code: "not_authenticated", error: "User not authenticated.", user: null })
     const parsePayload = vi.fn().mockResolvedValue(commandFailure("invalid_payload", "invalid", 400))
-    const response = await handleRequest(new Request("https://example.test", { method: "POST", body: "not-json" }), auth.authenticateRequest, parsePayload)
+    const response = await handleRequest(request("POST", "not-json"), auth.authenticateRequest, parsePayload)
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toMatchObject({ error: { code: "not_authenticated" } })
     expect(parsePayload).not.toHaveBeenCalled()
@@ -32,7 +37,7 @@ describe("epoch-allocation-close HTTP boundary", () => {
 
   it("returns 405 with Allow only after authentication", async () => {
     const auth = dependencies(adminAuth())
-    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
     expect(response.status).toBe(405)
     expect(response.headers.get("allow")).toBe("POST")
   })
@@ -42,28 +47,49 @@ describe("epoch-allocation-close HTTP boundary", () => {
     const options = await handleRequest(new Request("https://example.test", { method: "OPTIONS" }), auth.authenticateRequest, accepted)
     expect(options.status).toBe(200)
     expect(auth.authenticateRequest).not.toHaveBeenCalled()
-    const invalid = await handleRequest(new Request("https://example.test", { method: "POST", body: "not-json" }), auth.authenticateRequest, async () => commandFailure("invalid_payload", "invalid", 400))
+    const invalid = await handleRequest(request("POST", "not-json"), auth.authenticateRequest, async () => commandFailure("invalid_payload", "invalid", 400))
     expect(invalid.status).toBe(400)
   })
 
   it("supports an explicit 403 response from the authenticated authorization handler", async () => {
     const auth = dependencies(adminAuth())
-    const response = await handleRequest(new Request("https://example.test", { method: "POST" }), auth.authenticateRequest,
+    const response = await handleRequest(request("POST"), auth.authenticateRequest,
       async () => commandFailure("forbidden", "Internal operator access is required.", 403))
     expect(response.status).toBe(403)
   })
 
   it("returns 500 when authentication infrastructure fails", async () => {
     const auth = { authenticateRequest: vi.fn().mockRejectedValue(new Error("provider failure")) }
-    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
     expect(response.status).toBe(500)
     await expect(response.json()).resolves.toMatchObject({ error: { code: "authentication_failed" } })
   })
 
   it("does not expose provider-controlled authentication failures", async () => {
     const auth = dependencies({ ok: false, code: "provider_failure", error: "sensitive provider detail", user: null })
-    const response = await handleRequest(new Request("https://example.test", { method: "GET" }), auth.authenticateRequest, accepted)
+    const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
     expect(response.status).toBe(500)
     expect(await response.text()).not.toContain("sensitive provider detail")
+  })
+
+  it.each([
+    ["absent", undefined],
+    ["blank", "   "],
+    ["wrong scheme", "Basic dXNlcjpwYXNz"],
+    ["Bearer without credentials", "Bearer   "],
+  ])("rejects %s authorization before provider auth", async (_label, authorization) => {
+    const auth = dependencies(adminAuth())
+    const headers = authorization === undefined ? undefined : { authorization }
+    const response = await handleRequest(new Request("https://example.test", { method: "GET", headers }), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "not_authenticated" } })
+    expect(auth.authenticateRequest).not.toHaveBeenCalled()
+  })
+
+  it("passes a valid Bearer credential to provider authentication", async () => {
+    const auth = dependencies(adminAuth())
+    const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(405)
+    expect(auth.authenticateRequest).toHaveBeenCalledOnce()
   })
 })

--- a/tests/epoch-allocation-close-http.test.ts
+++ b/tests/epoch-allocation-close-http.test.ts
@@ -77,6 +77,8 @@ describe("epoch-allocation-close HTTP boundary", () => {
     ["blank", "   "],
     ["wrong scheme", "Basic dXNlcjpwYXNz"],
     ["Bearer without credentials", "Bearer   "],
+    ["tab separator", "Bearer\tabc.def.ghi"],
+    ["embedded tab", "Bearer abc.def\t.ghi"],
   ])("rejects %s authorization before provider auth", async (_label, authorization) => {
     const auth = dependencies(adminAuth())
     const headers = authorization === undefined ? undefined : { authorization }
@@ -89,6 +91,16 @@ describe("epoch-allocation-close HTTP boundary", () => {
   it("passes a valid Bearer credential to provider authentication", async () => {
     const auth = dependencies(adminAuth())
     const response = await handleRequest(request("GET"), auth.authenticateRequest, accepted)
+    expect(response.status).toBe(405)
+    expect(auth.authenticateRequest).toHaveBeenCalledOnce()
+  })
+
+  it("accepts multiple literal spaces before a valid Bearer credential", async () => {
+    const auth = dependencies(adminAuth())
+    const response = await handleRequest(new Request("https://example.test", {
+      method: "GET",
+      headers: { authorization: "Bearer   abc.def.ghi" },
+    }), auth.authenticateRequest, accepted)
     expect(response.status).toBe(405)
     expect(auth.authenticateRequest).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
## Summary
- Reject missing or malformed Authorization locally before calling Supabase Auth.
- Return the safe hosted smoke's required HTTP 401 for absent credentials.
- Restrict the Bearer separator to literal spaces, excluding control-whitespace ambiguity.

## Objective
Recover Task #160 after merge run 31643321191 re-proved exact Dev database and all-function parity but returned a sanitized HTTP 500 because its no-header request reached provider authentication instead of being classified as unauthenticated.

## Changes
- Require a syntactically valid Bearer credential before provider authentication.
- Reject absent, blank, wrong-scheme, empty, tab-separated, and embedded-control credentials as `not_authenticated` 401.
- Preserve OPTIONS and sanitized provider-infrastructure 500 behavior.
- Add focused adversarial tests and operator documentation.

## Validation
- Independent issue-validator verdict: PASS after one found tab-separator blocker was fixed and revalidated.
- Node 22 focused Vitest: 29/29.
- Focused ESLint, full typecheck, Deno check, and git diff check.
- Independent Deno probes cover realistic JWT and opaque Supabase token forms, literal multi-space separators, and control-character rejection.

## Reviewer Notes
Review `authenticated-command-http.ts`, then its adversarial table. This does not validate token authenticity locally; it only distinguishes clearly missing/malformed credentials from provider authentication. Valid Bearer credentials still go to Supabase Auth.

## Follow-ups
- CI-owned Dev must again prove 95-migration/schema parity and all 62 ACTIVE function source closures.
- The unchanged safe hosted smoke must return exactly 401 before #160 can complete.
- No #161, Production, payout, cutover, or value-flow activation is included.

Contributes to #160.
