### PR TITLE
fix(ci): use structured libpq drift credentials (#161)

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1245,3 +1245,40 @@ avoids accidental output serialization.
 
 - Independently validate this focused recovery, publish it to `dev`, and rerun the
   manual read-only Dev observation before advancing #161.
+### session v26: Remove containerized libpq URI ambiguity (#161)
+
+- Timestamp: 2026-08-12T19:20:00-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-drift-libpq-recovery`
+- Head: `8b00e245e7c8277a8fe53265b243c40d8b3d119c`
+
+#### Objective
+
+Make the read-only drift verifier preserve special-character pooler passwords when
+running PostgreSQL 17 client tools inside the disposable parity container.
+
+#### Actions Taken
+
+- Parse the already validated Postgres URL once into individual libpq fields.
+- Pass only environment variable names through `docker exec --env`; values remain in
+  the subprocess environment and never appear in command arguments or logs.
+- Run containerized `psql` and `pg_dump` without a URI, eliminating libpq authority
+  ambiguity while retaining required TLS for remote hosts and disabling it locally.
+- Added encoded password and local/remote SSL-mode contract coverage.
+
+#### Tests And Validation Notes
+
+- Passed: Node 22 focused delivery-parity suite, 13/13.
+- Passed: focused ESLint, TypeScript typecheck, Node syntax, and `git diff --check`.
+- No remote mutation, Production action, credential prompt, reset, or value-flow
+  activation was performed.
+
+#### Reflections
+
+Secrets with URI-reserved bytes should reach libpq as structured connection fields,
+not be reparsed as authority text inside another process boundary.
+
+#### Suggested Next Steps
+
+- Independently validate this focused recovery, publish to `dev`, then rerun the
+  read-only Dev drift observation against the same SHA-bound deploy baseline.

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -236,8 +236,30 @@ export function validateMigrationDeployEvidence(expected, observed) {
     && observed.inventorySha256 === expected.inventorySha256
 }
 
+export function libpqConnectionEnvironment(dbUrl) {
+  const parsed = new URL(dbUrl)
+  if (!["postgres:", "postgresql:"].includes(parsed.protocol) || !parsed.hostname || !parsed.username || !parsed.pathname.startsWith("/")) throw new Error("invalid-libpq-connection-url")
+  return {
+    PGHOST: parsed.hostname,
+    PGPORT: parsed.port || "5432",
+    PGUSER: decodeURIComponent(parsed.username),
+    PGPASSWORD: decodeURIComponent(parsed.password),
+    PGDATABASE: decodeURIComponent(parsed.pathname.slice(1)),
+    PGSSLMODE: parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" ? "disable" : "require",
+  }
+}
+
+function containerLibpqConnection(projectId, dbUrl) {
+  const env = libpqConnectionEnvironment(dbUrl)
+  return {
+    args: ["exec", ...Object.keys(env).flatMap((name) => ["--env", name]), `supabase_db_${projectId}`],
+    env: { ...process.env, ...env },
+  }
+}
+
 function dumpPublicSchemaFromParityContainer(projectId, dbUrl) {
-  return run("docker", ["exec", `supabase_db_${projectId}`, "pg_dump", "--schema-only", "--schema=public", "--no-owner", "--no-privileges", "--no-comments", dbUrl], { encoding: "utf8" })
+  const connection = containerLibpqConnection(projectId, dbUrl)
+  return run("docker", [...connection.args, "pg_dump", "--schema-only", "--schema=public", "--no-owner", "--no-privileges", "--no-comments"], { encoding: "utf8", env: connection.env })
 }
 
 function pgDumpVersionFromParityContainer(projectId) {
@@ -245,12 +267,18 @@ function pgDumpVersionFromParityContainer(projectId) {
 }
 
 function psqlFromParityContainer(projectId, dbUrl, sql) {
-  return run("docker", ["exec", `supabase_db_${projectId}`, "psql", dbUrl, "-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8" }).trim()
+  const connection = containerLibpqConnection(projectId, dbUrl)
+  return run("docker", [...connection.args, "psql", "-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8", env: connection.env }).trim()
+}
+
+function psqlFromHost(dbUrl, sql) {
+  const connection = libpqConnectionEnvironment(dbUrl)
+  return run("psql", ["-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8", env: { ...process.env, ...connection } }).trim()
 }
 
 function observedMigrationEvidence(dbUrl, binding) {
   const sql = `select json_build_object('contractVersion',contract_version,'candidateGitSha',candidate_git_sha,'actionsRunId',actions_run_id::text,'runAttempt',run_attempt,'environment',deployment_environment,'projectRef',project_ref,'migrations',migration_inventory,'inventorySha256',inventory_sha256,'recordedAt',recorded_at)::text from public.supabase_deploy_migration_evidence where candidate_git_sha='${binding.candidateGitSha}' and actions_run_id=${Number(binding.actionsRunId)} and run_attempt=${Number(binding.runAttempt)} and deployment_environment='${binding.environment}' and project_ref='${binding.projectRef}' order by recorded_at desc limit 1`
-  const output = run("psql", [dbUrl, "-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8" }).trim()
+  const output = psqlFromHost(dbUrl, sql)
   if (!output) throw new Error("unverifiable-migration-source: no candidate-bound remote deploy evidence")
   return JSON.parse(output)
 }
@@ -269,7 +297,7 @@ export function validateMatchingMigrationEvidence(evidence, binding, expectedInv
 
 function latestMatchingMigrationEvidence(dbUrl, binding, expectedInventorySha256) {
   const sql = `select json_build_object('contractVersion',contract_version,'candidateGitSha',candidate_git_sha,'actionsRunId',actions_run_id::text,'runAttempt',run_attempt,'environment',deployment_environment,'projectRef',project_ref,'migrations',migration_inventory,'inventorySha256',inventory_sha256,'recordedAt',recorded_at)::text from public.supabase_deploy_migration_evidence where deployment_environment='${binding.environment}' and project_ref='${binding.projectRef}' and inventory_sha256='${expectedInventorySha256}' order by recorded_at desc limit 1`
-  const output = run("psql", [dbUrl, "-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8" }).trim()
+  const output = psqlFromHost(dbUrl, sql)
   if (!output) throw new Error("deployment-evidence-missing: no immutable deployment record matches reviewed migration bytes")
   const evidence = JSON.parse(output)
   if (!validateMatchingMigrationEvidence(evidence, binding, expectedInventorySha256)) {
@@ -294,7 +322,7 @@ function assertValueFlowDisabledWithQuery(query) {
 }
 
 function assertValueFlowDisabled(dbUrl) {
-  return assertValueFlowDisabledWithQuery((sql) => run("psql", [dbUrl, "-X", "-v", "ON_ERROR_STOP=1", "-Atqc", sql], { encoding: "utf8" }).trim())
+  return assertValueFlowDisabledWithQuery((sql) => psqlFromHost(dbUrl, sql))
 }
 
 async function main() {

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -11,6 +11,21 @@ const retired = JSON.parse(readFileSync("supabase/retired-functions.json", "utf8
 const repairManifest = JSON.parse(readFileSync("supabase/schema-repair-manifests/20260812_dev_public_schema_drift.json", "utf8"))
 
 describe("Supabase delivery parity", () => {
+  it("passes containerized libpq credentials as fields instead of an ambiguous URI", () => {
+    expect(libpqConnectionEnvironment("postgresql://postgres.aaaaaaaaaaaaaaaaaaaa:p%40ss%3A%2F%24@aws-0-ca-central-1.pooler.supabase.com:5432/postgres")).toEqual({
+      PGHOST: "aws-0-ca-central-1.pooler.supabase.com",
+      PGPORT: "5432",
+      PGUSER: "postgres.aaaaaaaaaaaaaaaaaaaa",
+      PGPASSWORD: "p@ss:/$",
+      PGDATABASE: "postgres",
+      PGSSLMODE: "require",
+    })
+    expect(libpqConnectionEnvironment("postgresql://postgres:postgres@127.0.0.1:5432/postgres").PGSSLMODE).toBe("disable")
+    expect(schemaVerifier).not.toContain('"psql", dbUrl')
+    expect(schemaVerifier).not.toMatch(/run\("psql", \[(?:dbUrl|remoteDbUrl)/)
+    expect(schemaVerifier).not.toContain('"--no-comments", dbUrl')
+    expect(schemaVerifier).not.toContain('`PGPASSWORD=${')
+  })
   it("derives the expected function inventory and records the one reviewed retirement", () => {
     const expected = expectedFunctionNames()
     expect(expected).toHaveLength(62)


### PR DESCRIPTION
## Summary
- removes secret-bearing database URIs from all remote `psql` and `pg_dump` arguments
- passes validated connection fields through libpq environment variables
- preserves encoded/special-character credentials across host and container process boundaries

## Objective
Recover Task #161's read-only drift observation after runs 31648585608 and 31650245381 showed libpq reparsing an encoded pooler password as part of the hostname.

## Changes
- add one structured libpq connection-field helper for host and disposable-container PostgreSQL clients
- invoke host `psql` and container `psql`/`pg_dump` without remote URI arguments
- pass only environment-variable names through `docker exec`, keeping values out of command lines and error text
- add encoded credential, TLS-mode, and no-URI-argv regression coverage plus session v26

## Validation
- independent issue-validator PASS on exact commit `20374c6`
- Node 22 focused Vitest: 13/13 delivery-parity tests
- independent combined focused suites: 20/20
- focused ESLint, TypeScript typecheck, Node syntax, and `git diff --check` passed

## Reviewer Notes
Review `libpqConnectionEnvironment`, `psqlFromHost`, and `containerLibpqConnection` first. The sole direct URI remaining is the fixed, disposable local `postgres:postgres@127.0.0.1` bootstrap, not a remote credential. No database mutation or repair behavior is introduced.

## Follow-ups
- merge only after exact-head review and green CI
- rerun the Dev-only read-only drift workflow and verify the immutable observation manifest before #161 advances
