### PR TITLE
fix(ci): preserve read-only drift credentials (#161)

### DIFF
--- a/.github/workflows/supabase-drift.yml
+++ b/.github/workflows/supabase-drift.yml
@@ -71,21 +71,24 @@ jobs:
           TARGET_ENVIRONMENT: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          if [[ "${TARGET_ENVIRONMENT}" == "dev" ]]; then db_url="${DEV_SUPABASE_SESSION_POOLER_URL}"; else db_url="${MAIN_SUPABASE_SESSION_POOLER_URL}"; fi
-          [[ -n "${db_url}" ]] || { echo "::error::Missing required ${TARGET_ENVIRONMENT} read-only database credential."; exit 1; }
-          project_ref="$(DB_URL="${db_url}" node -e 'const u=new URL(process.env.DB_URL);const m=decodeURIComponent(u.username).match(/^postgres\.([a-z0-9]{20,})$/);if(!m)throw Error("invalid pooler username");console.log(m[1])')"
-          echo "db_url=${db_url}" >> "$GITHUB_OUTPUT"
+          project_ref="$(node scripts/resolve-supabase-pooler-target.mjs)"
           echo "project_ref=${project_ref}" >> "$GITHUB_OUTPUT"
           echo "observation_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Observe exact schema and migration drift
         env:
           TARGET_ENVIRONMENT: ${{ matrix.target }}
           SUPABASE_PROJECT_REF: ${{ steps.target.outputs.project_ref }}
-          SUPABASE_SCHEMA_DB_URL: ${{ steps.target.outputs.db_url }}
           SUPABASE_SCHEMA_PARITY_OUTPUT: ${{ runner.temp }}/supabase-schema-parity.json
           SUPABASE_SCHEMA_DIAGNOSTIC_OUTPUT: ${{ runner.temp }}/supabase-schema-diagnostic.json
           OBSERVATION_GIT_SHA: ${{ steps.target.outputs.observation_sha }}
-        run: node scripts/verify-supabase-schema-parity.mjs drift
+        run: |
+          set -euo pipefail
+          case "${TARGET_ENVIRONMENT}" in
+            dev) db_url="${DEV_SUPABASE_SESSION_POOLER_URL}" ;;
+            main) db_url="${MAIN_SUPABASE_SESSION_POOLER_URL}" ;;
+            *) echo "::error::Unsupported target environment."; exit 1 ;;
+          esac
+          SUPABASE_SCHEMA_DB_URL="${db_url}" node scripts/verify-supabase-schema-parity.mjs drift
       - name: Observe exact Edge Function drift
         env:
           TARGET_ENVIRONMENT: ${{ matrix.target }}

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1198,3 +1198,50 @@ every deployed value-bearing source byte.
 - Return the commit to independent validation, then let the orchestrator publish and
   require CI-owned read-back of all 62 functions plus the safe Dev smoke.
 - Keep #160 In Progress until that hosted evidence passes.
+### session v25: Preserve protected drift credentials across steps (#161)
+
+- Timestamp: 2026-08-12T18:54:20-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-drift-secret-transport-recovery`
+- Head: `f49dd54e87769ae7ed09b0631077119dca8fe4d6`
+
+#### Objective
+
+Repair the read-only Dev drift workflow after GitHub command-file transport corrupted
+a URL-encoded pooler credential, without changing Dev or weakening parity checks.
+
+#### Actions Taken
+
+- Selected the target pooler secret directly into a masked job environment variable
+  and stopped writing database URLs to `GITHUB_OUTPUT`.
+- Kept step outputs limited to the non-secret project reference and observation SHA;
+  schema observation now consumes the job-scoped secret environment value directly.
+- Replaced expression fallback with explicit Dev/Main selection, so a missing Main
+  credential fails rather than falling through to Dev.
+- Added a pre-network URL validator for Postgres protocol, trusted Supabase pooler
+  hostname, session-pooler port, database path, project username, and password.
+- Added workflow contract tests that reject secret step-output transport and documented
+  the credential boundary in the deployment runbook.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused environment-manifest and delivery-parity suites, 19/19,
+  including encoded credentials, missing Main, hostile protocols/hosts, wrong ports,
+  wrong databases, and missing passwords.
+- Passed: focused ESLint, TypeScript typecheck, workflow YAML parse, and
+  `git diff --check`.
+- The failing read-only run was transport-only: the CI-owned deploy immediately before
+  it passed exact 95-migration/schema/62-function/401/value-flow evidence. No remote
+  mutation, Production action, credential prompt, reset, or value-flow activation was
+  performed by this recovery.
+
+#### Reflections
+
+GitHub command files are not an appropriate transport for structured secrets. Keeping
+the selected URL in the masked job environment preserves its encoded authority and
+avoids accidental output serialization.
+
+#### Suggested Next Steps
+
+- Independently validate this focused recovery, publish it to `dev`, and rerun the
+  manual read-only Dev observation before advancing #161.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -75,6 +75,12 @@ developer Supabase project.
 
 - `DEV_SUPABASE_SESSION_POOLER_URL`
 - `MAIN_SUPABASE_SESSION_POOLER_URL`
+
+The read-only drift job selects exactly one target pooler secret into a masked job
+environment variable. It never writes a database URL to `GITHUB_OUTPUT` or an
+artifact; step outputs contain only the derived project reference and checkout SHA.
+This preserves URL-encoded credentials byte-for-byte across steps and keeps them out
+of GitHub's command-file transport.
 - `SUPABASE_ACCESS_TOKEN`
 
 The pooler URLs must be session-pooler Postgres connection strings with the standard Supabase username format:

--- a/scripts/resolve-supabase-pooler-target.mjs
+++ b/scripts/resolve-supabase-pooler-target.mjs
@@ -1,0 +1,33 @@
+const PROJECT_REF_PATTERN = /^[a-z0-9]{20}$/
+const TRUSTED_POOLER_HOST_PATTERN = /^(?:[a-z0-9-]+\.)+pooler\.supabase\.com$/
+
+export function resolveSupabasePoolerTarget(environment, urls) {
+  if (!['dev', 'main'].includes(environment)) throw new Error('unsupported-target-environment')
+  const rawUrl = environment === 'dev' ? urls.dev : urls.main
+  if (!rawUrl) throw new Error(`missing-${environment}-pooler-credential`)
+
+  let parsed
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new Error('invalid-pooler-url')
+  }
+  if (!['postgres:', 'postgresql:'].includes(parsed.protocol)) throw new Error('invalid-pooler-protocol')
+  if (!TRUSTED_POOLER_HOST_PATTERN.test(parsed.hostname)) throw new Error('invalid-pooler-host')
+  if (parsed.port !== '5432') throw new Error('invalid-session-pooler-port')
+  if (parsed.pathname !== '/postgres' || parsed.search || parsed.hash) throw new Error('invalid-pooler-database')
+  if (!parsed.password) throw new Error('missing-pooler-password')
+
+  const username = decodeURIComponent(parsed.username)
+  const match = username.match(/^postgres\.([a-z0-9]{20})$/)
+  if (!match || !PROJECT_REF_PATTERN.test(match[1])) throw new Error('invalid-pooler-username')
+  return { projectRef: match[1], url: rawUrl }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  const resolved = resolveSupabasePoolerTarget(process.env.TARGET_ENVIRONMENT, {
+    dev: process.env.DEV_SUPABASE_SESSION_POOLER_URL,
+    main: process.env.MAIN_SUPABASE_SESSION_POOLER_URL,
+  })
+  process.stdout.write(`${resolved.projectRef}\n`)
+}

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import { buildEnvironmentManifest, buildSafeSmokeEvidence, verifyEnvironmentManifest } from "../scripts/verify-supabase-environment-manifest.mjs"
 import { shouldObservePush, SUPABASE_DEPLOY_PATH_GLOBS } from "../scripts/classify-supabase-drift-push.mjs"
 import { expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
+import { resolveSupabasePoolerTarget } from "../scripts/resolve-supabase-pooler-target.mjs"
 
 const migration = { version: "20260812130000", name: "20260812130000_repair.sql", fileSha256: "a".repeat(64) }
 const functionEntry = (index: number) => ({
@@ -99,8 +100,32 @@ describe("immutable Supabase environment manifests", () => {
     expect(workflow).not.toContain("supabase db push")
     expect(workflow).not.toContain("supabase functions deploy")
     expect(workflow).toContain("SUPABASE_SCHEMA_DIAGNOSTIC_OUTPUT: ${{ runner.temp }}/supabase-schema-diagnostic.json")
+    expect(workflow).toContain("project_ref=\"$(node scripts/resolve-supabase-pooler-target.mjs)\"")
+    expect(workflow).toContain("main) db_url=\"${MAIN_SUPABASE_SESSION_POOLER_URL}\"")
+    expect(workflow).toContain("SUPABASE_SCHEMA_DB_URL=\"${db_url}\" node scripts/verify-supabase-schema-parity.mjs drift")
+    expect(workflow).not.toContain("TARGET_SUPABASE_SESSION_POOLER_URL")
+    expect(workflow).not.toContain("echo \"db_url=${db_url}\" >> \"$GITHUB_OUTPUT\"")
+    expect(workflow).not.toContain("steps.target.outputs.db_url")
+    expect(workflow).not.toContain("::add-mask::")
     expect(workflow).toContain("if: ${{ always() }}")
     expect(workflow).toContain("${{ runner.temp }}/supabase-schema-diagnostic.json")
+  })
+
+  it("selects exact pooler credentials and rejects hostile connection targets", () => {
+    const ref = "a".repeat(20)
+    const dev = `postgresql://postgres.${ref}:p%40ss%3Aword@aws-0-ca-central-1.pooler.supabase.com:5432/postgres`
+    const main = `postgres://postgres.${"b".repeat(20)}:main-secret@aws-0-ca-central-1.pooler.supabase.com:5432/postgres`
+    expect(resolveSupabasePoolerTarget("dev", { dev, main })).toEqual({ projectRef: ref, url: dev })
+    expect(resolveSupabasePoolerTarget("main", { dev, main }).projectRef).toBe("b".repeat(20))
+    expect(() => resolveSupabasePoolerTarget("main", { dev, main: "" })).toThrow("missing-main-pooler-credential")
+    for (const hostile of [
+      `https://postgres.${ref}:secret@aws-0-ca-central-1.pooler.supabase.com:5432/postgres`,
+      `postgresql://postgres.${ref}:secret@evil.example:5432/postgres`,
+      `postgresql://postgres.${ref}:secret@pooler.supabase.com.evil.example:5432/postgres`,
+      `postgresql://postgres.${ref}:secret@aws-0-ca-central-1.pooler.supabase.com:6543/postgres`,
+      `postgresql://postgres.${ref}:secret@aws-0-ca-central-1.pooler.supabase.com:5432/other`,
+      `postgresql://postgres.${ref}@aws-0-ca-central-1.pooler.supabase.com:5432/postgres`,
+    ]) expect(() => resolveSupabasePoolerTarget("dev", { dev: hostile, main })).toThrow()
   })
 
   it("assigns every reviewed Edge Function closure member to the deploy lane", () => {


### PR DESCRIPTION
## Summary
- keeps Supabase pooler credentials out of GitHub step-output transport
- selects Dev and Main credentials explicitly with no cross-environment fallback
- rejects untrusted or malformed pooler targets before any network command

## Objective
Recover Task #161's read-only drift observation after run 31648585608 showed that a URL-encoded Dev pooler secret was corrupted when serialized through `GITHUB_OUTPUT`.

## Changes
- add a pure pooler-target resolver that validates Postgres protocol, trusted Supabase pooler host, session port, database path, project username, and password
- keep database URLs job-scoped and pass the selected value only to the schema verifier process
- add adversarial workflow/URL tests and document the secret boundary
- record session v25 evidence

## Validation
- independent issue-validator PASS on the recovery design
- Node 22 focused Vitest: 19/19 across environment-manifest and delivery-parity suites
- focused ESLint, TypeScript typecheck, Node syntax, workflow YAML parse, and `git diff --check` passed

## Reviewer Notes
Review the workflow selection and `scripts/resolve-supabase-pooler-target.mjs` first. Main with a missing Main credential must fail; it must never fall back to Dev. The workflow remains read-only and does not deploy, repair, reset, or expose database URLs.

## Follow-ups
- merge only after review and green CI
- rerun the manual read-only Dev drift workflow and inspect its immutable observation manifest before #161 advances
- automatic `workflow_run` observation remains subject to GitHub's default-branch workflow bootstrap and will be exercised when the workflow reaches `main`
