### PR TITLE
fix(release): preserve certified deployment provenance (#161)

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -371,6 +371,25 @@ jobs:
           SUPABASE_MANIFEST_MODE: deploy
         run: node scripts/verify-supabase-environment-manifest.mjs compose
 
+      - name: Certify completed Supabase deployment
+        if: steps.target.outputs.mode == 'deploy'
+        env:
+          SUPABASE_PROJECT_REF: ${{ steps.target.outputs.project_ref }}
+          TARGET_ENVIRONMENT: ${{ steps.target.outputs.target_environment }}
+          SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT: ${{ runner.temp }}/supabase-environment-manifest.json
+        run: |
+          set -euo pipefail
+
+          case "${TARGET_ENVIRONMENT}" in
+            dev) supabase_db_url="${DEV_SUPABASE_SESSION_POOLER_URL}" ;;
+            main) supabase_db_url="${MAIN_SUPABASE_SESSION_POOLER_URL}" ;;
+            *) echo "::error::Unsupported completion target '${TARGET_ENVIRONMENT}'."; exit 1 ;;
+          esac
+          echo "::add-mask::${supabase_db_url}"
+
+          SUPABASE_SCHEMA_DB_URL="${supabase_db_url}" \
+            node scripts/verify-supabase-schema-parity.mjs complete
+
       - name: Upload sanitized Supabase parity evidence
         if: ${{ always() && steps.target.outputs.mode == 'deploy' }}
         uses: actions/upload-artifact@v4
@@ -381,7 +400,6 @@ jobs:
             ${{ runner.temp }}/supabase-schema-diagnostic.json
             ${{ runner.temp }}/supabase-function-parity.json
             ${{ runner.temp }}/supabase-safe-runtime-smoke.json
-            ${{ runner.temp }}/supabase-environment-manifest.json
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -371,6 +371,28 @@ jobs:
           SUPABASE_MANIFEST_MODE: deploy
         run: node scripts/verify-supabase-environment-manifest.mjs compose
 
+      - name: Upload sanitized Supabase parity evidence
+        if: steps.target.outputs.mode == 'deploy'
+        uses: actions/upload-artifact@v4
+        with:
+          name: supabase-parity-${{ steps.target.outputs.target_environment }}-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/supabase-schema-parity.json
+            ${{ runner.temp }}/supabase-schema-diagnostic.json
+            ${{ runner.temp }}/supabase-function-parity.json
+            ${{ runner.temp }}/supabase-safe-runtime-smoke.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload immutable environment manifest
+        if: steps.target.outputs.mode == 'deploy'
+        uses: actions/upload-artifact@v4
+        with:
+          name: environment-manifest-${{ steps.target.outputs.target_environment }}-deploy-${{ steps.environment_manifest.outputs.deployment_sha }}-${{ steps.environment_manifest.outputs.deployment_run_id }}-${{ steps.environment_manifest.outputs.deployment_run_attempt }}-observe-${{ steps.environment_manifest.outputs.observation_sha }}-${{ steps.environment_manifest.outputs.observation_run_id }}-${{ steps.environment_manifest.outputs.observation_run_attempt }}
+          path: ${{ runner.temp }}/supabase-environment-manifest.json
+          if-no-files-found: error
+          retention-days: 90
+
       - name: Certify completed Supabase deployment
         if: steps.target.outputs.mode == 'deploy'
         env:
@@ -388,29 +410,7 @@ jobs:
           echo "::add-mask::${supabase_db_url}"
 
           SUPABASE_SCHEMA_DB_URL="${supabase_db_url}" \
-            node scripts/verify-supabase-schema-parity.mjs complete
-
-      - name: Upload sanitized Supabase parity evidence
-        if: ${{ always() && steps.target.outputs.mode == 'deploy' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: supabase-parity-${{ steps.target.outputs.target_environment }}-${{ github.sha }}
-          path: |
-            ${{ runner.temp }}/supabase-schema-parity.json
-            ${{ runner.temp }}/supabase-schema-diagnostic.json
-            ${{ runner.temp }}/supabase-function-parity.json
-            ${{ runner.temp }}/supabase-safe-runtime-smoke.json
-          if-no-files-found: warn
-          retention-days: 30
-
-      - name: Upload immutable environment manifest
-        if: steps.target.outputs.mode == 'deploy'
-        uses: actions/upload-artifact@v4
-        with:
-          name: environment-manifest-${{ steps.target.outputs.target_environment }}-deploy-${{ steps.environment_manifest.outputs.deployment_sha }}-${{ steps.environment_manifest.outputs.deployment_run_id }}-${{ steps.environment_manifest.outputs.deployment_run_attempt }}-observe-${{ steps.environment_manifest.outputs.observation_sha }}-${{ steps.environment_manifest.outputs.observation_run_id }}-${{ steps.environment_manifest.outputs.observation_run_attempt }}
-          path: ${{ runner.temp }}/supabase-environment-manifest.json
-          if-no-files-found: error
-          retention-days: 90
+            node scripts/verify-supabase-environment-manifest.mjs complete
 
       - name: Upload sanitized Dev schema diagnostic
         if: ${{ always() && steps.target.outputs.mode == 'dry-run' && steps.target.outputs.target_environment == 'dev' }}

--- a/.github/workflows/supabase-drift.yml
+++ b/.github/workflows/supabase-drift.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         target: ${{ fromJSON(format('["{0}"]', github.event_name == 'schedule' && 'dev' || inputs.target_environment || github.event.workflow_run.head_branch || github.ref_name)) }}
     needs: classify
-    if: needs.classify.outputs.should_observe == 'true' && (github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.repository.full_name == github.repository && (github.event.workflow_run.head_branch == 'dev' || github.event.workflow_run.head_branch == 'main')))
+    if: needs.classify.outputs.should_observe == 'true' && (github.event_name != 'workflow_run' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.repository.full_name == github.repository && (github.event.workflow_run.head_branch == 'dev' || github.event.workflow_run.head_branch == 'main')))
     runs-on: ubuntu-latest
     environment: ${{ matrix.target == 'main' && 'Production' || 'Preview' }}
     concurrency:

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1324,3 +1324,43 @@ but cannot safely identify the selected target of a manual cross-environment dis
 
 - Return this commit to independent validation, then publish only through the
   orchestrator-owned flow and exercise explicit hosted Dev observation.
+
+### session v28: Require explicit RFC3339 deployment timestamps (#161)
+
+- Timestamp: 2026-08-12T20:00:00-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `cb9f7a2a8d4247740217dfbc1c429af36f2d9120`
+
+#### Objective
+
+Close the remaining evidence-validator ambiguity by accepting only explicit RFC3339
+timestamps with seconds and a timezone in both deploy and drift provenance paths.
+
+#### Actions Taken
+
+- Added one shared timestamp predicate requiring `T`, seconds, optional fractional
+  seconds, and either `Z` or a bounded `±HH:MM` offset, plus a finite parsed value.
+- Applied it to candidate-bound deploy evidence binding and latest-matching drift
+  evidence validation.
+- Added PostgreSQL microsecond-offset and ISO `Z` positives plus adversarial numeric,
+  date-only, space-separated, timezone-less, missing-seconds, and malformed-offset
+  negatives, including direct checks through both evidence validators.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22: focused environment-manifest and delivery-parity suites, 23/23.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse, and
+  `git diff --check`.
+- No push, workflow dispatch, remote call or mutation, status change, Production action,
+  #162 work, credential prompt, or value-flow activation occurred.
+
+#### Reflections
+
+Generic JavaScript date parsing accepts shorthand values that are not auditable
+timestamps. Evidence contracts need an explicit wire grammar before semantic parsing.
+
+#### Suggested Next Steps
+
+- Return this localized fix to independent validation and keep hosted observation in the
+  orchestrator-owned publish path.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1282,3 +1282,45 @@ not be reparsed as authority text inside another process boundary.
 
 - Independently validate this focused recovery, publish to `dev`, then rerun the
   read-only Dev drift observation against the same SHA-bound deploy baseline.
+
+### session v27: Preserve deploy provenance and route manual observations safely (#161)
+
+- Timestamp: 2026-08-12T19:46:00-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `3ccafbbda0724fadb6191202319851c6e92840b3`
+
+#### Objective
+
+Close the final manifest provenance and observation-routing gaps without expanding into
+Production validation or Task #162.
+
+#### Actions Taken
+
+- Bound deploy-mode certified provenance to the actual `recorded_at` timestamp returned
+  by the independently validated append-only migration evidence row.
+- Added positive/negative coverage proving deploy and drift use the same immutable row
+  timestamp and reject invalid timestamps or changed inventory digests.
+- Restricted automatic `workflow_run` observations to successful same-repository
+  push-origin deploys on `dev` or `main`. Manual cross-target deploys now require the
+  drift workflow's explicit environment selection instead of inferring from branch.
+- Documented both provenance and manual routing contracts.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22: focused environment-manifest and delivery-parity suites, 22/22.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse, and
+  `git diff --check`.
+- No push, workflow dispatch, remote call or mutation, status change, Production action,
+  #162 work, credential prompt, or value-flow activation occurred.
+
+#### Reflections
+
+An immutable record's creation time is evidence, while a verifier's wall-clock time is
+only observation metadata. Likewise, branch identity is authoritative for push deploys
+but cannot safely identify the selected target of a manual cross-environment dispatch.
+
+#### Suggested Next Steps
+
+- Return this commit to independent validation, then publish only through the
+  orchestrator-owned flow and exercise explicit hosted Dev observation.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1404,3 +1404,50 @@ evidence needs both to remain deterministic across runtimes.
 
 - Return the amended localized commit to independent validation and keep hosted
   observation in the orchestrator-owned publish path.
+
+### session v30: Enforce final-manifest timestamp semantics (#161)
+
+- Timestamp: 2026-08-12T23:41:18-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `f496642d796d5db4693cef6f1cd52489846649d8`
+
+#### Objective
+
+Make final environment-manifest composition and independent verification enforce the
+same semantic RFC3339-with-timezone timestamp contract as immutable database evidence.
+
+#### Actions Taken
+
+- Reused the shared strict timestamp predicate for certified deployment provenance,
+  observation metadata, and hosted-smoke evidence in the final manifest path.
+- Refused manifest composition with invalid deployment or observation timestamps and
+  returned precise independent-verifier blockers without cascading chronology noise.
+- Added self-consistent adversarial-manifest coverage for numeric shorthand, impossible
+  dates, timezone-less timestamps, and hour 24, plus PostgreSQL microsecond-offset and
+  ISO `Z` positives.
+- Audited every final-manifest timestamp comparison so chronology checks only run after
+  the relevant timestamps satisfy the shared semantic contract.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22.23.2: focused environment-manifest, delivery-parity, and function
+  source-readback suites, 55/55.
+- Passed: full repository ESLint, full TypeScript typecheck, both affected Node script syntax
+  checks, Supabase deploy/drift workflow YAML parse, and `git diff --check`.
+- The first focused test run exposed a positive fixture whose deployment time followed
+  its observation; the fixture was corrected and the complete validation set rerun.
+- The first YAML command used an unsupported Ruby 2.6 keyword; the same two workflows
+  passed the compatible parser invocation immediately afterward.
+- No workflow dispatch, remote Supabase or Production mutation, status change, #162
+  work, credential prompt, reset, or value-flow activation occurred.
+
+#### Reflections
+
+A self-consistent digest proves integrity, not timestamp semantics. Producers and
+independent consumers must enforce the same wire, calendar, clock, and timezone rules.
+
+#### Suggested Next Steps
+
+- Publish this single review-fix commit to PR #202, reply with exact validation evidence,
+  and resolve only the addressed timestamp-contract thread.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1364,3 +1364,43 @@ timestamps. Evidence contracts need an explicit wire grammar before semantic par
 
 - Return this localized fix to independent validation and keep hosted observation in the
   orchestrator-owned publish path.
+
+### session v29: Validate RFC3339 calendar and clock semantics (#161)
+
+- Timestamp: 2026-08-12T19:54:00-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `ab67866471cc4d8ba818e3a804638119e637ac01`
+
+#### Objective
+
+Reject calendar-invalid or out-of-range clock timestamps that satisfy the RFC3339 wire
+shape but cannot represent valid immutable deployment evidence.
+
+#### Actions Taken
+
+- Added leap-year-aware month/day validation and strict hour, minute, and second ranges
+  to the shared deploy/drift timestamp predicate.
+- Retained PostgreSQL microsecond-offset and ISO `Z` support.
+- Added both-path negatives for a non-leap February 29, April 31, and hour 24, plus
+  minute/second overflow; added leap-day and calendar/clock boundary positives.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22: focused environment-manifest and delivery-parity suites, 23/23.
+- Passed: focused ESLint, TypeScript typecheck, script syntax, workflow YAML parse, and
+  `git diff --check`.
+- Initial validation hit host-level `ENOSPC`; only this worktree's generated `.next`
+  cache was deleted, after which all gates passed. No tracked or authored file was removed.
+- No push, workflow dispatch, remote call or mutation, status change, Production action,
+  #162 work, credential prompt, or value-flow activation occurred.
+
+#### Reflections
+
+Wire-format validation and semantic calendar validation are separate requirements;
+evidence needs both to remain deterministic across runtimes.
+
+#### Suggested Next Steps
+
+- Return the amended localized commit to independent validation and keep hosted
+  observation in the orchestrator-owned publish path.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1618,3 +1618,58 @@ from retained evidence rather than accepted as a correctly formatted claim.
 - Push this one consolidated commit to existing PR #202, let its read-only Dev dry-run
   exercise the exact 95-to-96 forward baseline, and return the exact head to independent
   validation without opening another PR or requesting another review.
+
+### session v34: Route and verify the retained deployment baseline (#161)
+
+- Timestamp: 2026-08-13T05:52:47-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `de242c78d39cae952a84325d487af6a0f4c8aff0`
+
+#### Objective
+
+Repair exact-head PR run `31667881328` without weakening the reviewed-forward-migration
+diagnostic, and make retained certified deploy manifests satisfy the complete deployment
+verification contract rather than only their self/evidence digest subset.
+
+#### Actions Taken
+
+- Replaced the forward-prefix database inside the candidate stack with a separately
+  task-owned Postgres 17 baseline stack whose host-side push and marker operations use
+  its dynamically allocated loopback port.
+- Preserved the isolated candidate replay and read-only remote comparison while keeping
+  the baseline container dump on its internal Postgres port.
+- Reused the complete deploy-manifest verifier for retained certification evidence, so
+  migration bytes/history/order, schema binding, function status/source/inventory,
+  smoke deployment binding, prerequisites, chronology, value-flow controls, and all
+  self/evidence digests must still pass.
+- Added explicit dynamic non-default-port coverage plus five recomputed, self-consistent
+  retained-manifest attacks: wrong schema digest, post-completion observation, inactive
+  function, mismatched migration history, and smoke/deployment SHA mismatch.
+
+#### Tests And Validation Notes
+
+- Passed Node 22 single-worker focused suites: environment manifest 14/14, delivery
+  parity 19/19, and function-source read-back 30/30.
+- Passed a workflow-equivalent disposable 95-to-96 forward diagnostic using a surrogate
+  remote prefix on host port 55432. It reported `reviewed-forward-replay`, exactly 95
+  baseline migrations, pending migration `20260813010000`, and zero enabled Production
+  value-flow controls.
+- Passed the pinned Supabase CLI 2.113.0 isolated replay: all 96 migrations, all three
+  representative SQL suites, and the deliberate invalid-migration history rejection.
+- Passed full repository ESLint and TypeScript typecheck, affected Node syntax checks,
+  workflow YAML parsing, and `git diff --check`.
+- The disposable surrogate and both verifier-owned stacks were stopped without backup.
+- No remote Supabase mutation/deployment/reset, workflow dispatch, Production action,
+  status change, #162 work, credential prompt, rereview, or value-flow activation occurred.
+
+#### Reflections
+
+A local Supabase stack exposes a randomized host port even though Postgres remains on
+5432 inside its container. Forward-baseline verification must bind commands to the side
+of that boundary they actually execute on.
+
+#### Suggested Next Steps
+
+- Push this localized correction to existing PR #202 after the full static and replay
+  gates pass, then report the exact head and CI state for independent validation.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1556,3 +1556,65 @@ record avoids rewriting evidence while making completion an explicit, auditable 
 
 - Push this consolidated certification fix to existing PR #202 only after the complete
   focused/static validation set passes, then return it for broad independent revalidation.
+
+### session v33: Bind certified artifacts and forward PR replay (#161)
+
+- Timestamp: 2026-08-13T00:38:10-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `1222869c23180636b1440dd9e347df083f0f15e9`
+
+#### Objective
+
+Close the complete final PR #202 blocker set in one recovery commit: exact retained
+deployment evidence, artifact-before-completion ordering, strict completion chronology,
+and non-mutating PR diagnosis for ordinary forward migration tails.
+
+#### Actions Taken
+
+- Retained the complete sanitized deploy manifest in append-only completion evidence
+  and bound its self-digest, evidence list, migration/schema/function digests, certified
+  hosted-smoke digest, candidate identity, and final observation chronology before insert.
+- Made drift re-verify that retained deploy manifest and completion record independently,
+  while preserving the certified deploy smoke separately from a distinct fresh smoke
+  observed only after completion.
+- Moved required parity and immutable-manifest artifact publication ahead of the final
+  completion insert; a failed upload now leaves candidate-only evidence.
+- Generalized Dev PR diagnosis to accept one or more strictly forward pending migrations
+  only after full candidate replay, immutable byte-bound prefix validation, and a
+  disposable exact-prefix schema comparison against the current read-only remote.
+- Added adversarial coverage for changed/unknown history, skeletal and self-digest-tampered
+  manifests, every completion digest mismatch, reversed completion chronology, and
+  distinct fresh observation smoke.
+- Updated canonical generated database types and deployment documentation for the stored
+  manifest, evidence lifecycle, and forward-baseline PR contract.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22.23.2 with single-worker forks: focused delivery parity,
+  environment-manifest, and function-source read-back suites, 62/62.
+- Passed the pinned Supabase CLI 2.113.0 isolated replay: all 96 migrations, three
+  representative SQL suites, and the deliberate invalid-migration history smoke.
+- Passed full repository ESLint and TypeScript typecheck.
+- Passed affected Node syntax, workflow YAML parse, and `git diff --check` before commit.
+- Two initial parallel Vitest tool processes orphaned despite a later successful run;
+  only those exact task-owned process trees were terminated, and all reported validation
+  uses the clean single-worker rerun.
+- A fully local workflow-equivalent remote baseline simulation was not run because the
+  verifier intentionally requires its PG17 container to reach a TLS remote target; the
+  pure forward-prefix matrix and full candidate/baseline replay paths are covered locally,
+  while the PR dry-run supplies the read-only Dev integration check after push.
+- No remote Supabase deployment/reset, workflow dispatch, Production action, status
+  change, #162 work, credential prompt, or value-flow activation occurred.
+
+#### Reflections
+
+Certification is the final mutation, not an optimistic marker. It is trustworthy only
+after required evidence is durably published and every stored digest can be recomputed
+from retained evidence rather than accepted as a correctly formatted claim.
+
+#### Suggested Next Steps
+
+- Push this one consolidated commit to existing PR #202, let its read-only Dev dry-run
+  exercise the exact 95-to-96 forward baseline, and return the exact head to independent
+  validation without opening another PR or requesting another review.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1451,3 +1451,53 @@ independent consumers must enforce the same wire, calendar, clock, and timezone 
 
 - Publish this single review-fix commit to PR #202, reply with exact validation evidence,
   and resolve only the addressed timestamp-contract thread.
+
+### session v31: Bind exact component provenance chronology (#161)
+
+- Timestamp: 2026-08-12T23:54:25-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `9b52ae3d20efdf3e3162fc32da7b17a2f1c39bf7`
+
+#### Objective
+
+Close the consolidated independent-validator gap by proving that every manifest
+component was observed from the final checkout after its certified deployment and no
+later than the final observation, without losing accepted fractional precision.
+
+#### Actions Taken
+
+- Added one exact RFC3339 comparator using epoch seconds, timezone offsets, and the full
+  fractional-second string rather than millisecond-truncating `Date.parse` ordering.
+- Preserved schema and function observation SHA/timestamps in their digest-bound final
+  manifest sections; hosted-smoke provenance remains bound through prerequisite evidence.
+- Required schema, function, and hosted-smoke SHAs to equal the final observation SHA.
+- Enforced certified deployment <= each component observation <= final observation in
+  both composition and independent verification with precise blockers.
+- Documented the component provenance and exact chronology contract.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22.23.2: focused environment-manifest, delivery-parity, and function
+  source-readback suites, 59/59.
+- Adversarial coverage includes digest-consistent stale/pre-deploy, post-observation,
+  cross-checkout, and microsecond-reversal forgeries, plus valid equality, timezone-offset,
+  PostgreSQL microsecond, ISO `Z`, and differing fractional-precision cases.
+- Passed: full repository ESLint, full TypeScript typecheck, affected script syntax,
+  Supabase deploy/drift workflow YAML parse, and `git diff --check`.
+- The first focused pass exposed an offset-regex capture-index error and newly strict
+  fixture chronology/checkout assumptions; both were corrected before the complete
+  focused and static validation sets passed.
+- No workflow dispatch, remote Supabase or Production mutation, status change, #162
+  work, credential prompt, reset, or value-flow activation occurred.
+
+#### Reflections
+
+Digest integrity cannot recover provenance that was discarded before composition, and
+millisecond timestamp coercion is insufficient once the evidence contract accepts
+microsecond precision.
+
+#### Suggested Next Steps
+
+- Push this single consolidated validator-fix commit to existing PR #202 for the
+  orchestrator's broad independent revalidation; do not open another PR or request review.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-1.md
@@ -1501,3 +1501,58 @@ microsecond precision.
 
 - Push this single consolidated validator-fix commit to existing PR #202 for the
   orchestrator's broad independent revalidation; do not open another PR or request review.
+
+### session v32: Certify only completed Supabase deployments (#161)
+
+- Timestamp: 2026-08-13T00:08:30-04:00
+- Agent: Codex
+- Branch: `codex/155-goal-1-manifest-provenance-routing-recovery`
+- Head: `0fbed61ebfcaa58d638fd7a3c062abc2b295ac62`
+
+#### Objective
+
+Prevent pre-push candidate evidence from certifying a failed deployment and exclude
+RFC3339's unknown `-00:00` offset from every chronology-bearing evidence path.
+
+#### Actions Taken
+
+- Added a forward-only append-only deployment-completion evidence table with an exact
+  foreign-key binding to candidate SHA/run/attempt/environment/project evidence.
+- Bound successful completion to migration inventory, matching schema digests, function
+  inventory, hosted-smoke evidence, and the composed deployment-manifest digest.
+- Routed the completion insert through the existing structured libpq field helper so
+  credentials never appear in `psql` arguments or get reparsed as a URI.
+- Kept candidate byte evidence before `db push`, but moved success certification after
+  database/schema parity, function deployment/read-back, hosted `401`, and manifest
+  composition; immutable manifest upload occurs only after completion insertion.
+- Made drift select candidate evidence only through its exact completion join and retain
+  that completion record in digest-bound certified deployment provenance.
+- Rejected unknown `-00:00` offsets while retaining `Z`, `+00:00`, and known positive or
+  negative offsets; updated adversarial producer/verifier tests and deployment docs.
+- Regenerated `types/supabase.ts` from the canonical local 96-migration schema with the
+  repository-pinned Supabase CLI 2.113.0.
+
+#### Tests And Validation Notes
+
+- Passed on Node 22.23.2: focused environment-manifest, delivery-parity, and function
+  source-readback suites, 60/60.
+- Passed the pinned-CLI isolated fresh-history replay with deliberate invalid-migration
+  smoke and an observed exit code of zero.
+- A canonical local Supabase reset applied all 96 tracked migrations, including the new
+  completion contract; types were generated from that database and the local stack was
+  stopped with no backup.
+- Negative coverage includes candidate-only failed runs, mismatched/stale completions,
+  schema mismatch, digest-consistent `-00:00` manifests, and producer rejection; one
+  exact completed run passes.
+- No remote Supabase or Production mutation, workflow dispatch, status change, #162
+  work, credential prompt, reset, or value-flow activation occurred.
+
+#### Reflections
+
+Pre-deploy evidence proves intent and bytes, not successful delivery. A second immutable
+record avoids rewriting evidence while making completion an explicit, auditable gate.
+
+#### Suggested Next Steps
+
+- Push this consolidated certification fix to existing PR #202 only after the complete
+  focused/static validation set passes, then return it for broad independent revalidation.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -253,6 +253,11 @@ ordered migration byte inventory. Function source parity remains bound to the cu
 observation checkout. In deployment mode the two SHA/run/attempt identities must be
 identical, and `certifiedDeployment.recordedAt` is the timestamp read back from that
 validated immutable database row—not the later verification or manifest timestamp.
+Schema, function, and hosted-smoke component evidence retain their own observation SHA
+and timestamp inside their digest-bound manifest sections. Every component SHA must
+equal the final observation SHA, and exact RFC3339 ordering (without millisecond
+truncation) requires the certified deployment to precede or equal every component,
+which must in turn precede or equal the final manifest observation.
 
 `Supabase Drift Detection` never deploys, repairs, seeds, prunes, or invokes database
 mutation commands. UI-only dev/main pushes are observed directly. A shared classifier

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -19,7 +19,10 @@ PR dry-runs targeting Dev also execute a read-only effective-schema diagnostic a
 the remote migration plan. The diagnostic replays the complete candidate history in
 a randomized Postgres 17 stack. When the PR contains ordinary forward migrations, it
 also replays the exact immutable remote-history prefix into a disposable baseline
-database and compares that baseline `public` schema with a read-only Dev dump. The
+Postgres 17 stack and compares that baseline `public` schema with a read-only Dev dump.
+The baseline stack is separately task-owned and every host-side command uses its
+dynamically allocated loopback port; container-side reads continue to use the stack's
+internal Postgres port. The
 candidate tail must be strictly forward, may contain one or more migrations, and its
 full replay must already have succeeded. Changed bytes, an unknown/non-prefix remote
 version, missing byte-bound baseline evidence, or unexplained remote schema drift

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -251,12 +251,16 @@ certified backend deployment from an earlier SHA only when the latest matching
 append-only deploy-evidence record independently recomputes to the checkout's exact
 ordered migration byte inventory. Function source parity remains bound to the current
 observation checkout. In deployment mode the two SHA/run/attempt identities must be
-identical.
+identical, and `certifiedDeployment.recordedAt` is the timestamp read back from that
+validated immutable database row—not the later verification or manifest timestamp.
 
 `Supabase Drift Detection` never deploys, repairs, seeds, prunes, or invokes database
 mutation commands. UI-only dev/main pushes are observed directly. A shared classifier
 assigns any backend or mixed push to `Supabase Deploy`; only its successful, same-repo
-`workflow_run` performs the read-only observation, eliminating the pre-deploy race.
+push-origin `workflow_run` performs the read-only observation, eliminating the
+pre-deploy race. A manually dispatched deploy can target an environment different from
+its source branch, so it is deliberately not inferred from `head_branch`; run the drift
+workflow explicitly for that selected target instead.
 The classifier's canonical path set is tested for exact equality with both deploy
 workflow path lists. The daily schedule observes Dev only. Production observation is
 an explicit manual or main-push protected-environment operation; missing Production

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -259,6 +259,21 @@ equal the final observation SHA, and exact RFC3339 ordering (without millisecond
 truncation) requires the certified deployment to precede or equal every component,
 which must in turn precede or equal the final manifest observation.
 
+Migration evidence is deliberately inserted before `supabase db push` so the exact
+candidate bytes remain auditable even when a deployment fails. That candidate row does
+not certify success. Only after migration/schema parity, Edge Function deployment and
+source read-back, hosted `401`, and manifest composition pass does the workflow append a
+separate immutable `fundloop.deploy-completion-evidence/v1` row. It binds the candidate
+SHA/run/attempt/environment/project and migration inventory to schema, function,
+hosted-smoke, and deployment-manifest digests. Read-only drift selects candidates only
+through an exact completion join; candidate-only, mismatched, legacy, or stale rows
+cannot become the certified deployment. Completion is written before artifact upload,
+and no failed prerequisite path reaches that write.
+
+All chronology-bearing evidence requires a semantic RFC3339 timestamp with an explicit
+known timezone. `Z`, `+00:00`, and known positive or negative offsets are accepted;
+RFC3339's unknown-local-offset form `-00:00` is rejected because it cannot prove order.
+
 `Supabase Drift Detection` never deploys, repairs, seeds, prunes, or invokes database
 mutation commands. UI-only dev/main pushes are observed directly. A shared classifier
 assigns any backend or mixed push to `Supabase Deploy`; only its successful, same-repo

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -17,9 +17,13 @@ PR runs intentionally do not mutate shared databases or deploy functions.
 
 PR dry-runs targeting Dev also execute a read-only effective-schema diagnostic after
 the remote migration plan. The diagnostic replays the complete candidate history in
-a randomized Postgres 17 stack and compares that full `public` schema with a read-only
-Dev dump. Unknown drift remains blocking; only the reviewed, unordered policy-role
-set is canonicalized.
+a randomized Postgres 17 stack. When the PR contains ordinary forward migrations, it
+also replays the exact immutable remote-history prefix into a disposable baseline
+database and compares that baseline `public` schema with a read-only Dev dump. The
+candidate tail must be strictly forward, may contain one or more migrations, and its
+full replay must already have succeeded. Changed bytes, an unknown/non-prefix remote
+version, missing byte-bound baseline evidence, or unexplained remote schema drift
+remain blocking. Only the reviewed, unordered policy-role set is canonicalized.
 
 Before failing, the runner writes a sanitized
 `fundloop.public-schema-diagnostic/v2` artifact. It contains candidate/environment
@@ -194,12 +198,13 @@ byte-for-byte using the exact `pg17-public-schema-normalized-v2` algorithm. Vers
 sorts only the unordered role set in `CREATE POLICY ... TO ...`; object names,
 definitions, expressions, and every other schema byte remain covered.
 
-One pending forward repair may pass the Dev PR diagnostic only when the tracked
-`fundloop.public-schema-repair/v1` manifest matches the complete legacy drift
-signature, the remote migration history is the byte-bound reviewed prefix, the repair
-is the sole pending migration, and production value flow remains disabled. The
-post-deploy verifier has no repair exception: it requires the complete migration
-history and zero normalized schema drift.
+Ordinary pending forward migrations may pass the Dev PR diagnostic only when remote
+history is the exact byte-bound reviewed prefix, a disposable replay of that prefix
+has zero normalized drift from Dev, the complete candidate tail replays successfully,
+and production value flow remains disabled. The legacy one-off
+`fundloop.public-schema-repair/v1` path remains limited to its exact recorded drift
+signature. The post-deploy verifier has no pending-migration exception: it requires
+the complete migration history and zero normalized schema drift.
 
 The expected function closure is derived with the repo-pinned TypeScript compiler
 API after `pnpm install --frozen-lockfile`. It follows side-effect imports, dynamic
@@ -265,10 +270,17 @@ not certify success. Only after migration/schema parity, Edge Function deploymen
 source read-back, hosted `401`, and manifest composition pass does the workflow append a
 separate immutable `fundloop.deploy-completion-evidence/v1` row. It binds the candidate
 SHA/run/attempt/environment/project and migration inventory to schema, function,
-hosted-smoke, and deployment-manifest digests. Read-only drift selects candidates only
-through an exact completion join; candidate-only, mismatched, legacy, or stale rows
-cannot become the certified deployment. Completion is written before artifact upload,
-and no failed prerequisite path reaches that write.
+certified deploy-smoke, and deployment-manifest digests, retains the complete sanitized
+deploy manifest, and requires completion time to follow every deploy observation.
+Both the required parity artifact and immutable manifest artifact must publish before
+the completion row is appended; an upload failure therefore leaves candidate-only
+evidence. Before that final mutation, the complete manifest, its self-digest, component
+digests, and evidence list are independently re-verified. Read-only drift selects
+candidates only through an exact completion join, re-verifies the retained deploy
+manifest, and binds every completion digest back to it. Candidate-only, skeletal,
+tampered, mismatched, legacy, or stale rows cannot become the certified deployment.
+The drift manifest retains the certified deploy smoke separately from a newly observed
+safe smoke; the fresh observation must be distinct and occur after completion.
 
 All chronology-bearing evidence requires a semantic RFC3339 timestamp with an explicit
 known timezone. `Z`, `+00:00`, and known positive or negative offsets are accepted;

--- a/scripts/verify-supabase-environment-manifest.mjs
+++ b/scripts/verify-supabase-environment-manifest.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
 import { pathToFileURL } from "node:url"
-import { compareExplicitRfc3339Timestamps, isExplicitRfc3339Timestamp, validateDeployCompletionEvidence } from "./verify-supabase-schema-parity.mjs"
+import { compareExplicitRfc3339Timestamps, isExplicitRfc3339Timestamp, recordDeployCompletion, validateDeployCompletionEvidence } from "./verify-supabase-schema-parity.mjs"
 
 const canonical = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`
@@ -56,9 +56,14 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
     inventorySha256: schema.migrationInventorySha256,
     recordedAt: schema.certifiedDeployment.recordedAt,
   }
-  if (context.mode === "drift" && !validateDeployCompletionEvidence(schema.certifiedDeployment.completion, deploymentEvidence)) throw new Error("deployment-completion: immutable manifest publication refused")
+  if (context.mode === "drift") {
+    const certifiedManifest = schema.certifiedDeployment.certifiedManifest
+    if (!validateDeployCompletionEvidence(schema.certifiedDeployment.completion, deploymentEvidence, certifiedManifest)) throw new Error("deployment-completion: immutable manifest publication refused")
+    if (certifiedManifest.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256 === smoke.evidenceSha256) throw new Error("observation-smoke-not-fresh: immutable manifest publication refused")
+  }
   for (const [name, observedAt] of [["schema", schema.observedAt], ["function", functions.observedAt], ["hosted-smoke", smoke.observedAt]]) {
     if (compareExplicitRfc3339Timestamps(observedAt, schema.certifiedDeployment.recordedAt) < 0) throw new Error(`${name}-before-deployment: immutable manifest publication refused`)
+    if (context.mode === "drift" && compareExplicitRfc3339Timestamps(observedAt, schema.certifiedDeployment.completion.completedAt) < 0) throw new Error(`${name}-before-completion: immutable manifest publication refused`)
     if (compareExplicitRfc3339Timestamps(observedAt, context.observedAt) > 0) throw new Error(`${name}-after-observation: immutable manifest publication refused`)
   }
   const functionItems = functions.functions.map((entry) => ({
@@ -153,7 +158,11 @@ export function verifyEnvironmentManifest(manifest) {
     inventorySha256: manifest.migrations?.inventorySha256,
     recordedAt: manifest.certifiedDeployment?.recordedAt,
   }
-  if (manifest.observation?.mode === "drift" && deploymentTimeValid && !validateDeployCompletionEvidence(manifest.certifiedDeployment?.completion, completionEvidence)) blockers.push("deployment-completion")
+  if (manifest.observation?.mode === "drift" && deploymentTimeValid) {
+    const certifiedManifest = manifest.certifiedDeployment?.certifiedManifest
+    if (!validateDeployCompletionEvidence(manifest.certifiedDeployment?.completion, completionEvidence, certifiedManifest)) blockers.push("deployment-completion")
+    if (certifiedManifest?.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256 === manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256) blockers.push("observation-smoke-not-fresh")
+  }
   if (!Array.isArray(manifest.migrations?.orderedInventory) || manifest.migrations.orderedInventory.length !== manifest.migrations.observedHistory?.length) blockers.push("migration-history")
   if (manifest.migrations?.algorithm !== "sha256-raw-bytes-sorted-filename-v1" || !/^[0-9a-f]{64}$/.test(manifest.migrations?.inventorySha256 ?? "")) blockers.push("migration-contract")
   const migrationVersions = manifest.migrations?.orderedInventory?.map((item) => item.version) ?? []
@@ -201,6 +210,7 @@ export function verifyEnvironmentManifest(manifest) {
     const componentTimeValid = isExplicitRfc3339Timestamp(observedAt)
     if (!componentTimeValid) blockers.push(`${name}-observation-time`)
     if (componentTimeValid && deploymentTimeValid && compareExplicitRfc3339Timestamps(observedAt, manifest.certifiedDeployment.recordedAt) < 0) blockers.push(`${name}-before-deployment`)
+    if (componentTimeValid && manifest.observation?.mode === "drift" && isExplicitRfc3339Timestamp(manifest.certifiedDeployment?.completion?.completedAt) && compareExplicitRfc3339Timestamps(observedAt, manifest.certifiedDeployment.completion.completedAt) < 0) blockers.push(`${name}-before-completion`)
     if (componentTimeValid && observationTimeValid && compareExplicitRfc3339Timestamps(observedAt, manifest.observation.observedAt) > 0) blockers.push(`${name}-after-observation`)
   }
   const expectedEvidence = [
@@ -217,6 +227,23 @@ export function verifyEnvironmentManifest(manifest) {
 function main() {
   const command = process.argv[2]
   const output = process.env.SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT
+  if (command === "complete") {
+    const dbUrl = process.env.SUPABASE_SCHEMA_DB_URL
+    if (!output || !dbUrl) throw new Error("SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT and SUPABASE_SCHEMA_DB_URL are required")
+    const manifest = JSON.parse(readFileSync(output, "utf8"))
+    const result = verifyEnvironmentManifest(manifest)
+    if (!result.ok || manifest.observation?.mode !== "deploy") throw new Error(`deployment-completion-invalid: ${result.blockers.join(",") || "not-a-deploy-manifest"}`)
+    const binding = {
+      candidateGitSha: process.env.GITHUB_SHA,
+      actionsRunId: process.env.GITHUB_RUN_ID,
+      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+      environment: process.env.TARGET_ENVIRONMENT,
+      projectRef: process.env.SUPABASE_PROJECT_REF,
+    }
+    recordDeployCompletion(dbUrl, manifest, binding)
+    console.log(`Certified completed ${binding.environment} Supabase deployment ${binding.candidateGitSha}`)
+    return
+  }
   if (command === "record-smoke") {
     const smokeOutput = process.env.SUPABASE_SAFE_SMOKE_OUTPUT
     if (!smokeOutput) throw new Error("SUPABASE_SAFE_SMOKE_OUTPUT is required")

--- a/scripts/verify-supabase-environment-manifest.mjs
+++ b/scripts/verify-supabase-environment-manifest.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
 import { pathToFileURL } from "node:url"
+import { isExplicitRfc3339Timestamp } from "./verify-supabase-schema-parity.mjs"
 
 const canonical = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`
@@ -30,13 +31,15 @@ export function verifySafeSmokeEvidence(smoke, binding) {
     && payload.observationGitSha === binding.gitSha
     && payload.functionName === "epoch-allocation-close"
     && payload.unauthenticatedStatusCode === 401
-    && Number.isFinite(Date.parse(payload.observedAt ?? ""))
+    && isExplicitRfc3339Timestamp(payload.observedAt)
     && evidenceSha256 === sha256(canonical(payload))
 }
 
 export function buildEnvironmentManifest({ schema, functions, smoke, context }) {
   if (schema.environment !== functions.environment || schema.projectRef !== functions.projectRef) throw new Error("environment-binding: parity records disagree")
   if (schema.enabledProductionValueFlowControlCount !== 0) throw new Error("value-flow-enabled: immutable manifest publication refused")
+  if (!isExplicitRfc3339Timestamp(schema.certifiedDeployment?.recordedAt)) throw new Error("deployment-time: immutable manifest publication refused")
+  if (!isExplicitRfc3339Timestamp(context.observedAt)) throw new Error("observation-time: immutable manifest publication refused")
   if (!verifySafeSmokeEvidence(smoke, { environment: schema.environment, projectRef: schema.projectRef, gitSha: context.gitSha })) throw new Error("runtime-smoke: evidence invalid")
   const functionItems = functions.functions.map((entry) => ({
     name: entry.name,
@@ -105,10 +108,13 @@ export function verifyEnvironmentManifest(manifest) {
   if (!/^[0-9a-f]{40}$/.test(manifest.observation?.gitSha ?? "")) blockers.push("observation-sha")
   if (!/^[0-9a-f]{40}$/.test(manifest.certifiedDeployment?.gitSha ?? "")) blockers.push("deployment-sha")
   if (manifest.certifiedDeployment?.environment !== manifest.environment || manifest.certifiedDeployment?.projectRef !== manifest.projectRef) blockers.push("deployment-binding")
-  if (!Number.isFinite(Date.parse(manifest.certifiedDeployment?.recordedAt ?? ""))) blockers.push("deployment-time")
+  const deploymentTimeValid = isExplicitRfc3339Timestamp(manifest.certifiedDeployment?.recordedAt)
+  if (!deploymentTimeValid) blockers.push("deployment-time")
   if (!/^\d+$/.test(manifest.certifiedDeployment?.githubRunId ?? "") || !Number.isInteger(manifest.certifiedDeployment?.githubRunAttempt) || manifest.certifiedDeployment.githubRunAttempt < 1) blockers.push("deployment-run")
-  if (!Number.isFinite(Date.parse(manifest.observation?.observedAt ?? "")) || !/^\d+$/.test(manifest.observation?.githubRunId ?? "") || !Number.isInteger(manifest.observation?.githubRunAttempt) || manifest.observation.githubRunAttempt < 1) blockers.push("observation-run")
-  if (Date.parse(manifest.certifiedDeployment?.recordedAt ?? "") > Date.parse(manifest.observation?.observedAt ?? "")) blockers.push("deployment-after-observation")
+  const observationTimeValid = isExplicitRfc3339Timestamp(manifest.observation?.observedAt)
+  if (!observationTimeValid) blockers.push("observation-time")
+  if (!/^\d+$/.test(manifest.observation?.githubRunId ?? "") || !Number.isInteger(manifest.observation?.githubRunAttempt) || manifest.observation.githubRunAttempt < 1) blockers.push("observation-run")
+  if (deploymentTimeValid && observationTimeValid && Date.parse(manifest.certifiedDeployment.recordedAt) > Date.parse(manifest.observation.observedAt)) blockers.push("deployment-after-observation")
   if (!/^[0-9a-f]{40}$/.test(manifest.observation?.functionCandidateGitSha ?? "") || manifest.observation.functionCandidateGitSha !== manifest.observation.gitSha) blockers.push("function-observation-sha")
   if (!['deploy', 'drift'].includes(manifest.observation?.mode)) blockers.push("observation-mode")
   if (!['push', 'workflow_run', 'schedule', 'workflow_dispatch'].includes(manifest.observation?.trigger)) blockers.push("observation-trigger")
@@ -140,6 +146,7 @@ export function verifyEnvironmentManifest(manifest) {
   }
   if (manifest.runtimeControls?.productionValueFlowEnabledCount !== 0) blockers.push("value-flow-enabled")
   const smoke = manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence
+  const smokeValid = verifySafeSmokeEvidence(smoke, { environment: manifest.environment, projectRef: manifest.projectRef, gitSha: manifest.observation?.gitSha })
   if (manifest.prerequisites?.migrationDeployment?.status !== "passed"
     || manifest.prerequisites?.schemaParity?.status !== "passed"
     || manifest.prerequisites?.functionParity?.status !== "passed") blockers.push("prerequisite-status")
@@ -148,8 +155,8 @@ export function verifyEnvironmentManifest(manifest) {
     || manifest.prerequisites.valueFlowReadback.tableCount < 1
     || manifest.prerequisites.valueFlowReadback.enabledCount !== 0) blockers.push("value-flow-readback")
   if (manifest.prerequisites?.hostedUnauthenticatedDenial?.status !== "passed"
-    || !verifySafeSmokeEvidence(smoke, { environment: manifest.environment, projectRef: manifest.projectRef, gitSha: manifest.observation?.gitSha })
-    || Date.parse(smoke?.observedAt ?? "") > Date.parse(manifest.observation?.observedAt ?? "")) blockers.push("runtime-smoke")
+    || !smokeValid
+    || (smokeValid && observationTimeValid && Date.parse(smoke.observedAt) > Date.parse(manifest.observation.observedAt))) blockers.push("runtime-smoke")
   const expectedEvidence = [
     { evidenceId: "migration-deployment", sha256: sha256(canonical(manifest.certifiedDeployment)) },
     { evidenceId: "schema-parity", sha256: sha256(canonical({ migrations: manifest.migrations, schema: manifest.schema, runtimeControls: manifest.runtimeControls, certifiedDeployment: manifest.certifiedDeployment })) },

--- a/scripts/verify-supabase-environment-manifest.mjs
+++ b/scripts/verify-supabase-environment-manifest.mjs
@@ -58,7 +58,8 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
   }
   if (context.mode === "drift") {
     const certifiedManifest = schema.certifiedDeployment.certifiedManifest
-    if (!validateDeployCompletionEvidence(schema.certifiedDeployment.completion, deploymentEvidence, certifiedManifest)) throw new Error("deployment-completion: immutable manifest publication refused")
+    if (!validateDeployCompletionEvidence(schema.certifiedDeployment.completion, deploymentEvidence, certifiedManifest)
+      || !verifyCertifiedDeploymentManifest(certifiedManifest).ok) throw new Error("deployment-completion: immutable manifest publication refused")
     if (certifiedManifest.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256 === smoke.evidenceSha256) throw new Error("observation-smoke-not-fresh: immutable manifest publication refused")
   }
   for (const [name, observedAt] of [["schema", schema.observedAt], ["function", functions.observedAt], ["hosted-smoke", smoke.observedAt]]) {
@@ -129,7 +130,7 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
   return { ...payload, manifestSha256: sha256(canonical(payload)) }
 }
 
-export function verifyEnvironmentManifest(manifest) {
+function verifyEnvironmentManifestCore(manifest) {
   const { manifestSha256, ...payload } = manifest
   const blockers = []
   if (manifest.contractVersion !== "fundloop.environment-delivery-manifest/v1") blockers.push("contract-version")
@@ -149,20 +150,6 @@ export function verifyEnvironmentManifest(manifest) {
   if (!['deploy', 'drift'].includes(manifest.observation?.mode)) blockers.push("observation-mode")
   if (!['push', 'workflow_run', 'schedule', 'workflow_dispatch'].includes(manifest.observation?.trigger)) blockers.push("observation-trigger")
   if (manifest.observation?.mode === "deploy" && (manifest.certifiedDeployment?.gitSha !== manifest.observation.gitSha || manifest.certifiedDeployment?.githubRunId !== manifest.observation.githubRunId || manifest.certifiedDeployment?.githubRunAttempt !== manifest.observation.githubRunAttempt)) blockers.push("deploy-observation-binding")
-  const completionEvidence = {
-    candidateGitSha: manifest.certifiedDeployment?.gitSha,
-    actionsRunId: manifest.certifiedDeployment?.githubRunId,
-    runAttempt: manifest.certifiedDeployment?.githubRunAttempt,
-    environment: manifest.certifiedDeployment?.environment,
-    projectRef: manifest.certifiedDeployment?.projectRef,
-    inventorySha256: manifest.migrations?.inventorySha256,
-    recordedAt: manifest.certifiedDeployment?.recordedAt,
-  }
-  if (manifest.observation?.mode === "drift" && deploymentTimeValid) {
-    const certifiedManifest = manifest.certifiedDeployment?.certifiedManifest
-    if (!validateDeployCompletionEvidence(manifest.certifiedDeployment?.completion, completionEvidence, certifiedManifest)) blockers.push("deployment-completion")
-    if (certifiedManifest?.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256 === manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256) blockers.push("observation-smoke-not-fresh")
-  }
   if (!Array.isArray(manifest.migrations?.orderedInventory) || manifest.migrations.orderedInventory.length !== manifest.migrations.observedHistory?.length) blockers.push("migration-history")
   if (manifest.migrations?.algorithm !== "sha256-raw-bytes-sorted-filename-v1" || !/^[0-9a-f]{64}$/.test(manifest.migrations?.inventorySha256 ?? "")) blockers.push("migration-contract")
   const migrationVersions = manifest.migrations?.orderedInventory?.map((item) => item.version) ?? []
@@ -221,6 +208,34 @@ export function verifyEnvironmentManifest(manifest) {
   ]
   if (canonical(manifest.evidence) !== canonical(expectedEvidence)) blockers.push("evidence")
   if (manifestSha256 !== sha256(canonical(payload))) blockers.push("manifest-digest")
+  return { ok: blockers.length === 0, blockers }
+}
+
+export function verifyCertifiedDeploymentManifest(manifest) {
+  const result = verifyEnvironmentManifestCore(manifest)
+  const blockers = [...result.blockers]
+  if (manifest.observation?.mode !== "deploy") blockers.push("certified-deployment-mode")
+  return { ok: blockers.length === 0, blockers }
+}
+
+export function verifyEnvironmentManifest(manifest) {
+  const result = verifyEnvironmentManifestCore(manifest)
+  const blockers = [...result.blockers]
+  if (manifest.observation?.mode === "drift" && isExplicitRfc3339Timestamp(manifest.certifiedDeployment?.recordedAt)) {
+    const certifiedManifest = manifest.certifiedDeployment?.certifiedManifest
+    const completionEvidence = {
+      candidateGitSha: manifest.certifiedDeployment?.gitSha,
+      actionsRunId: manifest.certifiedDeployment?.githubRunId,
+      runAttempt: manifest.certifiedDeployment?.githubRunAttempt,
+      environment: manifest.certifiedDeployment?.environment,
+      projectRef: manifest.certifiedDeployment?.projectRef,
+      inventorySha256: manifest.migrations?.inventorySha256,
+      recordedAt: manifest.certifiedDeployment?.recordedAt,
+    }
+    if (!validateDeployCompletionEvidence(manifest.certifiedDeployment?.completion, completionEvidence, certifiedManifest)
+      || !verifyCertifiedDeploymentManifest(certifiedManifest).ok) blockers.push("deployment-completion")
+    if (certifiedManifest?.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256 === manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256) blockers.push("observation-smoke-not-fresh")
+  }
   return { ok: blockers.length === 0, blockers }
 }
 

--- a/scripts/verify-supabase-environment-manifest.mjs
+++ b/scripts/verify-supabase-environment-manifest.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
 import { pathToFileURL } from "node:url"
-import { compareExplicitRfc3339Timestamps, isExplicitRfc3339Timestamp } from "./verify-supabase-schema-parity.mjs"
+import { compareExplicitRfc3339Timestamps, isExplicitRfc3339Timestamp, validateDeployCompletionEvidence } from "./verify-supabase-schema-parity.mjs"
 
 const canonical = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`
@@ -47,6 +47,16 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
   if (smoke.observationGitSha !== context.gitSha) throw new Error("hosted-smoke-observation-sha: immutable manifest publication refused")
   if (!verifySafeSmokeEvidence(smoke, { environment: schema.environment, projectRef: schema.projectRef, gitSha: context.gitSha })) throw new Error("runtime-smoke: evidence invalid")
   if (compareExplicitRfc3339Timestamps(schema.certifiedDeployment.recordedAt, context.observedAt) > 0) throw new Error("deployment-after-observation: immutable manifest publication refused")
+  const deploymentEvidence = {
+    candidateGitSha: schema.certifiedDeployment.gitSha,
+    actionsRunId: schema.certifiedDeployment.githubRunId,
+    runAttempt: schema.certifiedDeployment.githubRunAttempt,
+    environment: schema.certifiedDeployment.environment,
+    projectRef: schema.certifiedDeployment.projectRef,
+    inventorySha256: schema.migrationInventorySha256,
+    recordedAt: schema.certifiedDeployment.recordedAt,
+  }
+  if (context.mode === "drift" && !validateDeployCompletionEvidence(schema.certifiedDeployment.completion, deploymentEvidence)) throw new Error("deployment-completion: immutable manifest publication refused")
   for (const [name, observedAt] of [["schema", schema.observedAt], ["function", functions.observedAt], ["hosted-smoke", smoke.observedAt]]) {
     if (compareExplicitRfc3339Timestamps(observedAt, schema.certifiedDeployment.recordedAt) < 0) throw new Error(`${name}-before-deployment: immutable manifest publication refused`)
     if (compareExplicitRfc3339Timestamps(observedAt, context.observedAt) > 0) throw new Error(`${name}-after-observation: immutable manifest publication refused`)
@@ -134,6 +144,16 @@ export function verifyEnvironmentManifest(manifest) {
   if (!['deploy', 'drift'].includes(manifest.observation?.mode)) blockers.push("observation-mode")
   if (!['push', 'workflow_run', 'schedule', 'workflow_dispatch'].includes(manifest.observation?.trigger)) blockers.push("observation-trigger")
   if (manifest.observation?.mode === "deploy" && (manifest.certifiedDeployment?.gitSha !== manifest.observation.gitSha || manifest.certifiedDeployment?.githubRunId !== manifest.observation.githubRunId || manifest.certifiedDeployment?.githubRunAttempt !== manifest.observation.githubRunAttempt)) blockers.push("deploy-observation-binding")
+  const completionEvidence = {
+    candidateGitSha: manifest.certifiedDeployment?.gitSha,
+    actionsRunId: manifest.certifiedDeployment?.githubRunId,
+    runAttempt: manifest.certifiedDeployment?.githubRunAttempt,
+    environment: manifest.certifiedDeployment?.environment,
+    projectRef: manifest.certifiedDeployment?.projectRef,
+    inventorySha256: manifest.migrations?.inventorySha256,
+    recordedAt: manifest.certifiedDeployment?.recordedAt,
+  }
+  if (manifest.observation?.mode === "drift" && deploymentTimeValid && !validateDeployCompletionEvidence(manifest.certifiedDeployment?.completion, completionEvidence)) blockers.push("deployment-completion")
   if (!Array.isArray(manifest.migrations?.orderedInventory) || manifest.migrations.orderedInventory.length !== manifest.migrations.observedHistory?.length) blockers.push("migration-history")
   if (manifest.migrations?.algorithm !== "sha256-raw-bytes-sorted-filename-v1" || !/^[0-9a-f]{64}$/.test(manifest.migrations?.inventorySha256 ?? "")) blockers.push("migration-contract")
   const migrationVersions = manifest.migrations?.orderedInventory?.map((item) => item.version) ?? []

--- a/scripts/verify-supabase-environment-manifest.mjs
+++ b/scripts/verify-supabase-environment-manifest.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto"
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs"
 import { pathToFileURL } from "node:url"
-import { isExplicitRfc3339Timestamp } from "./verify-supabase-schema-parity.mjs"
+import { compareExplicitRfc3339Timestamps, isExplicitRfc3339Timestamp } from "./verify-supabase-schema-parity.mjs"
 
 const canonical = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`
@@ -39,8 +39,18 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
   if (schema.environment !== functions.environment || schema.projectRef !== functions.projectRef) throw new Error("environment-binding: parity records disagree")
   if (schema.enabledProductionValueFlowControlCount !== 0) throw new Error("value-flow-enabled: immutable manifest publication refused")
   if (!isExplicitRfc3339Timestamp(schema.certifiedDeployment?.recordedAt)) throw new Error("deployment-time: immutable manifest publication refused")
+  if (!isExplicitRfc3339Timestamp(schema.observedAt)) throw new Error("schema-observation-time: immutable manifest publication refused")
+  if (!isExplicitRfc3339Timestamp(functions.observedAt)) throw new Error("function-observation-time: immutable manifest publication refused")
   if (!isExplicitRfc3339Timestamp(context.observedAt)) throw new Error("observation-time: immutable manifest publication refused")
+  if (schema.candidateGitSha !== context.gitSha) throw new Error("schema-observation-sha: immutable manifest publication refused")
+  if (functions.candidateGitSha !== context.gitSha) throw new Error("function-observation-sha: immutable manifest publication refused")
+  if (smoke.observationGitSha !== context.gitSha) throw new Error("hosted-smoke-observation-sha: immutable manifest publication refused")
   if (!verifySafeSmokeEvidence(smoke, { environment: schema.environment, projectRef: schema.projectRef, gitSha: context.gitSha })) throw new Error("runtime-smoke: evidence invalid")
+  if (compareExplicitRfc3339Timestamps(schema.certifiedDeployment.recordedAt, context.observedAt) > 0) throw new Error("deployment-after-observation: immutable manifest publication refused")
+  for (const [name, observedAt] of [["schema", schema.observedAt], ["function", functions.observedAt], ["hosted-smoke", smoke.observedAt]]) {
+    if (compareExplicitRfc3339Timestamps(observedAt, schema.certifiedDeployment.recordedAt) < 0) throw new Error(`${name}-before-deployment: immutable manifest publication refused`)
+    if (compareExplicitRfc3339Timestamps(observedAt, context.observedAt) > 0) throw new Error(`${name}-after-observation: immutable manifest publication refused`)
+  }
   const functionItems = functions.functions.map((entry) => ({
     name: entry.name,
     expectedSourceSha256: entry.expectedSourceSha256,
@@ -71,12 +81,16 @@ export function buildEnvironmentManifest({ schema, functions, smoke, context }) 
       observedHistory: schema.migrationHistory,
     },
     schema: {
+      candidateGitSha: schema.candidateGitSha,
+      observedAt: schema.observedAt,
       algorithm: schema.algorithm,
       expectedSha256: schema.expectedSha256,
       observedSha256: schema.observedSha256,
       postgresMajor: schema.postgresMajor,
     },
     functions: {
+      candidateGitSha: functions.candidateGitSha,
+      observedAt: functions.observedAt,
       algorithm: "sha256-function-runtime-closure-sorted-path-v1",
       count: functionItems.length,
       inventorySha256: functionInventorySha256,
@@ -114,8 +128,9 @@ export function verifyEnvironmentManifest(manifest) {
   const observationTimeValid = isExplicitRfc3339Timestamp(manifest.observation?.observedAt)
   if (!observationTimeValid) blockers.push("observation-time")
   if (!/^\d+$/.test(manifest.observation?.githubRunId ?? "") || !Number.isInteger(manifest.observation?.githubRunAttempt) || manifest.observation.githubRunAttempt < 1) blockers.push("observation-run")
-  if (deploymentTimeValid && observationTimeValid && Date.parse(manifest.certifiedDeployment.recordedAt) > Date.parse(manifest.observation.observedAt)) blockers.push("deployment-after-observation")
-  if (!/^[0-9a-f]{40}$/.test(manifest.observation?.functionCandidateGitSha ?? "") || manifest.observation.functionCandidateGitSha !== manifest.observation.gitSha) blockers.push("function-observation-sha")
+  if (deploymentTimeValid && observationTimeValid && compareExplicitRfc3339Timestamps(manifest.certifiedDeployment.recordedAt, manifest.observation.observedAt) > 0) blockers.push("deployment-after-observation")
+  if (!/^[0-9a-f]{40}$/.test(manifest.schema?.candidateGitSha ?? "") || manifest.schema.candidateGitSha !== manifest.observation?.gitSha) blockers.push("schema-observation-sha")
+  if (!/^[0-9a-f]{40}$/.test(manifest.functions?.candidateGitSha ?? "") || manifest.functions.candidateGitSha !== manifest.observation?.gitSha || manifest.observation?.functionCandidateGitSha !== manifest.functions?.candidateGitSha) blockers.push("function-observation-sha")
   if (!['deploy', 'drift'].includes(manifest.observation?.mode)) blockers.push("observation-mode")
   if (!['push', 'workflow_run', 'schedule', 'workflow_dispatch'].includes(manifest.observation?.trigger)) blockers.push("observation-trigger")
   if (manifest.observation?.mode === "deploy" && (manifest.certifiedDeployment?.gitSha !== manifest.observation.gitSha || manifest.certifiedDeployment?.githubRunId !== manifest.observation.githubRunId || manifest.certifiedDeployment?.githubRunAttempt !== manifest.observation.githubRunAttempt)) blockers.push("deploy-observation-binding")
@@ -146,6 +161,7 @@ export function verifyEnvironmentManifest(manifest) {
   }
   if (manifest.runtimeControls?.productionValueFlowEnabledCount !== 0) blockers.push("value-flow-enabled")
   const smoke = manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence
+  if (!/^[0-9a-f]{40}$/.test(smoke?.observationGitSha ?? "") || smoke.observationGitSha !== manifest.observation?.gitSha) blockers.push("hosted-smoke-observation-sha")
   const smokeValid = verifySafeSmokeEvidence(smoke, { environment: manifest.environment, projectRef: manifest.projectRef, gitSha: manifest.observation?.gitSha })
   if (manifest.prerequisites?.migrationDeployment?.status !== "passed"
     || manifest.prerequisites?.schemaParity?.status !== "passed"
@@ -155,8 +171,18 @@ export function verifyEnvironmentManifest(manifest) {
     || manifest.prerequisites.valueFlowReadback.tableCount < 1
     || manifest.prerequisites.valueFlowReadback.enabledCount !== 0) blockers.push("value-flow-readback")
   if (manifest.prerequisites?.hostedUnauthenticatedDenial?.status !== "passed"
-    || !smokeValid
-    || (smokeValid && observationTimeValid && Date.parse(smoke.observedAt) > Date.parse(manifest.observation.observedAt))) blockers.push("runtime-smoke")
+    || !smokeValid) blockers.push("runtime-smoke")
+  const componentObservations = [
+    ["schema", manifest.schema?.observedAt],
+    ["function", manifest.functions?.observedAt],
+    ["hosted-smoke", smoke?.observedAt],
+  ]
+  for (const [name, observedAt] of componentObservations) {
+    const componentTimeValid = isExplicitRfc3339Timestamp(observedAt)
+    if (!componentTimeValid) blockers.push(`${name}-observation-time`)
+    if (componentTimeValid && deploymentTimeValid && compareExplicitRfc3339Timestamps(observedAt, manifest.certifiedDeployment.recordedAt) < 0) blockers.push(`${name}-before-deployment`)
+    if (componentTimeValid && observationTimeValid && compareExplicitRfc3339Timestamps(observedAt, manifest.observation.observedAt) > 0) blockers.push(`${name}-after-observation`)
+  }
   const expectedEvidence = [
     { evidenceId: "migration-deployment", sha256: sha256(canonical(manifest.certifiedDeployment)) },
     { evidenceId: "schema-parity", sha256: sha256(canonical({ migrations: manifest.migrations, schema: manifest.schema, runtimeControls: manifest.runtimeControls, certifiedDeployment: manifest.certifiedDeployment })) },

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -237,9 +237,15 @@ export function validateMigrationDeployEvidence(expected, observed) {
 }
 
 export function isExplicitRfc3339Timestamp(value) {
-  return typeof value === "string"
-    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/.test(value)
-    && Number.isFinite(Date.parse(value))
+  if (typeof value !== "string") return false
+  const match = /^(\d{4})-(0[1-9]|1[0-2])-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/.exec(value)
+  if (!match) return false
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1]
+  return day >= 1 && day <= daysInMonth && Number.isFinite(Date.parse(value))
 }
 
 export function bindObservedMigrationDeployEvidence(expected, observed) {

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -236,6 +236,14 @@ export function validateMigrationDeployEvidence(expected, observed) {
     && observed.inventorySha256 === expected.inventorySha256
 }
 
+export function bindObservedMigrationDeployEvidence(expected, observed) {
+  if (!validateMigrationDeployEvidence(expected, observed)
+    || !Number.isFinite(Date.parse(observed.recordedAt ?? ""))) {
+    throw new Error("migration-deployment-evidence-invalid: remote immutable row failed candidate or timestamp validation")
+  }
+  return { ...expected, recordedAt: observed.recordedAt }
+}
+
 export function libpqConnectionEnvironment(dbUrl) {
   const parsed = new URL(dbUrl)
   if (!["postgres:", "postgresql:"].includes(parsed.protocol) || !parsed.hostname || !parsed.username || !parsed.pathname.startsWith("/")) throw new Error("invalid-libpq-connection-url")
@@ -405,9 +413,8 @@ sql_paths = []
     if (!diagnosticMode && !driftMode) {
       expectedEvidence = buildMigrationDeployEvidence(deploymentBinding)
       const observedEvidence = observedMigrationEvidence(remoteDbUrl, deploymentBinding)
-      if (!validateMigrationDeployEvidence(expectedEvidence, observedEvidence)) {
-        throw new Error("migration-digest: remote candidate-bound deploy evidence differs from reviewed migration bytes")
-      }
+      try { expectedEvidence = bindObservedMigrationDeployEvidence(expectedEvidence, observedEvidence) }
+      catch { throw new Error("migration-digest: remote candidate-bound deploy evidence differs from reviewed migration bytes or has no immutable timestamp") }
     } else if (driftMode) {
       const expectedInventory = buildMigrationDeployEvidence({
         ...deploymentBinding,

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -236,9 +236,15 @@ export function validateMigrationDeployEvidence(expected, observed) {
     && observed.inventorySha256 === expected.inventorySha256
 }
 
+export function isExplicitRfc3339Timestamp(value) {
+  return typeof value === "string"
+    && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/.test(value)
+    && Number.isFinite(Date.parse(value))
+}
+
 export function bindObservedMigrationDeployEvidence(expected, observed) {
   if (!validateMigrationDeployEvidence(expected, observed)
-    || !Number.isFinite(Date.parse(observed.recordedAt ?? ""))) {
+    || !isExplicitRfc3339Timestamp(observed.recordedAt)) {
     throw new Error("migration-deployment-evidence-invalid: remote immutable row failed candidate or timestamp validation")
   }
   return { ...expected, recordedAt: observed.recordedAt }
@@ -298,7 +304,7 @@ export function validateMatchingMigrationEvidence(evidence, binding, expectedInv
     && /^[0-9a-f]{40}$/.test(evidence.candidateGitSha ?? "")
     && /^\d+$/.test(evidence.actionsRunId ?? "")
     && Number.isInteger(evidence.runAttempt) && evidence.runAttempt >= 1
-    && Number.isFinite(Date.parse(evidence.recordedAt ?? ""))
+    && isExplicitRfc3339Timestamp(evidence.recordedAt)
     && evidence.inventorySha256 === migrationInventorySha256(evidence.migrations ?? [])
     && evidence.inventorySha256 === expectedInventorySha256
 }

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -1,6 +1,6 @@
 import { createHash, randomBytes } from "node:crypto"
 import { execFileSync } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import net from "node:net"
 import os from "node:os"
 import path from "node:path"
@@ -211,6 +211,25 @@ export function migrationInventorySha256(items) {
   return fingerprint(canonicalJson(items))
 }
 
+export function validateForwardPendingMigrationHistory(expectedMigrations, observedVersions, baselineEvidence, binding) {
+  const observedMigrations = expectedMigrations.slice(0, observedVersions.length)
+  const expectedVersions = expectedMigrations.map((entry) => entry.version)
+  if (observedVersions.length > expectedVersions.length
+    || canonicalJson(expectedVersions.slice(0, observedVersions.length)) !== canonicalJson(observedVersions)) {
+    throw new Error(`Migration history drift: expected-prefix=${expectedVersions.slice(0, observedVersions.length).join(",")} observed=${observedVersions.join(",")}`)
+  }
+  const baselineInventorySha256 = migrationInventorySha256(observedMigrations)
+  if (!validateMatchingMigrationEvidence(baselineEvidence, binding, baselineInventorySha256)
+    || canonicalJson(baselineEvidence.migrations) !== canonicalJson(observedMigrations)) {
+    throw new Error("migration-baseline-digest: remote history does not match the reviewed forward-migration baseline")
+  }
+  return {
+    observedMigrations,
+    pendingMigrations: expectedMigrations.slice(observedVersions.length),
+    baselineInventorySha256,
+  }
+}
+
 export function buildMigrationDeployEvidence(input, root = process.cwd()) {
   const migrations = expectedMigrationInventory(root)
   return {
@@ -330,6 +349,13 @@ function observedMigrationEvidence(dbUrl, binding) {
   return JSON.parse(output)
 }
 
+function latestMigrationBaselineEvidence(projectId, dbUrl, binding, baselineInventorySha256) {
+  const sql = `select json_build_object('contractVersion',contract_version,'candidateGitSha',candidate_git_sha,'actionsRunId',actions_run_id::text,'runAttempt',run_attempt,'environment',deployment_environment,'projectRef',project_ref,'migrations',migration_inventory,'inventorySha256',inventory_sha256,'recordedAt',recorded_at)::text from public.supabase_deploy_migration_evidence where deployment_environment='${binding.environment}' and project_ref='${binding.projectRef}' and inventory_sha256='${baselineInventorySha256}' order by recorded_at desc limit 1`
+  const output = psqlFromParityContainer(projectId, dbUrl, sql)
+  if (!output) throw new Error("migration-baseline-evidence-missing: no immutable deployment record matches the remote migration baseline")
+  return JSON.parse(output)
+}
+
 export function validateMatchingMigrationEvidence(evidence, binding, expectedInventorySha256) {
   return evidence.contractVersion === "fundloop.migration-deploy-evidence/v1"
     && evidence.environment === binding.environment
@@ -337,12 +363,47 @@ export function validateMatchingMigrationEvidence(evidence, binding, expectedInv
     && /^[0-9a-f]{40}$/.test(evidence.candidateGitSha ?? "")
     && /^\d+$/.test(evidence.actionsRunId ?? "")
     && Number.isInteger(evidence.runAttempt) && evidence.runAttempt >= 1
+    && Array.isArray(evidence.migrations)
+    && evidence.migrations.length >= 1
+    && evidence.migrations.every((migration) => /^\d{14}$/.test(migration.version ?? "")
+      && migration.name?.startsWith(`${migration.version}_`)
+      && /^[0-9a-f]{64}$/.test(migration.fileSha256 ?? ""))
+    && new Set(evidence.migrations.map((migration) => migration.version)).size === evidence.migrations.length
+    && canonicalJson(evidence.migrations.map((migration) => migration.version)) === canonicalJson([...evidence.migrations.map((migration) => migration.version)].sort())
     && isExplicitRfc3339Timestamp(evidence.recordedAt)
     && evidence.inventorySha256 === migrationInventorySha256(evidence.migrations ?? [])
     && evidence.inventorySha256 === expectedInventorySha256
 }
 
-export function validateDeployCompletionEvidence(completion, evidence) {
+function validateCertifiedDeploymentManifestIntegrity(manifest) {
+  if (!manifest || manifest.contractVersion !== "fundloop.environment-delivery-manifest/v1" || manifest.observation?.mode !== "deploy") return false
+  if (!Array.isArray(manifest.evidence)
+    || !Array.isArray(manifest.migrations?.orderedInventory) || manifest.migrations.orderedInventory.length === 0
+    || !Array.isArray(manifest.migrations?.observedHistory)
+    || !Array.isArray(manifest.functions?.items) || manifest.functions.items.length === 0
+    || !manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence) return false
+  const { manifestSha256, ...payload } = manifest
+  const smoke = manifest.prerequisites?.hostedUnauthenticatedDenial?.evidence
+  const { evidenceSha256, ...smokePayload } = smoke ?? {}
+  const expectedEvidence = [
+    { evidenceId: "migration-deployment", sha256: fingerprint(canonicalJson(manifest.certifiedDeployment)) },
+    { evidenceId: "schema-parity", sha256: fingerprint(canonicalJson({ migrations: manifest.migrations, schema: manifest.schema, runtimeControls: manifest.runtimeControls, certifiedDeployment: manifest.certifiedDeployment })) },
+    { evidenceId: "function-parity", sha256: fingerprint(canonicalJson(manifest.functions)) },
+    { evidenceId: "runtime-prerequisites", sha256: fingerprint(canonicalJson(manifest.prerequisites)) },
+  ]
+  return /^[0-9a-f]{64}$/.test(manifestSha256 ?? "")
+    && manifestSha256 === fingerprint(canonicalJson(payload))
+    && canonicalJson(manifest.evidence) === canonicalJson(expectedEvidence)
+    && manifest.migrations.inventorySha256 === migrationInventorySha256(manifest.migrations.orderedInventory)
+    && manifest.migrations.orderedInventory.length === manifest.migrations.observedHistory?.length
+    && manifest.schema?.expectedSha256 === manifest.schema?.observedSha256
+    && manifest.functions.count === manifest.functions.items.length
+    && manifest.functions.inventorySha256 === fingerprint(canonicalJson(manifest.functions.items))
+    && smoke?.unauthenticatedStatusCode === 401
+    && evidenceSha256 === fingerprint(canonicalJson(smokePayload))
+}
+
+export function validateDeployCompletionEvidence(completion, evidence, certifiedManifest) {
   return completion?.contractVersion === "fundloop.deploy-completion-evidence/v1"
     && completion.candidateGitSha === evidence.candidateGitSha
     && completion.actionsRunId === evidence.actionsRunId
@@ -358,6 +419,33 @@ export function validateDeployCompletionEvidence(completion, evidence) {
     && isExplicitRfc3339Timestamp(completion.completedAt)
     && isExplicitRfc3339Timestamp(evidence.recordedAt)
     && compareExplicitRfc3339Timestamps(completion.completedAt, evidence.recordedAt) >= 0
+    && validateCertifiedDeploymentManifestIntegrity(certifiedManifest)
+    && certifiedManifest?.contractVersion === "fundloop.environment-delivery-manifest/v1"
+    && certifiedManifest.observation?.mode === "deploy"
+    && certifiedManifest.certifiedDeployment?.gitSha === completion.candidateGitSha
+    && certifiedManifest.certifiedDeployment?.githubRunId === completion.actionsRunId
+    && certifiedManifest.certifiedDeployment?.githubRunAttempt === completion.runAttempt
+    && certifiedManifest.certifiedDeployment?.recordedAt === evidence.recordedAt
+    && certifiedManifest.observation?.gitSha === completion.candidateGitSha
+    && certifiedManifest.observation?.githubRunId === completion.actionsRunId
+    && certifiedManifest.observation?.githubRunAttempt === completion.runAttempt
+    && certifiedManifest.environment === completion.environment
+    && certifiedManifest.projectRef === completion.projectRef
+    && certifiedManifest.migrations?.inventorySha256 === completion.inventorySha256
+    && certifiedManifest.schema?.expectedSha256 === completion.schemaExpectedSha256
+    && certifiedManifest.schema?.observedSha256 === completion.schemaObservedSha256
+    && certifiedManifest.functions?.inventorySha256 === completion.functionInventorySha256
+    && certifiedManifest.runtimeControls?.productionValueFlowEnabledCount === 0
+    && certifiedManifest.prerequisites?.migrationDeployment?.status === "passed"
+    && certifiedManifest.prerequisites?.schemaParity?.status === "passed"
+    && certifiedManifest.prerequisites?.functionParity?.status === "passed"
+    && certifiedManifest.prerequisites?.valueFlowReadback?.status === "passed"
+    && certifiedManifest.prerequisites?.valueFlowReadback?.enabledCount === 0
+    && certifiedManifest.prerequisites?.hostedUnauthenticatedDenial?.status === "passed"
+    && certifiedManifest.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256 === completion.hostedSmokeEvidenceSha256
+    && certifiedManifest.manifestSha256 === completion.deploymentManifestSha256
+    && isExplicitRfc3339Timestamp(certifiedManifest.observation?.observedAt)
+    && compareExplicitRfc3339Timestamps(completion.completedAt, certifiedManifest.observation.observedAt) >= 0
 }
 
 export function buildDeployCompletionEvidence(manifest, binding) {
@@ -374,6 +462,7 @@ export function buildDeployCompletionEvidence(manifest, binding) {
     functionInventorySha256: manifest?.functions?.inventorySha256,
     hostedSmokeEvidenceSha256: manifest?.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256,
     deploymentManifestSha256: manifest?.manifestSha256,
+    completedAt: new Date().toISOString(),
   }
   const digests = [completion.inventorySha256, completion.schemaExpectedSha256, completion.schemaObservedSha256, completion.functionInventorySha256, completion.hostedSmokeEvidenceSha256, completion.deploymentManifestSha256]
   if (manifest?.contractVersion !== "fundloop.environment-delivery-manifest/v1"
@@ -389,13 +478,15 @@ export function buildDeployCompletionEvidence(manifest, binding) {
     || manifest?.observation?.githubRunId !== binding.actionsRunId
     || manifest?.observation?.githubRunAttempt !== binding.runAttempt
     || completion.schemaExpectedSha256 !== completion.schemaObservedSha256
+    || !isExplicitRfc3339Timestamp(manifest?.observation?.observedAt)
+    || compareExplicitRfc3339Timestamps(completion.completedAt, manifest.observation.observedAt) < 0
     || digests.some((digest) => !/^[0-9a-f]{64}$/.test(digest ?? ""))) {
     throw new Error("deployment-completion-invalid: manifest does not bind the exact successful deploy context")
   }
   return completion
 }
 
-function recordDeployCompletion(dbUrl, manifest, binding) {
+export function recordDeployCompletion(dbUrl, manifest, binding) {
   const completion = buildDeployCompletionEvidence(manifest, binding)
   const connection = libpqConnectionEnvironment(dbUrl)
   const sql = `INSERT INTO public.supabase_deploy_completion_evidence (
@@ -403,14 +494,14 @@ function recordDeployCompletion(dbUrl, manifest, binding) {
     deployment_environment, project_ref, inventory_sha256,
     schema_expected_sha256, schema_observed_sha256,
     function_inventory_sha256, hosted_smoke_evidence_sha256,
-    deployment_manifest_sha256
+    deployment_manifest_sha256, deployment_manifest, completed_at
   ) VALUES (
     'fundloop.deploy-completion-evidence/v1', :'candidate_git_sha',
     :'actions_run_id'::bigint, :'run_attempt'::integer,
     :'target_environment', :'project_ref', :'inventory_sha256',
     :'schema_expected_sha256', :'schema_observed_sha256',
     :'function_inventory_sha256', :'hosted_smoke_evidence_sha256',
-    :'deployment_manifest_sha256'
+    :'deployment_manifest_sha256', :'deployment_manifest'::jsonb, :'completed_at'::timestamptz
   );`
   const variables = {
     candidate_git_sha: completion.candidateGitSha,
@@ -424,6 +515,8 @@ function recordDeployCompletion(dbUrl, manifest, binding) {
     function_inventory_sha256: completion.functionInventorySha256,
     hosted_smoke_evidence_sha256: completion.hostedSmokeEvidenceSha256,
     deployment_manifest_sha256: completion.deploymentManifestSha256,
+    deployment_manifest: JSON.stringify(manifest),
+    completed_at: completion.completedAt,
   }
   run("psql", ["-X", "-v", "ON_ERROR_STOP=1", ...Object.entries(variables).flatMap(([name, value]) => ["-v", `${name}=${value}`])], {
     encoding: "utf8",
@@ -433,12 +526,12 @@ function recordDeployCompletion(dbUrl, manifest, binding) {
 }
 
 function latestMatchingMigrationEvidence(dbUrl, binding, expectedInventorySha256) {
-  const sql = `select json_build_object('contractVersion',m.contract_version,'candidateGitSha',m.candidate_git_sha,'actionsRunId',m.actions_run_id::text,'runAttempt',m.run_attempt,'environment',m.deployment_environment,'projectRef',m.project_ref,'migrations',m.migration_inventory,'inventorySha256',m.inventory_sha256,'recordedAt',m.recorded_at,'completion',json_build_object('contractVersion',c.contract_version,'candidateGitSha',c.candidate_git_sha,'actionsRunId',c.actions_run_id::text,'runAttempt',c.run_attempt,'environment',c.deployment_environment,'projectRef',c.project_ref,'inventorySha256',c.inventory_sha256,'schemaExpectedSha256',c.schema_expected_sha256,'schemaObservedSha256',c.schema_observed_sha256,'functionInventorySha256',c.function_inventory_sha256,'hostedSmokeEvidenceSha256',c.hosted_smoke_evidence_sha256,'deploymentManifestSha256',c.deployment_manifest_sha256,'completedAt',c.completed_at))::text from public.supabase_deploy_migration_evidence m join public.supabase_deploy_completion_evidence c using (candidate_git_sha,actions_run_id,run_attempt,deployment_environment,project_ref) where m.deployment_environment='${binding.environment}' and m.project_ref='${binding.projectRef}' and m.inventory_sha256='${expectedInventorySha256}' order by c.completed_at desc limit 1`
+  const sql = `select json_build_object('contractVersion',m.contract_version,'candidateGitSha',m.candidate_git_sha,'actionsRunId',m.actions_run_id::text,'runAttempt',m.run_attempt,'environment',m.deployment_environment,'projectRef',m.project_ref,'migrations',m.migration_inventory,'inventorySha256',m.inventory_sha256,'recordedAt',m.recorded_at,'certifiedManifest',c.deployment_manifest,'completion',json_build_object('contractVersion',c.contract_version,'candidateGitSha',c.candidate_git_sha,'actionsRunId',c.actions_run_id::text,'runAttempt',c.run_attempt,'environment',c.deployment_environment,'projectRef',c.project_ref,'inventorySha256',c.inventory_sha256,'schemaExpectedSha256',c.schema_expected_sha256,'schemaObservedSha256',c.schema_observed_sha256,'functionInventorySha256',c.function_inventory_sha256,'hostedSmokeEvidenceSha256',c.hosted_smoke_evidence_sha256,'deploymentManifestSha256',c.deployment_manifest_sha256,'completedAt',c.completed_at))::text from public.supabase_deploy_migration_evidence m join public.supabase_deploy_completion_evidence c using (candidate_git_sha,actions_run_id,run_attempt,deployment_environment,project_ref) where m.deployment_environment='${binding.environment}' and m.project_ref='${binding.projectRef}' and m.inventory_sha256='${expectedInventorySha256}' order by c.completed_at desc limit 1`
   const output = psqlFromHost(dbUrl, sql)
   if (!output) throw new Error("deployment-evidence-missing: no immutable deployment record matches reviewed migration bytes")
   const evidence = JSON.parse(output)
   if (!validateMatchingMigrationEvidence(evidence, binding, expectedInventorySha256)
-    || !validateDeployCompletionEvidence(evidence.completion, evidence)) {
+    || !validateDeployCompletionEvidence(evidence.completion, evidence, evidence.certifiedManifest)) {
     throw new Error("deployment-evidence-invalid: immutable deployment record failed independent validation")
   }
   return evidence
@@ -476,21 +569,6 @@ async function main() {
     if (!output || !/^[0-9a-f]{40}$/.test(evidence.candidateGitSha ?? "") || !/^\d+$/.test(evidence.actionsRunId) || evidence.runAttempt < 1 || !["dev", "main"].includes(evidence.environment) || !/^[a-z0-9]{20,}$/.test(evidence.projectRef ?? "")) throw new Error("Candidate-bound GitHub deployment context and SUPABASE_MIGRATION_EVIDENCE_OUTPUT are required")
     writeFileSync(output, `${JSON.stringify(evidence)}\n`, "utf8")
     console.log(`Prepared ${evidence.migrations.length} reviewed migration digests: ${evidence.inventorySha256}`)
-    return
-  }
-  if (process.argv[2] === "complete") {
-    const manifestPath = process.env.SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT
-    const dbUrl = process.env.SUPABASE_SCHEMA_DB_URL
-    if (!manifestPath || !dbUrl) throw new Error("SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT and SUPABASE_SCHEMA_DB_URL are required")
-    const binding = {
-      candidateGitSha: process.env.GITHUB_SHA,
-      actionsRunId: process.env.GITHUB_RUN_ID,
-      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
-      environment: process.env.TARGET_ENVIRONMENT,
-      projectRef: process.env.SUPABASE_PROJECT_REF,
-    }
-    recordDeployCompletion(dbUrl, JSON.parse(readFileSync(manifestPath, "utf8")), binding)
-    console.log(`Certified completed ${binding.environment} Supabase deployment ${binding.candidateGitSha}`)
     return
   }
   const remoteDbUrl = process.env.SUPABASE_SCHEMA_DB_URL
@@ -546,13 +624,37 @@ sql_paths = []
 
     const expectedMigrations = expectedMigrationInventory()
     const expectedVersions = expectedMigrations.map((entry) => entry.version)
-    const observedVersions = psqlFromParityContainer(projectId, remoteDbUrl, "select version from supabase_migrations.schema_migrations order by version").split("\n")
+    const observedVersions = psqlFromParityContainer(projectId, remoteDbUrl, "select version from supabase_migrations.schema_migrations order by version").split("\n").filter(Boolean)
     const repairIsOnlyPendingMigration = diagnosticMode && repairManifest
       && expectedVersions.length === observedVersions.length + 1
       && expectedVersions.at(-1) === repairManifest.repairMigrationVersion
       && canonicalJson(expectedVersions.slice(0, -1)) === canonicalJson(observedVersions)
-    if (JSON.stringify(expectedVersions) !== JSON.stringify(observedVersions) && !repairIsOnlyPendingMigration) {
+    const hasForwardPendingMigrations = diagnosticMode
+      && expectedVersions.length > observedVersions.length
+      && canonicalJson(expectedVersions.slice(0, observedVersions.length)) === canonicalJson(observedVersions)
+    if (JSON.stringify(expectedVersions) !== JSON.stringify(observedVersions) && !repairIsOnlyPendingMigration && !hasForwardPendingMigrations) {
       throw new Error(`Migration history drift: expected=${expectedVersions.join(",")} observed=${observedVersions.join(",")}`)
+    }
+    let forwardPendingValidation = null
+    let expectedDump = dumpPublicSchemaFromParityContainer(projectId, "postgresql://postgres:postgres@127.0.0.1:5432/postgres")
+    if (hasForwardPendingMigrations && !repairIsOnlyPendingMigration) {
+      const baselineMigrations = expectedMigrations.slice(0, observedVersions.length)
+      const baselineInventorySha256 = migrationInventorySha256(baselineMigrations)
+      const baselineEvidence = latestMigrationBaselineEvidence(projectId, remoteDbUrl, deploymentBinding, baselineInventorySha256)
+      forwardPendingValidation = validateForwardPendingMigrationHistory(expectedMigrations, observedVersions, baselineEvidence, deploymentBinding)
+
+      const baselineRoot = path.join(bootstrapRoot, "forward-baseline")
+      const baselineSupabase = path.join(baselineRoot, "supabase")
+      mkdirSync(path.join(baselineSupabase, "migrations"), { recursive: true })
+      writeFileSync(path.join(baselineSupabase, "config.toml"), `project_id = "${projectId}-baseline"\n\n[db]\nmajor_version = 17\n\n[db.migrations]\nenabled = true\nschema_paths = []\n\n[db.seed]\nenabled = false\nsql_paths = []\n`, "utf8")
+      for (const migration of forwardPendingValidation.observedMigrations) {
+        copyFileSync(path.join(process.cwd(), "supabase/migrations", migration.name), path.join(baselineSupabase, "migrations", migration.name))
+      }
+      psqlFromParityContainer(projectId, "postgresql://postgres:postgres@127.0.0.1:5432/postgres", "CREATE DATABASE fundloop_forward_baseline")
+      const baselineDbUrl = "postgresql://postgres:postgres@127.0.0.1:5432/fundloop_forward_baseline"
+      psqlFromParityContainer(projectId, baselineDbUrl, `CREATE TABLE public.supabase_deploy_context (id boolean PRIMARY KEY DEFAULT true CHECK (id), target_environment text NOT NULL CHECK (target_environment IN ('dev', 'main')), updated_at timestamptz NOT NULL DEFAULT now()); INSERT INTO public.supabase_deploy_context (id, target_environment) VALUES (true, '${targetEnvironment}');`)
+      run("supabase", ["db", "push", "--yes", "--include-all", "--db-url", baselineDbUrl, "--workdir", baselineRoot], { env: localEnv })
+      expectedDump = dumpPublicSchemaFromParityContainer(projectId, baselineDbUrl)
     }
     let expectedEvidence
     if (!diagnosticMode && !driftMode) {
@@ -573,8 +675,6 @@ sql_paths = []
       ? assertValueFlowDisabledWithQuery((sql) => psqlFromParityContainer(projectId, remoteDbUrl, sql))
       : assertValueFlowDisabled(remoteDbUrl)
 
-    const containerLocalDbUrl = "postgresql://postgres:postgres@127.0.0.1:5432/postgres"
-    const expectedDump = dumpPublicSchemaFromParityContainer(projectId, containerLocalDbUrl)
     const observedDump = dumpPublicSchemaFromParityContainer(projectId, remoteDumpDbUrl)
     const diagnostic = buildSchemaDiagnostic(expectedDump, observedDump, {
       candidateGitSha: process.env.OBSERVATION_GIT_SHA ?? process.env.GITHUB_SHA,
@@ -583,7 +683,7 @@ sql_paths = []
       observedAt: new Date().toISOString(),
       pgDumpVersion: pgDumpVersionFromParityContainer(projectId),
       migrationCount: observedVersions.length,
-      migrationInventorySha256: expectedEvidence?.inventorySha256 ?? migrationInventorySha256(expectedMigrations),
+      migrationInventorySha256: expectedEvidence?.inventorySha256 ?? forwardPendingValidation?.baselineInventorySha256 ?? migrationInventorySha256(expectedMigrations),
       baselineMigrationInventorySha256: repairIsOnlyPendingMigration
         ? migrationInventorySha256(expectedMigrations.slice(0, -1))
         : null,
@@ -601,6 +701,17 @@ sql_paths = []
     if (diagnostic.status === "drift" && !pendingRepairValidated) throw new Error(`Effective public schema drift: expected=${diagnostic.expectedSha256} observed=${diagnostic.observedSha256}; sanitized diagnostic written`)
     if (pendingRepairValidated) {
       console.log(`Validated exact pending Dev schema repair ${repairManifest.repairMigrationVersion} for observed drift ${diagnostic.observedSha256}`)
+      return
+    }
+    if (forwardPendingValidation) {
+      diagnostic.forwardPendingValidation = {
+        status: "reviewed-forward-replay",
+        baselineMigrationCount: forwardPendingValidation.observedMigrations.length,
+        baselineMigrationInventorySha256: forwardPendingValidation.baselineInventorySha256,
+        pendingMigrationVersions: forwardPendingValidation.pendingMigrations.map((migration) => migration.version),
+      }
+      if (process.env.SUPABASE_SCHEMA_DIAGNOSTIC_OUTPUT) writeFileSync(process.env.SUPABASE_SCHEMA_DIAGNOSTIC_OUTPUT, `${JSON.stringify(diagnostic, null, 2)}\n`, "utf8")
+      console.log(`Validated ${forwardPendingValidation.pendingMigrations.length} reviewed forward migration(s) against exact remote baseline ${forwardPendingValidation.baselineInventorySha256}`)
       return
     }
     const { expectedSha256, observedSha256 } = diagnostic
@@ -627,6 +738,7 @@ sql_paths = []
         environment: targetEnvironment,
         projectRef,
         ...(expectedEvidence?.completion ? { completion: expectedEvidence.completion } : {}),
+        ...(expectedEvidence?.certifiedManifest ? { certifiedManifest: expectedEvidence.certifiedManifest } : {}),
       },
       productionValueFlowControlTableCount: valueFlowControls.tableCount,
       enabledProductionValueFlowControlCount: valueFlowControls.enabledCount,

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -311,8 +311,14 @@ export function libpqConnectionEnvironment(dbUrl) {
     PGUSER: decodeURIComponent(parsed.username),
     PGPASSWORD: decodeURIComponent(parsed.password),
     PGDATABASE: decodeURIComponent(parsed.pathname.slice(1)),
-    PGSSLMODE: parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" ? "disable" : "require",
+    PGSSLMODE: ["127.0.0.1", "localhost", "host.docker.internal"].includes(parsed.hostname) ? "disable" : "require",
   }
+}
+
+export function localStackDatabaseUrl(port, databaseName = "postgres") {
+  if (!Number.isInteger(port) || port < 1 || port > 65535
+    || !/^[a-z][a-z0-9_]*$/.test(databaseName)) throw new Error("invalid-local-database-target")
+  return `postgresql://postgres:postgres@127.0.0.1:${port}/${databaseName}`
 }
 
 function containerLibpqConnection(projectId, dbUrl) {
@@ -596,9 +602,15 @@ async function main() {
   const bootstrapRoot = mkdtempSync(path.join(os.tmpdir(), `${projectId}-`))
   const bootstrapSupabase = path.join(bootstrapRoot, "supabase")
   const dbPort = await availablePort()
-  const localDbUrl = `postgresql://postgres:postgres@127.0.0.1:${dbPort}/postgres`
+  const localDbUrl = localStackDatabaseUrl(dbPort)
+  const baselineProjectId = `fundloop-baseline-${randomBytes(8).toString("hex")}`
+  const baselineRoot = path.join(bootstrapRoot, "forward-baseline")
+  const baselineSupabase = path.join(baselineRoot, "supabase")
+  const baselineDbPort = await availablePort()
+  const baselineLocalDbUrl = localStackDatabaseUrl(baselineDbPort)
   const localEnv = { ...process.env, PGSSLMODE: "disable", PGOPTIONS: `-c app.settings.fundloop_target_environment=${targetEnvironment}` }
   let startAttempted = false
+  let baselineStartAttempted = false
 
   try {
     mkdirSync(path.join(bootstrapSupabase, "migrations"), { recursive: true })
@@ -643,18 +655,16 @@ sql_paths = []
       const baselineEvidence = latestMigrationBaselineEvidence(projectId, remoteDbUrl, deploymentBinding, baselineInventorySha256)
       forwardPendingValidation = validateForwardPendingMigrationHistory(expectedMigrations, observedVersions, baselineEvidence, deploymentBinding)
 
-      const baselineRoot = path.join(bootstrapRoot, "forward-baseline")
-      const baselineSupabase = path.join(baselineRoot, "supabase")
       mkdirSync(path.join(baselineSupabase, "migrations"), { recursive: true })
-      writeFileSync(path.join(baselineSupabase, "config.toml"), `project_id = "${projectId}-baseline"\n\n[db]\nmajor_version = 17\n\n[db.migrations]\nenabled = true\nschema_paths = []\n\n[db.seed]\nenabled = false\nsql_paths = []\n`, "utf8")
+      writeFileSync(path.join(baselineSupabase, "config.toml"), `project_id = "${baselineProjectId}"\n\n[db]\nport = ${baselineDbPort}\nmajor_version = 17\nhealth_timeout = "2m"\n\n[db.migrations]\nenabled = true\nschema_paths = []\n\n[db.seed]\nenabled = false\nsql_paths = []\n`, "utf8")
+      baselineStartAttempted = true
+      run("supabase", ["db", "start", "--yes", "--workdir", baselineRoot], { env: localEnv })
+      run("psql", [baselineLocalDbUrl, "-X", "-v", "ON_ERROR_STOP=1", "-c", `CREATE TABLE public.supabase_deploy_context (id boolean PRIMARY KEY DEFAULT true CHECK (id), target_environment text NOT NULL CHECK (target_environment IN ('dev', 'main')), updated_at timestamptz NOT NULL DEFAULT now()); INSERT INTO public.supabase_deploy_context (id, target_environment) VALUES (true, '${targetEnvironment}');`], { env: localEnv })
       for (const migration of forwardPendingValidation.observedMigrations) {
         copyFileSync(path.join(process.cwd(), "supabase/migrations", migration.name), path.join(baselineSupabase, "migrations", migration.name))
       }
-      psqlFromParityContainer(projectId, "postgresql://postgres:postgres@127.0.0.1:5432/postgres", "CREATE DATABASE fundloop_forward_baseline")
-      const baselineDbUrl = "postgresql://postgres:postgres@127.0.0.1:5432/fundloop_forward_baseline"
-      psqlFromParityContainer(projectId, baselineDbUrl, `CREATE TABLE public.supabase_deploy_context (id boolean PRIMARY KEY DEFAULT true CHECK (id), target_environment text NOT NULL CHECK (target_environment IN ('dev', 'main')), updated_at timestamptz NOT NULL DEFAULT now()); INSERT INTO public.supabase_deploy_context (id, target_environment) VALUES (true, '${targetEnvironment}');`)
-      run("supabase", ["db", "push", "--yes", "--include-all", "--db-url", baselineDbUrl, "--workdir", baselineRoot], { env: localEnv })
-      expectedDump = dumpPublicSchemaFromParityContainer(projectId, baselineDbUrl)
+      run("supabase", ["db", "push", "--yes", "--include-all", "--db-url", baselineLocalDbUrl, "--workdir", baselineRoot], { env: localEnv })
+      expectedDump = dumpPublicSchemaFromParityContainer(baselineProjectId, "postgresql://postgres:postgres@127.0.0.1:5432/postgres")
     }
     let expectedEvidence
     if (!diagnosticMode && !driftMode) {
@@ -746,6 +756,10 @@ sql_paths = []
     if (process.env.SUPABASE_SCHEMA_PARITY_OUTPUT) writeFileSync(process.env.SUPABASE_SCHEMA_PARITY_OUTPUT, `${JSON.stringify(result, null, 2)}\n`, "utf8")
     console.log(`Verified effective public schema parity: ${observedSha256}`)
   } finally {
+    if (baselineStartAttempted) {
+      try { run("supabase", ["stop", "--no-backup", "--workdir", baselineRoot], { env: localEnv }) }
+      catch (error) { console.error(`Could not fully stop task-owned schema baseline project ${baselineProjectId}:`, error) }
+    }
     if (startAttempted) {
       try { run("supabase", ["stop", "--no-backup", "--workdir", bootstrapRoot], { env: localEnv }) }
       catch (error) { console.error(`Could not fully stop task-owned schema project ${projectId}:`, error) }

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -236,16 +236,41 @@ export function validateMigrationDeployEvidence(expected, observed) {
     && observed.inventorySha256 === expected.inventorySha256
 }
 
-export function isExplicitRfc3339Timestamp(value) {
+function parseExplicitRfc3339Timestamp(value) {
   if (typeof value !== "string") return false
-  const match = /^(\d{4})-(0[1-9]|1[0-2])-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/.exec(value)
+  const match = /^(\d{4})-(0[1-9]|1[0-2])-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.(\d+))?(Z|([+-])([01]\d|2[0-3]):([0-5]\d))$/.exec(value)
   if (!match) return false
   const year = Number(match[1])
   const month = Number(match[2])
   const day = Number(match[3])
   const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
   const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1]
-  return day >= 1 && day <= daysInMonth && Number.isFinite(Date.parse(value))
+  if (day < 1 || day > daysInMonth) return false
+  const utc = new Date(0)
+  utc.setUTCFullYear(year, month - 1, day)
+  utc.setUTCHours(Number(match[4]), Number(match[5]), Number(match[6]), 0)
+  const offsetSeconds = match[9]
+    ? (match[9] === "+" ? 1 : -1) * (Number(match[10]) * 60 + Number(match[11])) * 60
+    : 0
+  return {
+    epochSecond: BigInt(utc.getTime() / 1000 - offsetSeconds),
+    fractionalSecond: match[7] ?? "",
+  }
+}
+
+export function isExplicitRfc3339Timestamp(value) {
+  return parseExplicitRfc3339Timestamp(value) !== false
+}
+
+export function compareExplicitRfc3339Timestamps(left, right) {
+  const parsedLeft = parseExplicitRfc3339Timestamp(left)
+  const parsedRight = parseExplicitRfc3339Timestamp(right)
+  if (!parsedLeft || !parsedRight) throw new Error("invalid-explicit-rfc3339-timestamp")
+  if (parsedLeft.epochSecond !== parsedRight.epochSecond) return parsedLeft.epochSecond < parsedRight.epochSecond ? -1 : 1
+  const precision = Math.max(parsedLeft.fractionalSecond.length, parsedRight.fractionalSecond.length)
+  const leftFraction = parsedLeft.fractionalSecond.padEnd(precision, "0")
+  const rightFraction = parsedRight.fractionalSecond.padEnd(precision, "0")
+  return leftFraction === rightFraction ? 0 : leftFraction < rightFraction ? -1 : 1
 }
 
 export function bindObservedMigrationDeployEvidence(expected, observed) {

--- a/scripts/verify-supabase-schema-parity.mjs
+++ b/scripts/verify-supabase-schema-parity.mjs
@@ -12,6 +12,7 @@ function run(command, args, options = {}) {
     env: options.env ?? process.env,
     encoding: options.encoding,
     stdio: options.encoding ? "pipe" : "inherit",
+    input: options.input,
     maxBuffer: options.maxBuffer ?? 32 * 1024 * 1024,
   })
 }
@@ -240,6 +241,7 @@ function parseExplicitRfc3339Timestamp(value) {
   if (typeof value !== "string") return false
   const match = /^(\d{4})-(0[1-9]|1[0-2])-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.(\d+))?(Z|([+-])([01]\d|2[0-3]):([0-5]\d))$/.exec(value)
   if (!match) return false
+  if (match[9] === "-" && match[10] === "00" && match[11] === "00") return false
   const year = Number(match[1])
   const month = Number(match[2])
   const day = Number(match[3])
@@ -340,12 +342,103 @@ export function validateMatchingMigrationEvidence(evidence, binding, expectedInv
     && evidence.inventorySha256 === expectedInventorySha256
 }
 
+export function validateDeployCompletionEvidence(completion, evidence) {
+  return completion?.contractVersion === "fundloop.deploy-completion-evidence/v1"
+    && completion.candidateGitSha === evidence.candidateGitSha
+    && completion.actionsRunId === evidence.actionsRunId
+    && completion.runAttempt === evidence.runAttempt
+    && completion.environment === evidence.environment
+    && completion.projectRef === evidence.projectRef
+    && completion.inventorySha256 === evidence.inventorySha256
+    && completion.schemaExpectedSha256 === completion.schemaObservedSha256
+    && /^[0-9a-f]{64}$/.test(completion.schemaExpectedSha256 ?? "")
+    && /^[0-9a-f]{64}$/.test(completion.functionInventorySha256 ?? "")
+    && /^[0-9a-f]{64}$/.test(completion.hostedSmokeEvidenceSha256 ?? "")
+    && /^[0-9a-f]{64}$/.test(completion.deploymentManifestSha256 ?? "")
+    && isExplicitRfc3339Timestamp(completion.completedAt)
+    && isExplicitRfc3339Timestamp(evidence.recordedAt)
+    && compareExplicitRfc3339Timestamps(completion.completedAt, evidence.recordedAt) >= 0
+}
+
+export function buildDeployCompletionEvidence(manifest, binding) {
+  const completion = {
+    contractVersion: "fundloop.deploy-completion-evidence/v1",
+    candidateGitSha: manifest?.certifiedDeployment?.gitSha,
+    actionsRunId: manifest?.certifiedDeployment?.githubRunId,
+    runAttempt: manifest?.certifiedDeployment?.githubRunAttempt,
+    environment: manifest?.environment,
+    projectRef: manifest?.projectRef,
+    inventorySha256: manifest?.migrations?.inventorySha256,
+    schemaExpectedSha256: manifest?.schema?.expectedSha256,
+    schemaObservedSha256: manifest?.schema?.observedSha256,
+    functionInventorySha256: manifest?.functions?.inventorySha256,
+    hostedSmokeEvidenceSha256: manifest?.prerequisites?.hostedUnauthenticatedDenial?.evidence?.evidenceSha256,
+    deploymentManifestSha256: manifest?.manifestSha256,
+  }
+  const digests = [completion.inventorySha256, completion.schemaExpectedSha256, completion.schemaObservedSha256, completion.functionInventorySha256, completion.hostedSmokeEvidenceSha256, completion.deploymentManifestSha256]
+  if (manifest?.contractVersion !== "fundloop.environment-delivery-manifest/v1"
+    || manifest?.observation?.mode !== "deploy"
+    || completion.candidateGitSha !== binding.candidateGitSha
+    || completion.actionsRunId !== binding.actionsRunId
+    || completion.runAttempt !== binding.runAttempt
+    || completion.environment !== binding.environment
+    || completion.projectRef !== binding.projectRef
+    || manifest?.certifiedDeployment?.environment !== binding.environment
+    || manifest?.certifiedDeployment?.projectRef !== binding.projectRef
+    || manifest?.observation?.gitSha !== binding.candidateGitSha
+    || manifest?.observation?.githubRunId !== binding.actionsRunId
+    || manifest?.observation?.githubRunAttempt !== binding.runAttempt
+    || completion.schemaExpectedSha256 !== completion.schemaObservedSha256
+    || digests.some((digest) => !/^[0-9a-f]{64}$/.test(digest ?? ""))) {
+    throw new Error("deployment-completion-invalid: manifest does not bind the exact successful deploy context")
+  }
+  return completion
+}
+
+function recordDeployCompletion(dbUrl, manifest, binding) {
+  const completion = buildDeployCompletionEvidence(manifest, binding)
+  const connection = libpqConnectionEnvironment(dbUrl)
+  const sql = `INSERT INTO public.supabase_deploy_completion_evidence (
+    contract_version, candidate_git_sha, actions_run_id, run_attempt,
+    deployment_environment, project_ref, inventory_sha256,
+    schema_expected_sha256, schema_observed_sha256,
+    function_inventory_sha256, hosted_smoke_evidence_sha256,
+    deployment_manifest_sha256
+  ) VALUES (
+    'fundloop.deploy-completion-evidence/v1', :'candidate_git_sha',
+    :'actions_run_id'::bigint, :'run_attempt'::integer,
+    :'target_environment', :'project_ref', :'inventory_sha256',
+    :'schema_expected_sha256', :'schema_observed_sha256',
+    :'function_inventory_sha256', :'hosted_smoke_evidence_sha256',
+    :'deployment_manifest_sha256'
+  );`
+  const variables = {
+    candidate_git_sha: completion.candidateGitSha,
+    actions_run_id: completion.actionsRunId,
+    run_attempt: String(completion.runAttempt),
+    target_environment: completion.environment,
+    project_ref: completion.projectRef,
+    inventory_sha256: completion.inventorySha256,
+    schema_expected_sha256: completion.schemaExpectedSha256,
+    schema_observed_sha256: completion.schemaObservedSha256,
+    function_inventory_sha256: completion.functionInventorySha256,
+    hosted_smoke_evidence_sha256: completion.hostedSmokeEvidenceSha256,
+    deployment_manifest_sha256: completion.deploymentManifestSha256,
+  }
+  run("psql", ["-X", "-v", "ON_ERROR_STOP=1", ...Object.entries(variables).flatMap(([name, value]) => ["-v", `${name}=${value}`])], {
+    encoding: "utf8",
+    env: { ...process.env, ...connection },
+    input: sql,
+  })
+}
+
 function latestMatchingMigrationEvidence(dbUrl, binding, expectedInventorySha256) {
-  const sql = `select json_build_object('contractVersion',contract_version,'candidateGitSha',candidate_git_sha,'actionsRunId',actions_run_id::text,'runAttempt',run_attempt,'environment',deployment_environment,'projectRef',project_ref,'migrations',migration_inventory,'inventorySha256',inventory_sha256,'recordedAt',recorded_at)::text from public.supabase_deploy_migration_evidence where deployment_environment='${binding.environment}' and project_ref='${binding.projectRef}' and inventory_sha256='${expectedInventorySha256}' order by recorded_at desc limit 1`
+  const sql = `select json_build_object('contractVersion',m.contract_version,'candidateGitSha',m.candidate_git_sha,'actionsRunId',m.actions_run_id::text,'runAttempt',m.run_attempt,'environment',m.deployment_environment,'projectRef',m.project_ref,'migrations',m.migration_inventory,'inventorySha256',m.inventory_sha256,'recordedAt',m.recorded_at,'completion',json_build_object('contractVersion',c.contract_version,'candidateGitSha',c.candidate_git_sha,'actionsRunId',c.actions_run_id::text,'runAttempt',c.run_attempt,'environment',c.deployment_environment,'projectRef',c.project_ref,'inventorySha256',c.inventory_sha256,'schemaExpectedSha256',c.schema_expected_sha256,'schemaObservedSha256',c.schema_observed_sha256,'functionInventorySha256',c.function_inventory_sha256,'hostedSmokeEvidenceSha256',c.hosted_smoke_evidence_sha256,'deploymentManifestSha256',c.deployment_manifest_sha256,'completedAt',c.completed_at))::text from public.supabase_deploy_migration_evidence m join public.supabase_deploy_completion_evidence c using (candidate_git_sha,actions_run_id,run_attempt,deployment_environment,project_ref) where m.deployment_environment='${binding.environment}' and m.project_ref='${binding.projectRef}' and m.inventory_sha256='${expectedInventorySha256}' order by c.completed_at desc limit 1`
   const output = psqlFromHost(dbUrl, sql)
   if (!output) throw new Error("deployment-evidence-missing: no immutable deployment record matches reviewed migration bytes")
   const evidence = JSON.parse(output)
-  if (!validateMatchingMigrationEvidence(evidence, binding, expectedInventorySha256)) {
+  if (!validateMatchingMigrationEvidence(evidence, binding, expectedInventorySha256)
+    || !validateDeployCompletionEvidence(evidence.completion, evidence)) {
     throw new Error("deployment-evidence-invalid: immutable deployment record failed independent validation")
   }
   return evidence
@@ -383,6 +476,21 @@ async function main() {
     if (!output || !/^[0-9a-f]{40}$/.test(evidence.candidateGitSha ?? "") || !/^\d+$/.test(evidence.actionsRunId) || evidence.runAttempt < 1 || !["dev", "main"].includes(evidence.environment) || !/^[a-z0-9]{20,}$/.test(evidence.projectRef ?? "")) throw new Error("Candidate-bound GitHub deployment context and SUPABASE_MIGRATION_EVIDENCE_OUTPUT are required")
     writeFileSync(output, `${JSON.stringify(evidence)}\n`, "utf8")
     console.log(`Prepared ${evidence.migrations.length} reviewed migration digests: ${evidence.inventorySha256}`)
+    return
+  }
+  if (process.argv[2] === "complete") {
+    const manifestPath = process.env.SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT
+    const dbUrl = process.env.SUPABASE_SCHEMA_DB_URL
+    if (!manifestPath || !dbUrl) throw new Error("SUPABASE_ENVIRONMENT_MANIFEST_OUTPUT and SUPABASE_SCHEMA_DB_URL are required")
+    const binding = {
+      candidateGitSha: process.env.GITHUB_SHA,
+      actionsRunId: process.env.GITHUB_RUN_ID,
+      runAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+      environment: process.env.TARGET_ENVIRONMENT,
+      projectRef: process.env.SUPABASE_PROJECT_REF,
+    }
+    recordDeployCompletion(dbUrl, JSON.parse(readFileSync(manifestPath, "utf8")), binding)
+    console.log(`Certified completed ${binding.environment} Supabase deployment ${binding.candidateGitSha}`)
     return
   }
   const remoteDbUrl = process.env.SUPABASE_SCHEMA_DB_URL
@@ -518,6 +626,7 @@ sql_paths = []
         recordedAt: expectedEvidence?.recordedAt ?? new Date().toISOString(),
         environment: targetEnvironment,
         projectRef,
+        ...(expectedEvidence?.completion ? { completion: expectedEvidence.completion } : {}),
       },
       productionValueFlowControlTableCount: valueFlowControls.tableCount,
       enabledProductionValueFlowControlCount: valueFlowControls.enabledCount,

--- a/supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql
+++ b/supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql
@@ -1,0 +1,70 @@
+CREATE TABLE public.supabase_deploy_completion_evidence (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  contract_version text NOT NULL DEFAULT 'fundloop.deploy-completion-evidence/v1'
+    CHECK (contract_version = 'fundloop.deploy-completion-evidence/v1'),
+  candidate_git_sha text NOT NULL CHECK (candidate_git_sha ~ '^[0-9a-f]{40}$'),
+  actions_run_id bigint NOT NULL CHECK (actions_run_id > 0),
+  run_attempt integer NOT NULL CHECK (run_attempt > 0),
+  deployment_environment text NOT NULL CHECK (deployment_environment IN ('dev', 'main')),
+  project_ref text NOT NULL CHECK (project_ref ~ '^[a-z0-9]{20,}$'),
+  inventory_sha256 text NOT NULL CHECK (inventory_sha256 ~ '^[0-9a-f]{64}$'),
+  schema_expected_sha256 text NOT NULL CHECK (schema_expected_sha256 ~ '^[0-9a-f]{64}$'),
+  schema_observed_sha256 text NOT NULL CHECK (
+    schema_observed_sha256 ~ '^[0-9a-f]{64}$'
+    AND schema_observed_sha256 = schema_expected_sha256
+  ),
+  function_inventory_sha256 text NOT NULL CHECK (function_inventory_sha256 ~ '^[0-9a-f]{64}$'),
+  hosted_smoke_evidence_sha256 text NOT NULL CHECK (hosted_smoke_evidence_sha256 ~ '^[0-9a-f]{64}$'),
+  deployment_manifest_sha256 text NOT NULL CHECK (deployment_manifest_sha256 ~ '^[0-9a-f]{64}$'),
+  completed_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  UNIQUE (candidate_git_sha, actions_run_id, run_attempt, deployment_environment, project_ref),
+  FOREIGN KEY (candidate_git_sha, actions_run_id, run_attempt, deployment_environment, project_ref)
+    REFERENCES public.supabase_deploy_migration_evidence (
+      candidate_git_sha, actions_run_id, run_attempt, deployment_environment, project_ref
+    )
+);
+
+CREATE OR REPLACE FUNCTION public.validate_supabase_deploy_completion_evidence_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.supabase_deploy_migration_evidence candidate
+    WHERE candidate.candidate_git_sha = NEW.candidate_git_sha
+      AND candidate.actions_run_id = NEW.actions_run_id
+      AND candidate.run_attempt = NEW.run_attempt
+      AND candidate.deployment_environment = NEW.deployment_environment
+      AND candidate.project_ref = NEW.project_ref
+      AND candidate.inventory_sha256 = NEW.inventory_sha256
+      AND candidate.recorded_at <= NEW.completed_at
+  ) THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'supabase_deploy_completion_candidate_mismatch';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER supabase_deploy_completion_evidence_validate
+BEFORE INSERT ON public.supabase_deploy_completion_evidence
+FOR EACH ROW EXECUTE FUNCTION public.validate_supabase_deploy_completion_evidence_insert();
+
+CREATE OR REPLACE FUNCTION public.reject_supabase_deploy_completion_evidence_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RAISE EXCEPTION USING ERRCODE = '55000', MESSAGE = 'supabase_deploy_completion_evidence_is_append_only';
+END;
+$$;
+
+CREATE TRIGGER supabase_deploy_completion_evidence_append_only
+BEFORE UPDATE OR DELETE ON public.supabase_deploy_completion_evidence
+FOR EACH ROW EXECUTE FUNCTION public.reject_supabase_deploy_completion_evidence_mutation();
+
+REVOKE ALL ON TABLE public.supabase_deploy_completion_evidence FROM anon, authenticated;
+REVOKE ALL ON FUNCTION public.validate_supabase_deploy_completion_evidence_insert() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reject_supabase_deploy_completion_evidence_mutation() FROM PUBLIC;

--- a/supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql
+++ b/supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql
@@ -16,6 +16,7 @@ CREATE TABLE public.supabase_deploy_completion_evidence (
   function_inventory_sha256 text NOT NULL CHECK (function_inventory_sha256 ~ '^[0-9a-f]{64}$'),
   hosted_smoke_evidence_sha256 text NOT NULL CHECK (hosted_smoke_evidence_sha256 ~ '^[0-9a-f]{64}$'),
   deployment_manifest_sha256 text NOT NULL CHECK (deployment_manifest_sha256 ~ '^[0-9a-f]{64}$'),
+  deployment_manifest jsonb NOT NULL CHECK (jsonb_typeof(deployment_manifest) = 'object'),
   completed_at timestamptz NOT NULL DEFAULT clock_timestamp(),
   UNIQUE (candidate_git_sha, actions_run_id, run_attempt, deployment_environment, project_ref),
   FOREIGN KEY (candidate_git_sha, actions_run_id, run_attempt, deployment_environment, project_ref)
@@ -30,6 +31,30 @@ LANGUAGE plpgsql
 SET search_path = public, pg_temp
 AS $$
 BEGIN
+  IF NEW.deployment_manifest ->> 'contractVersion' IS DISTINCT FROM 'fundloop.environment-delivery-manifest/v1'
+    OR NEW.deployment_manifest #>> '{observation,mode}' IS DISTINCT FROM 'deploy'
+    OR NEW.deployment_manifest #>> '{observation,gitSha}' IS DISTINCT FROM NEW.candidate_git_sha
+    OR NEW.deployment_manifest #>> '{observation,githubRunId}' IS DISTINCT FROM NEW.actions_run_id::text
+    OR (NEW.deployment_manifest #>> '{observation,githubRunAttempt}')::integer IS DISTINCT FROM NEW.run_attempt
+    OR NEW.deployment_manifest ->> 'environment' IS DISTINCT FROM NEW.deployment_environment
+    OR NEW.deployment_manifest ->> 'projectRef' IS DISTINCT FROM NEW.project_ref
+    OR NEW.deployment_manifest #>> '{migrations,inventorySha256}' IS DISTINCT FROM NEW.inventory_sha256
+    OR NEW.deployment_manifest #>> '{schema,expectedSha256}' IS DISTINCT FROM NEW.schema_expected_sha256
+    OR NEW.deployment_manifest #>> '{schema,observedSha256}' IS DISTINCT FROM NEW.schema_observed_sha256
+    OR NEW.deployment_manifest #>> '{functions,inventorySha256}' IS DISTINCT FROM NEW.function_inventory_sha256
+    OR NEW.deployment_manifest #>> '{prerequisites,hostedUnauthenticatedDenial,evidence,evidenceSha256}' IS DISTINCT FROM NEW.hosted_smoke_evidence_sha256
+    OR NEW.deployment_manifest ->> 'manifestSha256' IS DISTINCT FROM NEW.deployment_manifest_sha256
+    OR NEW.deployment_manifest #>> '{observation,observedAt}' IS NULL
+    OR (NEW.deployment_manifest #>> '{observation,observedAt}')::timestamptz > NEW.completed_at
+    OR NEW.deployment_manifest #>> '{schema,observedAt}' IS NULL
+    OR (NEW.deployment_manifest #>> '{schema,observedAt}')::timestamptz > NEW.completed_at
+    OR NEW.deployment_manifest #>> '{functions,observedAt}' IS NULL
+    OR (NEW.deployment_manifest #>> '{functions,observedAt}')::timestamptz > NEW.completed_at
+    OR NEW.deployment_manifest #>> '{prerequisites,hostedUnauthenticatedDenial,evidence,observedAt}' IS NULL
+    OR (NEW.deployment_manifest #>> '{prerequisites,hostedUnauthenticatedDenial,evidence,observedAt}')::timestamptz > NEW.completed_at
+  THEN
+    RAISE EXCEPTION USING ERRCODE = '23514', MESSAGE = 'supabase_deploy_completion_manifest_mismatch';
+  END IF;
   IF NOT EXISTS (
     SELECT 1
     FROM public.supabase_deploy_migration_evidence candidate

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -181,12 +181,35 @@ describe("Supabase delivery parity", () => {
       inventorySha256: "",
     }
     expected.inventorySha256 = migrationInventorySha256(expected.migrations)
-    const observed = { ...structuredClone(expected), recordedAt: "2026-08-12T19:00:00.123Z" }
+    const observed = { ...structuredClone(expected), recordedAt: "2026-08-12T23:28:57.708226+00:00" }
     const deployEvidence = bindObservedMigrationDeployEvidence(expected, observed)
     expect(deployEvidence.recordedAt).toBe(observed.recordedAt)
     expect(validateMatchingMigrationEvidence(observed, expected, expected.inventorySha256)).toBe(true)
-    expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, recordedAt: "invalid" })).toThrow("remote immutable row")
+    for (const recordedAt of ["0", "12", "2026-08-12", "2026-08-12 23:28:57+00:00", "2026-08-12T23:28:57", "2026-08-12T23:28:57+24:00"]) {
+      expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, recordedAt }), recordedAt).toThrow("remote immutable row")
+      expect(validateMatchingMigrationEvidence({ ...observed, recordedAt }, expected, expected.inventorySha256), recordedAt).toBe(false)
+    }
     expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, inventorySha256: "0".repeat(64) })).toThrow("remote immutable row")
+  })
+
+  it("requires explicit RFC3339 seconds and timezone for immutable timestamps", () => {
+    for (const timestamp of [
+      "2026-08-12T23:28:57.708226+00:00",
+      "2026-08-12T23:28:57Z",
+      "2026-08-12T19:28:57.1-04:00",
+    ]) expect(isExplicitRfc3339Timestamp(timestamp), timestamp).toBe(true)
+
+    for (const timestamp of [
+      "0",
+      "12",
+      "2026-08-12",
+      "2026-08-12 23:28:57+00:00",
+      "2026-08-12T23:28:57",
+      "2026-08-12T23:28Z",
+      "2026-08-12T23:28:57+0000",
+      "2026-08-12T23:28:57+24:00",
+      "2026-08-12T23:28:57+00:60",
+    ]) expect(isExplicitRfc3339Timestamp(timestamp), timestamp).toBe(false)
   })
 
   it("keeps candidate-bound migration evidence append-only and non-browser-readable", () => {

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -170,6 +170,23 @@ describe("Supabase delivery parity", () => {
     changed.migrations[0].fileSha256 = "0".repeat(64)
     expect(validateMatchingMigrationEvidence(changed, binding, inventorySha256)).toBe(false)
     expect(validateMatchingMigrationEvidence({ ...evidence, environment: "main" }, binding, inventorySha256)).toBe(false)
+  })
+
+  it("preserves one validated immutable timestamp for deploy and drift provenance", () => {
+    const expected = {
+      contractVersion: "fundloop.migration-deploy-evidence/v1",
+      candidateGitSha: "b".repeat(40), actionsRunId: "42", runAttempt: 1,
+      environment: "dev", projectRef: "a".repeat(20),
+      migrations: [{ version: "20260101000000", name: "20260101000000_first.sql", fileSha256: "a".repeat(64) }],
+      inventorySha256: "",
+    }
+    expected.inventorySha256 = migrationInventorySha256(expected.migrations)
+    const observed = { ...structuredClone(expected), recordedAt: "2026-08-12T19:00:00.123Z" }
+    const deployEvidence = bindObservedMigrationDeployEvidence(expected, observed)
+    expect(deployEvidence.recordedAt).toBe(observed.recordedAt)
+    expect(validateMatchingMigrationEvidence(observed, expected, expected.inventorySha256)).toBe(true)
+    expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, recordedAt: "invalid" })).toThrow("remote immutable row")
+    expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, inventorySha256: "0".repeat(64) })).toThrow("remote immutable row")
   })
 
   it("keeps candidate-bound migration evidence append-only and non-browser-readable", () => {

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { bindObservedMigrationDeployEvidence, buildDeployCompletionEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateDeployCompletionEvidence, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -86,7 +86,9 @@ describe("Supabase delivery parity", () => {
   })
 
   it("accepts only the exact versioned Dev drift while its repair is the sole pending migration", () => {
-    const baselineMigrations = expectedMigrationInventory().slice(0, -1)
+    const migrations = expectedMigrationInventory()
+    const repairIndex = migrations.findIndex((entry) => entry.version === repairManifest.repairMigrationVersion)
+    const baselineMigrations = migrations.slice(0, repairIndex)
     expect(migrationInventorySha256(baselineMigrations)).toBe(repairManifest.baselineMigrationInventorySha256)
     const diagnostic = {
       environment: repairManifest.environment,
@@ -215,6 +217,7 @@ describe("Supabase delivery parity", () => {
       "2026-08-12T23:28:57+0000",
       "2026-08-12T23:28:57+24:00",
       "2026-08-12T23:28:57+00:60",
+      "2026-08-12T23:28:57-00:00",
       "2026-02-29T00:00:00Z",
       "2026-04-31T23:59:59Z",
       "2026-12-31T24:00:00Z",
@@ -230,11 +233,56 @@ describe("Supabase delivery parity", () => {
     expect(compareExplicitRfc3339Timestamps("2026-08-12T20:00:00.1Z", "2026-08-12T20:00:00.1000000000Z")).toBe(0)
   })
 
+  it("certifies only exact immutable candidate/completion evidence pairs", () => {
+    const evidence = {
+      contractVersion: "fundloop.migration-deploy-evidence/v1",
+      candidateGitSha: "b".repeat(40), actionsRunId: "42", runAttempt: 1,
+      environment: "dev", projectRef: "a".repeat(20),
+      migrations: [{ version: "20260101000000", name: "20260101000000_first.sql", fileSha256: "a".repeat(64) }],
+      inventorySha256: "c".repeat(64), recordedAt: "2026-08-13T00:00:00.000001Z",
+    }
+    const completion = {
+      contractVersion: "fundloop.deploy-completion-evidence/v1",
+      candidateGitSha: evidence.candidateGitSha, actionsRunId: evidence.actionsRunId,
+      runAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef,
+      inventorySha256: evidence.inventorySha256,
+      schemaExpectedSha256: "d".repeat(64), schemaObservedSha256: "d".repeat(64),
+      functionInventorySha256: "e".repeat(64), hostedSmokeEvidenceSha256: "f".repeat(64),
+      deploymentManifestSha256: "1".repeat(64), completedAt: "2026-08-13T00:00:00.000999Z",
+    }
+    expect(validateDeployCompletionEvidence(completion, evidence)).toBe(true)
+    expect(validateDeployCompletionEvidence(undefined, evidence)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, candidateGitSha: "9".repeat(40) }, evidence)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, inventorySha256: "9".repeat(64) }, evidence)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, schemaObservedSha256: "9".repeat(64) }, evidence)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, completedAt: "2026-08-12T23:59:59Z" }, evidence)).toBe(false)
+    const manifest = {
+      contractVersion: "fundloop.environment-delivery-manifest/v1",
+      environment: evidence.environment, projectRef: evidence.projectRef,
+      observation: { mode: "deploy", gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt },
+      certifiedDeployment: { gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef },
+      migrations: { inventorySha256: evidence.inventorySha256 },
+      schema: { expectedSha256: completion.schemaExpectedSha256, observedSha256: completion.schemaObservedSha256 },
+      functions: { inventorySha256: completion.functionInventorySha256 },
+      prerequisites: { hostedUnauthenticatedDenial: { evidence: { evidenceSha256: completion.hostedSmokeEvidenceSha256 } } },
+      manifestSha256: completion.deploymentManifestSha256,
+    }
+    const binding = { candidateGitSha: evidence.candidateGitSha, actionsRunId: evidence.actionsRunId, runAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef }
+    expect(buildDeployCompletionEvidence(manifest, binding)).toMatchObject({ deploymentManifestSha256: completion.deploymentManifestSha256 })
+    expect(() => buildDeployCompletionEvidence(manifest, { ...binding, actionsRunId: "43" })).toThrow("deployment-completion-invalid")
+  })
+
   it("keeps candidate-bound migration evidence append-only and non-browser-readable", () => {
     const sql = readFileSync("supabase/migrations/20260812120000_supabase_deploy_migration_evidence.sql", "utf8")
     expect(sql).toContain("BEFORE UPDATE OR DELETE")
     expect(sql).toContain("supabase_deploy_migration_evidence_is_append_only")
     expect(sql).toContain("REVOKE ALL ON TABLE public.supabase_deploy_migration_evidence FROM anon, authenticated")
+    const completionSql = readFileSync("supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql", "utf8")
+    expect(completionSql).toContain("REFERENCES public.supabase_deploy_migration_evidence")
+    expect(completionSql).toContain("supabase_deploy_completion_candidate_mismatch")
+    expect(completionSql).toContain("candidate.inventory_sha256 = NEW.inventory_sha256")
+    expect(completionSql).toContain("supabase_deploy_completion_evidence_is_append_only")
+    expect(completionSql).toContain("REVOKE ALL ON TABLE public.supabase_deploy_completion_evidence FROM anon, authenticated")
   })
 
   it("derives reviewed function closures independently and blocks missing or extra remote paths", () => {
@@ -270,6 +318,13 @@ describe("Supabase delivery parity", () => {
     expect(workflow).toContain('status_code}" != "401"')
     expect(workflow).toContain("Record safe hosted runtime denial")
     expect(workflow.indexOf("Record safe hosted runtime denial")).toBeLessThan(workflow.indexOf("Publish immutable environment manifest"))
+    expect(workflow.indexOf("Publish immutable environment manifest")).toBeLessThan(workflow.indexOf("Certify completed Supabase deployment"))
+    expect(workflow.indexOf("Certify completed Supabase deployment")).toBeLessThan(workflow.indexOf("Upload immutable environment manifest"))
+    expect(workflow).toContain("verify-supabase-schema-parity.mjs complete")
+    expect(workflow).toContain('SUPABASE_SCHEMA_DB_URL="${supabase_db_url}"')
+    const completionStep = workflow.slice(workflow.indexOf("- name: Certify completed Supabase deployment"), workflow.indexOf("- name: Upload sanitized Supabase parity evidence"))
+    expect(completionStep).not.toContain('psql "${supabase_db_url}"')
+    expect(schemaVerifier).toContain("INSERT INTO public.supabase_deploy_completion_evidence")
     expect(workflow).toContain("actions/upload-artifact@v4")
     expect(workflow).toContain("if: ${{ always() && steps.target.outputs.mode == 'deploy' }}")
     expect(workflow).toContain("if-no-files-found: warn")

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -4,7 +4,7 @@ import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
 import { buildEnvironmentManifest, buildSafeSmokeEvidence } from "../scripts/verify-supabase-environment-manifest.mjs"
-import { bindObservedMigrationDeployEvidence, buildDeployCompletionEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateDeployCompletionEvidence, validateForwardPendingMigrationHistory, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { bindObservedMigrationDeployEvidence, buildDeployCompletionEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, localStackDatabaseUrl, migrationInventorySha256, normalizePublicSchema, validateDeployCompletionEvidence, validateForwardPendingMigrationHistory, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -22,10 +22,21 @@ describe("Supabase delivery parity", () => {
       PGSSLMODE: "require",
     })
     expect(libpqConnectionEnvironment("postgresql://postgres:postgres@127.0.0.1:5432/postgres").PGSSLMODE).toBe("disable")
+    expect(libpqConnectionEnvironment("postgresql://postgres:postgres@host.docker.internal:58743/postgres").PGSSLMODE).toBe("disable")
     expect(schemaVerifier).not.toContain('"psql", dbUrl')
     expect(schemaVerifier).not.toMatch(/run\("psql", \[(?:dbUrl|remoteDbUrl)/)
     expect(schemaVerifier).not.toContain('"--no-comments", dbUrl')
     expect(schemaVerifier).not.toContain('`PGPASSWORD=${')
+  })
+
+  it("routes host-side baseline replay through the dynamically allocated local port", () => {
+    expect(localStackDatabaseUrl(58743)).toBe("postgresql://postgres:postgres@127.0.0.1:58743/postgres")
+    expect(localStackDatabaseUrl(49171, "reviewed_prefix")).toBe("postgresql://postgres:postgres@127.0.0.1:49171/reviewed_prefix")
+    expect(() => localStackDatabaseUrl(0)).toThrow("invalid-local-database-target")
+    expect(() => localStackDatabaseUrl(65536)).toThrow("invalid-local-database-target")
+    expect(() => localStackDatabaseUrl(58743, "unsafe-name")).toThrow("invalid-local-database-target")
+    expect(schemaVerifier).toContain("const baselineLocalDbUrl = localStackDatabaseUrl(baselineDbPort)")
+    expect(schemaVerifier).not.toContain('const baselineDbUrl = "postgresql://postgres:postgres@127.0.0.1:5432')
   })
   it("derives the expected function inventory and records the one reviewed retirement", () => {
     const expected = expectedFunctionNames()

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { bindObservedMigrationDeployEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -221,6 +221,13 @@ describe("Supabase delivery parity", () => {
       "2026-12-31T23:60:00Z",
       "2026-12-31T23:59:60Z",
     ]) expect(isExplicitRfc3339Timestamp(timestamp), timestamp).toBe(false)
+  })
+
+  it("orders explicit RFC3339 instants without losing fractional precision", () => {
+    expect(compareExplicitRfc3339Timestamps("2026-08-12T20:00:00.000001Z", "2026-08-12T20:00:00.000999Z")).toBe(-1)
+    expect(compareExplicitRfc3339Timestamps("2026-08-12T20:00:00.000999Z", "2026-08-12T20:00:00.000001Z")).toBe(1)
+    expect(compareExplicitRfc3339Timestamps("2026-08-12T20:00:00Z", "2026-08-12T16:00:00-04:00")).toBe(0)
+    expect(compareExplicitRfc3339Timestamps("2026-08-12T20:00:00.1Z", "2026-08-12T20:00:00.1000000000Z")).toBe(0)
   })
 
   it("keeps candidate-bound migration evidence append-only and non-browser-readable", () => {

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -185,9 +185,13 @@ describe("Supabase delivery parity", () => {
     const deployEvidence = bindObservedMigrationDeployEvidence(expected, observed)
     expect(deployEvidence.recordedAt).toBe(observed.recordedAt)
     expect(validateMatchingMigrationEvidence(observed, expected, expected.inventorySha256)).toBe(true)
-    for (const recordedAt of ["0", "12", "2026-08-12", "2026-08-12 23:28:57+00:00", "2026-08-12T23:28:57", "2026-08-12T23:28:57+24:00"]) {
+    for (const recordedAt of ["0", "12", "2026-08-12", "2026-08-12 23:28:57+00:00", "2026-08-12T23:28:57", "2026-08-12T23:28:57+24:00", "2026-02-29T00:00:00Z", "2026-04-31T23:59:59Z", "2026-12-31T24:00:00Z"]) {
       expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, recordedAt }), recordedAt).toThrow("remote immutable row")
       expect(validateMatchingMigrationEvidence({ ...observed, recordedAt }, expected, expected.inventorySha256), recordedAt).toBe(false)
+    }
+    for (const recordedAt of ["2024-02-29T00:00:00Z", "2026-01-01T00:00:00Z", "2026-12-31T23:59:59.999999-23:59"]) {
+      expect(bindObservedMigrationDeployEvidence(expected, { ...observed, recordedAt }).recordedAt, recordedAt).toBe(recordedAt)
+      expect(validateMatchingMigrationEvidence({ ...observed, recordedAt }, expected, expected.inventorySha256), recordedAt).toBe(true)
     }
     expect(() => bindObservedMigrationDeployEvidence(expected, { ...observed, inventorySha256: "0".repeat(64) })).toThrow("remote immutable row")
   })
@@ -197,6 +201,8 @@ describe("Supabase delivery parity", () => {
       "2026-08-12T23:28:57.708226+00:00",
       "2026-08-12T23:28:57Z",
       "2026-08-12T19:28:57.1-04:00",
+      "2024-02-29T00:00:00Z",
+      "2026-12-31T23:59:59+23:59",
     ]) expect(isExplicitRfc3339Timestamp(timestamp), timestamp).toBe(true)
 
     for (const timestamp of [
@@ -209,6 +215,11 @@ describe("Supabase delivery parity", () => {
       "2026-08-12T23:28:57+0000",
       "2026-08-12T23:28:57+24:00",
       "2026-08-12T23:28:57+00:60",
+      "2026-02-29T00:00:00Z",
+      "2026-04-31T23:59:59Z",
+      "2026-12-31T24:00:00Z",
+      "2026-12-31T23:60:00Z",
+      "2026-12-31T23:59:60Z",
     ]) expect(isExplicitRfc3339Timestamp(timestamp), timestamp).toBe(false)
   })
 

--- a/tests/supabase-delivery-parity.test.ts
+++ b/tests/supabase-delivery-parity.test.ts
@@ -3,7 +3,8 @@ import os from "node:os"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 import { classifyFunctionInventory, compareClosurePaths, expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
-import { bindObservedMigrationDeployEvidence, buildDeployCompletionEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateDeployCompletionEvidence, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
+import { buildEnvironmentManifest, buildSafeSmokeEvidence } from "../scripts/verify-supabase-environment-manifest.mjs"
+import { bindObservedMigrationDeployEvidence, buildDeployCompletionEvidence, buildMigrationDeployEvidence, buildSchemaDiagnostic, compareExplicitRfc3339Timestamps, expectedMigrationInventory, isExplicitRfc3339Timestamp, libpqConnectionEnvironment, migrationInventorySha256, normalizePublicSchema, validateDeployCompletionEvidence, validateForwardPendingMigrationHistory, validateMatchingMigrationEvidence, validateMigrationDeployEvidence, validatePendingSchemaRepair } from "../scripts/verify-supabase-schema-parity.mjs"
 
 const workflow = readFileSync(".github/workflows/supabase-deploy.yml", "utf8")
 const schemaVerifier = readFileSync("scripts/verify-supabase-schema-parity.mjs", "utf8")
@@ -174,6 +175,32 @@ describe("Supabase delivery parity", () => {
     expect(validateMatchingMigrationEvidence({ ...evidence, environment: "main" }, binding, inventorySha256)).toBe(false)
   })
 
+  it("accepts only reviewed forward pending migrations over an exact immutable remote baseline", () => {
+    const migrations = [
+      { version: "20260101000000", name: "20260101000000_first.sql", fileSha256: "a".repeat(64) },
+      { version: "20260102000000", name: "20260102000000_second.sql", fileSha256: "b".repeat(64) },
+      { version: "20260103000000", name: "20260103000000_third.sql", fileSha256: "c".repeat(64) },
+    ]
+    const binding = { environment: "dev", projectRef: "a".repeat(20) }
+    const baseline = (count: number) => ({
+      contractVersion: "fundloop.migration-deploy-evidence/v1",
+      candidateGitSha: "d".repeat(40), actionsRunId: "42", runAttempt: 1, ...binding,
+      migrations: migrations.slice(0, count), inventorySha256: migrationInventorySha256(migrations.slice(0, count)),
+      recordedAt: "2026-08-13T00:00:00Z",
+    })
+    expect(validateForwardPendingMigrationHistory(migrations, [migrations[0].version, migrations[1].version], baseline(2), binding).pendingMigrations).toEqual([migrations[2]])
+    expect(validateForwardPendingMigrationHistory(migrations, [migrations[0].version], baseline(1), binding).pendingMigrations).toEqual(migrations.slice(1))
+    const changedBaseline = baseline(2)
+    changedBaseline.migrations[0].fileSha256 = "9".repeat(64)
+    expect(() => validateForwardPendingMigrationHistory(migrations, [migrations[0].version, migrations[1].version], changedBaseline, binding)).toThrow("migration-baseline-digest")
+    const malformedBaseline = baseline(2)
+    malformedBaseline.migrations[0] = { version: "invalid", name: "invalid.sql", fileSha256: "9".repeat(64) }
+    malformedBaseline.inventorySha256 = migrationInventorySha256(malformedBaseline.migrations)
+    expect(() => validateForwardPendingMigrationHistory(migrations, [migrations[0].version, migrations[1].version], malformedBaseline, binding)).toThrow("migration-baseline-digest")
+    expect(() => validateForwardPendingMigrationHistory(migrations, [migrations[0].version, "20260102595959"], baseline(2), binding)).toThrow("Migration history drift")
+    expect(() => validateForwardPendingMigrationHistory(migrations, [migrations[1].version], baseline(1), binding)).toThrow("Migration history drift")
+  })
+
   it("preserves one validated immutable timestamp for deploy and drift provenance", () => {
     const expected = {
       contractVersion: "fundloop.migration-deploy-evidence/v1",
@@ -234,40 +261,52 @@ describe("Supabase delivery parity", () => {
   })
 
   it("certifies only exact immutable candidate/completion evidence pairs", () => {
+    const migration = { version: "20260101000000", name: "20260101000000_first.sql", fileSha256: "a".repeat(64) }
+    const inventorySha256 = migrationInventorySha256([migration])
     const evidence = {
       contractVersion: "fundloop.migration-deploy-evidence/v1",
       candidateGitSha: "b".repeat(40), actionsRunId: "42", runAttempt: 1,
       environment: "dev", projectRef: "a".repeat(20),
-      migrations: [{ version: "20260101000000", name: "20260101000000_first.sql", fileSha256: "a".repeat(64) }],
-      inventorySha256: "c".repeat(64), recordedAt: "2026-08-13T00:00:00.000001Z",
+      migrations: [migration], inventorySha256, recordedAt: "2026-08-13T00:00:00.000001Z",
     }
+    const binding = { candidateGitSha: evidence.candidateGitSha, actionsRunId: evidence.actionsRunId, runAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef }
+    const manifest = buildEnvironmentManifest({
+      schema: {
+        environment: evidence.environment, projectRef: evidence.projectRef, candidateGitSha: evidence.candidateGitSha,
+        observedAt: "2026-08-13T00:00:00.000100Z", algorithm: "pg17-public-schema-normalized-v2", postgresMajor: 17,
+        expectedSha256: "d".repeat(64), observedSha256: "d".repeat(64), migrationInventorySha256: inventorySha256,
+        migrationInventory: [migration], migrationHistory: [migration.version], enabledProductionValueFlowControlCount: 0,
+        productionValueFlowControlTableCount: 1,
+        certifiedDeployment: { gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt, recordedAt: evidence.recordedAt, environment: evidence.environment, projectRef: evidence.projectRef },
+      },
+      functions: {
+        environment: evidence.environment, projectRef: evidence.projectRef, candidateGitSha: evidence.candidateGitSha,
+        observedAt: "2026-08-13T00:00:00.000200Z",
+        functions: [{ name: "example", expectedSourceSha256: "e".repeat(64), observedSourceSha256: "e".repeat(64), deployedBundleSha256: "f".repeat(64), remoteVersion: 1, remoteStatus: "ACTIVE" }],
+      },
+      smoke: buildSafeSmokeEvidence({ environment: evidence.environment, projectRef: evidence.projectRef, observationGitSha: evidence.candidateGitSha, statusCode: 401, observedAt: "2026-08-13T00:00:00.000300Z" }),
+      context: { gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt, observedAt: "2026-08-13T00:00:00.000400Z", trigger: "push", mode: "deploy" },
+    })
     const completion = {
       contractVersion: "fundloop.deploy-completion-evidence/v1",
       candidateGitSha: evidence.candidateGitSha, actionsRunId: evidence.actionsRunId,
       runAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef,
       inventorySha256: evidence.inventorySha256,
-      schemaExpectedSha256: "d".repeat(64), schemaObservedSha256: "d".repeat(64),
-      functionInventorySha256: "e".repeat(64), hostedSmokeEvidenceSha256: "f".repeat(64),
-      deploymentManifestSha256: "1".repeat(64), completedAt: "2026-08-13T00:00:00.000999Z",
+      schemaExpectedSha256: manifest.schema.expectedSha256, schemaObservedSha256: manifest.schema.observedSha256,
+      functionInventorySha256: manifest.functions.inventorySha256,
+      hostedSmokeEvidenceSha256: manifest.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256,
+      deploymentManifestSha256: manifest.manifestSha256, completedAt: "2026-08-13T00:00:00.000999Z",
     }
-    expect(validateDeployCompletionEvidence(completion, evidence)).toBe(true)
-    expect(validateDeployCompletionEvidence(undefined, evidence)).toBe(false)
-    expect(validateDeployCompletionEvidence({ ...completion, candidateGitSha: "9".repeat(40) }, evidence)).toBe(false)
-    expect(validateDeployCompletionEvidence({ ...completion, inventorySha256: "9".repeat(64) }, evidence)).toBe(false)
-    expect(validateDeployCompletionEvidence({ ...completion, schemaObservedSha256: "9".repeat(64) }, evidence)).toBe(false)
-    expect(validateDeployCompletionEvidence({ ...completion, completedAt: "2026-08-12T23:59:59Z" }, evidence)).toBe(false)
-    const manifest = {
-      contractVersion: "fundloop.environment-delivery-manifest/v1",
-      environment: evidence.environment, projectRef: evidence.projectRef,
-      observation: { mode: "deploy", gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt },
-      certifiedDeployment: { gitSha: evidence.candidateGitSha, githubRunId: evidence.actionsRunId, githubRunAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef },
-      migrations: { inventorySha256: evidence.inventorySha256 },
-      schema: { expectedSha256: completion.schemaExpectedSha256, observedSha256: completion.schemaObservedSha256 },
-      functions: { inventorySha256: completion.functionInventorySha256 },
-      prerequisites: { hostedUnauthenticatedDenial: { evidence: { evidenceSha256: completion.hostedSmokeEvidenceSha256 } } },
-      manifestSha256: completion.deploymentManifestSha256,
-    }
-    const binding = { candidateGitSha: evidence.candidateGitSha, actionsRunId: evidence.actionsRunId, runAttempt: evidence.runAttempt, environment: evidence.environment, projectRef: evidence.projectRef }
+    expect(validateDeployCompletionEvidence(completion, evidence, manifest)).toBe(true)
+    expect(validateDeployCompletionEvidence(undefined, evidence, manifest)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, candidateGitSha: "9".repeat(40) }, evidence, manifest)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, inventorySha256: "9".repeat(64) }, evidence, manifest)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, schemaObservedSha256: "9".repeat(64) }, evidence, manifest)).toBe(false)
+    expect(validateDeployCompletionEvidence({ ...completion, completedAt: "2026-08-12T23:59:59Z" }, evidence, manifest)).toBe(false)
+    const tampered = structuredClone(manifest)
+    tampered.manifestSha256 = "9".repeat(64)
+    expect(validateDeployCompletionEvidence(completion, evidence, tampered)).toBe(false)
+    expect(validateDeployCompletionEvidence(completion, evidence, { ...manifest, migrations: { inventorySha256 } })).toBe(false)
     expect(buildDeployCompletionEvidence(manifest, binding)).toMatchObject({ deploymentManifestSha256: completion.deploymentManifestSha256 })
     expect(() => buildDeployCompletionEvidence(manifest, { ...binding, actionsRunId: "43" })).toThrow("deployment-completion-invalid")
   })
@@ -280,6 +319,9 @@ describe("Supabase delivery parity", () => {
     const completionSql = readFileSync("supabase/migrations/20260813010000_supabase_deploy_completion_evidence.sql", "utf8")
     expect(completionSql).toContain("REFERENCES public.supabase_deploy_migration_evidence")
     expect(completionSql).toContain("supabase_deploy_completion_candidate_mismatch")
+    expect(completionSql).toContain("supabase_deploy_completion_manifest_mismatch")
+    expect(completionSql).toContain("deployment_manifest jsonb NOT NULL")
+    expect(completionSql).toContain("{observation,observedAt}")
     expect(completionSql).toContain("candidate.inventory_sha256 = NEW.inventory_sha256")
     expect(completionSql).toContain("supabase_deploy_completion_evidence_is_append_only")
     expect(completionSql).toContain("REVOKE ALL ON TABLE public.supabase_deploy_completion_evidence FROM anon, authenticated")
@@ -318,16 +360,17 @@ describe("Supabase delivery parity", () => {
     expect(workflow).toContain('status_code}" != "401"')
     expect(workflow).toContain("Record safe hosted runtime denial")
     expect(workflow.indexOf("Record safe hosted runtime denial")).toBeLessThan(workflow.indexOf("Publish immutable environment manifest"))
-    expect(workflow.indexOf("Publish immutable environment manifest")).toBeLessThan(workflow.indexOf("Certify completed Supabase deployment"))
-    expect(workflow.indexOf("Certify completed Supabase deployment")).toBeLessThan(workflow.indexOf("Upload immutable environment manifest"))
-    expect(workflow).toContain("verify-supabase-schema-parity.mjs complete")
+    expect(workflow.indexOf("Publish immutable environment manifest")).toBeLessThan(workflow.indexOf("Upload sanitized Supabase parity evidence"))
+    expect(workflow.indexOf("Upload sanitized Supabase parity evidence")).toBeLessThan(workflow.indexOf("Upload immutable environment manifest"))
+    expect(workflow.indexOf("Upload immutable environment manifest")).toBeLessThan(workflow.indexOf("Certify completed Supabase deployment"))
+    expect(workflow).toContain("verify-supabase-environment-manifest.mjs complete")
     expect(workflow).toContain('SUPABASE_SCHEMA_DB_URL="${supabase_db_url}"')
-    const completionStep = workflow.slice(workflow.indexOf("- name: Certify completed Supabase deployment"), workflow.indexOf("- name: Upload sanitized Supabase parity evidence"))
+    const completionStep = workflow.slice(workflow.indexOf("- name: Certify completed Supabase deployment"), workflow.indexOf("- name: Upload sanitized Dev schema diagnostic"))
     expect(completionStep).not.toContain('psql "${supabase_db_url}"')
     expect(schemaVerifier).toContain("INSERT INTO public.supabase_deploy_completion_evidence")
     expect(workflow).toContain("actions/upload-artifact@v4")
-    expect(workflow).toContain("if: ${{ always() && steps.target.outputs.mode == 'deploy' }}")
-    expect(workflow).toContain("if-no-files-found: warn")
+    expect(workflow).not.toContain("if: ${{ always() && steps.target.outputs.mode == 'deploy' }}")
+    expect(workflow).toContain("if-no-files-found: error")
     expect(workflow).toContain("verify-supabase-schema-parity.mjs diagnose")
     expect(workflow).toContain("supabase-schema-diagnostic-dev-${{ github.sha }}")
     expect(workflow).toContain("steps.target.outputs.mode == 'dry-run' && steps.target.outputs.target_environment == 'dev'")

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -16,6 +16,7 @@ const functionEntry = (index: number) => ({
   remoteStatus: "ACTIVE",
 })
 const stable = (value: any): string => Array.isArray(value) ? `[${value.map(stable).join(",")}]` : value && typeof value === "object" ? `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}` : JSON.stringify(value)
+const digest = (value: any) => createHash("sha256").update(stable(value)).digest("hex")
 const migrationDigest = createHash("sha256").update(stable([migration])).digest("hex")
 const schema = {
   environment: "dev", projectRef: "a".repeat(20), algorithm: "pg17-public-schema-normalized-v2", postgresMajor: 17,
@@ -27,6 +28,18 @@ const schema = {
 const functions = { candidateGitSha: "2".repeat(40), environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
 const context = { gitSha: "2".repeat(40), githubRunId: "200", githubRunAttempt: 3, observedAt: "2026-08-12T20:00:00Z", trigger: "push", mode: "drift" }
 const smoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: "a".repeat(20), observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
+
+const restoreManifestIntegrity = (manifest: any) => {
+  manifest.evidence = [
+    { evidenceId: "migration-deployment", sha256: digest(manifest.certifiedDeployment) },
+    { evidenceId: "schema-parity", sha256: digest({ migrations: manifest.migrations, schema: manifest.schema, runtimeControls: manifest.runtimeControls, certifiedDeployment: manifest.certifiedDeployment }) },
+    { evidenceId: "function-parity", sha256: digest(manifest.functions) },
+    { evidenceId: "runtime-prerequisites", sha256: digest(manifest.prerequisites) },
+  ]
+  const { manifestSha256: _ignored, ...payload } = manifest
+  manifest.manifestSha256 = digest(payload)
+  return manifest
+}
 
 describe("immutable Supabase environment manifests", () => {
   it("preserves distinct certified deployment and observation provenance", () => {
@@ -41,6 +54,29 @@ describe("immutable Supabase environment manifests", () => {
     const deployFunctions = { ...functions, candidateGitSha: deployContext.gitSha }
     const deploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: deployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
     expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema, functions: deployFunctions, smoke: deploySmoke, context: deployContext }))).toEqual({ ok: true, blockers: [] })
+  })
+
+  it("requires semantic RFC3339 timestamps when building and independently verifying manifests", () => {
+    for (const recordedAt of ["2026-08-12T23:28:57.708226+00:00", "2026-08-12T23:28:57Z"]) {
+      const manifest = buildEnvironmentManifest({ schema: { ...schema, certifiedDeployment: { ...schema.certifiedDeployment, recordedAt } }, functions, smoke, context: { ...context, observedAt: "2026-08-13T00:00:00Z" } })
+      expect(verifyEnvironmentManifest(manifest), recordedAt).toEqual({ ok: true, blockers: [] })
+    }
+
+    for (const recordedAt of ["0", "2026-04-31T23:59:59Z", "2026-08-12T23:28:57", "2026-12-31T24:00:00Z"]) {
+      const invalidSchema = { ...schema, certifiedDeployment: { ...schema.certifiedDeployment, recordedAt } }
+      expect(() => buildEnvironmentManifest({ schema: invalidSchema, functions, smoke, context }), recordedAt).toThrow("deployment-time")
+
+      const selfConsistent = restoreManifestIntegrity(structuredClone(buildEnvironmentManifest({ schema, functions, smoke, context })))
+      selfConsistent.certifiedDeployment.recordedAt = recordedAt
+      restoreManifestIntegrity(selfConsistent)
+      expect(verifyEnvironmentManifest(selfConsistent), recordedAt).toEqual({ ok: false, blockers: ["deployment-time"] })
+    }
+  })
+
+  it("applies the same timestamp contract to observation and hosted-smoke evidence", () => {
+    expect(() => buildEnvironmentManifest({ schema, functions, smoke, context: { ...context, observedAt: "2026-08-12T20:00:00" } })).toThrow("observation-time")
+    const timezoneLessSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00" })
+    expect(() => buildEnvironmentManifest({ schema, functions, smoke: timezoneLessSmoke, context })).toThrow("runtime-smoke")
   })
 
   it("fails precisely for changed, reordered, missing, stale, and enabled assets", () => {

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { createHash } from "node:crypto"
 import { describe, expect, it } from "vitest"
-import { buildEnvironmentManifest, buildSafeSmokeEvidence, verifyEnvironmentManifest } from "../scripts/verify-supabase-environment-manifest.mjs"
+import { buildEnvironmentManifest, buildSafeSmokeEvidence, verifyCertifiedDeploymentManifest, verifyEnvironmentManifest } from "../scripts/verify-supabase-environment-manifest.mjs"
 import { shouldObservePush, SUPABASE_DEPLOY_PATH_GLOBS } from "../scripts/classify-supabase-drift-push.mjs"
 import { expectedFunctionNames, expectedSourceClosure } from "../scripts/verify-supabase-function-parity.mjs"
 import { resolveSupabasePoolerTarget } from "../scripts/resolve-supabase-pooler-target.mjs"
@@ -81,6 +81,7 @@ describe("immutable Supabase environment manifests", () => {
 
   it("binds completion to the full retained certified deploy manifest and a later fresh smoke", () => {
     const valid = buildEnvironmentManifest({ schema, functions, smoke, context })
+    expect(verifyCertifiedDeploymentManifest(valid.certifiedDeployment.certifiedManifest)).toEqual({ ok: true, blockers: [] })
     const completionCases: Array<[string, (changed: any) => void]> = [
       ["schema", (changed) => { changed.certifiedDeployment.completion.schemaExpectedSha256 = "9".repeat(64); changed.certifiedDeployment.completion.schemaObservedSha256 = "9".repeat(64) }],
       ["function", (changed) => { changed.certifiedDeployment.completion.functionInventorySha256 = "9".repeat(64) }],
@@ -107,6 +108,22 @@ describe("immutable Supabase environment manifests", () => {
     }
     restoreManifestIntegrity(skeletal)
     expect(verifyEnvironmentManifest(skeletal).blockers).toContain("deployment-completion")
+
+    const retainedManifestCases: Array<[string, (forged: any) => void]> = [
+      ["wrong schema digest", (forged) => { forged.certifiedDeployment.certifiedManifest.schema.observedSha256 = "8".repeat(64) }],
+      ["schema observation after completion", (forged) => { forged.certifiedDeployment.certifiedManifest.schema.observedAt = "2026-08-12T19:56:00Z"; forged.certifiedDeployment.certifiedManifest.observation.observedAt = "2026-08-12T19:56:00Z" }],
+      ["inactive function", (forged) => { const certified = forged.certifiedDeployment.certifiedManifest; certified.functions.items[0].remoteStatus = "INACTIVE"; certified.functions.inventorySha256 = digest(certified.functions.items); forged.certifiedDeployment.completion.functionInventorySha256 = certified.functions.inventorySha256 }],
+      ["mismatched migration history", (forged) => { forged.certifiedDeployment.certifiedManifest.migrations.observedHistory = ["20990101000000"] }],
+      ["smoke checkout differs from deployment", (forged) => { const certified = forged.certifiedDeployment.certifiedManifest; certified.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: "9".repeat(40), statusCode: 401, observedAt: deploySmoke.observedAt }); forged.certifiedDeployment.completion.hostedSmokeEvidenceSha256 = certified.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256 }],
+    ]
+    for (const [name, mutate] of retainedManifestCases) {
+      const forged = structuredClone(valid)
+      mutate(forged)
+      restoreManifestIntegrity(forged.certifiedDeployment.certifiedManifest)
+      forged.certifiedDeployment.completion.deploymentManifestSha256 = forged.certifiedDeployment.certifiedManifest.manifestSha256
+      restoreManifestIntegrity(forged)
+      expect(verifyEnvironmentManifest(forged).blockers, name).toContain("deployment-completion")
+    }
 
     const sameShaSchema = { ...schema, candidateGitSha: deployContext.gitSha }
     const sameShaFunctions = { ...functions, candidateGitSha: deployContext.gitSha }

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -18,20 +18,28 @@ const functionEntry = (index: number) => ({
 const stable = (value: any): string => Array.isArray(value) ? `[${value.map(stable).join(",")}]` : value && typeof value === "object" ? `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stable(value[key])}`).join(",")}}` : JSON.stringify(value)
 const digest = (value: any) => createHash("sha256").update(stable(value)).digest("hex")
 const migrationDigest = createHash("sha256").update(stable([migration])).digest("hex")
-const schema = {
+const schema: any = {
   environment: "dev", projectRef: "a".repeat(20), algorithm: "pg17-public-schema-normalized-v2", postgresMajor: 17,
   expectedSha256: "d".repeat(64), observedSha256: "d".repeat(64), migrationInventorySha256: migrationDigest,
   migrationInventory: [migration], migrationHistory: [migration.version], enabledProductionValueFlowControlCount: 0,
   productionValueFlowControlTableCount: 4,
-  candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:30:00Z",
-  certifiedDeployment: { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, recordedAt: "2026-08-12T19:00:00Z", environment: "dev", projectRef: "a".repeat(20), completion: {
-    contractVersion: "fundloop.deploy-completion-evidence/v1", candidateGitSha: "1".repeat(40), actionsRunId: "100", runAttempt: 2,
-    environment: "dev", projectRef: "a".repeat(20), inventorySha256: migrationDigest,
-    schemaExpectedSha256: "d".repeat(64), schemaObservedSha256: "d".repeat(64), functionInventorySha256: "e".repeat(64),
-    hostedSmokeEvidenceSha256: "f".repeat(64), deploymentManifestSha256: "1".repeat(64), completedAt: "2026-08-12T19:15:00Z",
-  } },
+  candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:56:00Z",
+  certifiedDeployment: { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, recordedAt: "2026-08-12T19:00:00Z", environment: "dev", projectRef: "a".repeat(20) },
 }
-const functions = { candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:45:00Z", environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
+const functions = { candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:57:00Z", environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
+const deployContext = { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, observedAt: "2026-08-12T19:50:00Z", trigger: "push", mode: "deploy" }
+const deploySchema = { ...schema, candidateGitSha: deployContext.gitSha, observedAt: "2026-08-12T19:30:00Z", certifiedDeployment: { ...schema.certifiedDeployment } }
+const deployFunctions = { ...functions, candidateGitSha: deployContext.gitSha, observedAt: "2026-08-12T19:45:00Z" }
+const deploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: "a".repeat(20), observationGitSha: deployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:49:00Z" })
+const certifiedManifest = buildEnvironmentManifest({ schema: deploySchema, functions: deployFunctions, smoke: deploySmoke, context: deployContext })
+schema.certifiedDeployment = { ...schema.certifiedDeployment, certifiedManifest, completion: {
+  contractVersion: "fundloop.deploy-completion-evidence/v1", candidateGitSha: "1".repeat(40), actionsRunId: "100", runAttempt: 2,
+  environment: "dev", projectRef: "a".repeat(20), inventorySha256: migrationDigest,
+  schemaExpectedSha256: certifiedManifest.schema.expectedSha256, schemaObservedSha256: certifiedManifest.schema.observedSha256,
+  functionInventorySha256: certifiedManifest.functions.inventorySha256,
+  hostedSmokeEvidenceSha256: deploySmoke.evidenceSha256, deploymentManifestSha256: certifiedManifest.manifestSha256,
+  completedAt: "2026-08-12T19:55:00Z",
+} }
 const context = { gitSha: "2".repeat(40), githubRunId: "200", githubRunAttempt: 3, observedAt: "2026-08-12T20:00:00Z", trigger: "push", mode: "drift" }
 const smoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: "a".repeat(20), observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
 
@@ -47,26 +55,78 @@ const restoreManifestIntegrity = (manifest: any) => {
   return manifest
 }
 
+const withCertifiedChronology = (input: any, recordedAt: string, completedAt: string) => {
+  const next = structuredClone(input)
+  const certified = structuredClone(next.certifiedDeployment.certifiedManifest)
+  certified.certifiedDeployment.recordedAt = recordedAt
+  restoreManifestIntegrity(certified)
+  next.certifiedDeployment.recordedAt = recordedAt
+  next.certifiedDeployment.certifiedManifest = certified
+  next.certifiedDeployment.completion = {
+    ...next.certifiedDeployment.completion,
+    deploymentManifestSha256: certified.manifestSha256,
+    completedAt,
+  }
+  return next
+}
+
 describe("immutable Supabase environment manifests", () => {
   it("preserves distinct certified deployment and observation provenance", () => {
     const manifest = buildEnvironmentManifest({ schema, functions, smoke, context })
     expect(manifest.certifiedDeployment.gitSha).toBe("1".repeat(40))
     expect(manifest.observation.gitSha).toBe("2".repeat(40))
+    expect(manifest.certifiedDeployment.certifiedManifest.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256).not.toBe(manifest.prerequisites.hostedUnauthenticatedDenial.evidence.evidenceSha256)
     expect(verifyEnvironmentManifest(manifest)).toEqual({ ok: true, blockers: [] })
   })
 
+  it("binds completion to the full retained certified deploy manifest and a later fresh smoke", () => {
+    const valid = buildEnvironmentManifest({ schema, functions, smoke, context })
+    const completionCases: Array<[string, (changed: any) => void]> = [
+      ["schema", (changed) => { changed.certifiedDeployment.completion.schemaExpectedSha256 = "9".repeat(64); changed.certifiedDeployment.completion.schemaObservedSha256 = "9".repeat(64) }],
+      ["function", (changed) => { changed.certifiedDeployment.completion.functionInventorySha256 = "9".repeat(64) }],
+      ["deploy smoke", (changed) => { changed.certifiedDeployment.completion.hostedSmokeEvidenceSha256 = "9".repeat(64) }],
+      ["manifest", (changed) => { changed.certifiedDeployment.completion.deploymentManifestSha256 = "9".repeat(64) }],
+      ["reversed completion", (changed) => { changed.certifiedDeployment.completion.completedAt = "2026-08-12T19:49:59Z" }],
+    ]
+    for (const [name, mutate] of completionCases) {
+      const changedSchema = structuredClone(schema)
+      mutate(changedSchema)
+      expect(() => buildEnvironmentManifest({ schema: changedSchema, functions, smoke, context }), name).toThrow("deployment-completion")
+    }
+
+    const tamperedSelf = structuredClone(valid)
+    tamperedSelf.certifiedDeployment.certifiedManifest.manifestSha256 = "9".repeat(64)
+    restoreManifestIntegrity(tamperedSelf)
+    expect(verifyEnvironmentManifest(tamperedSelf).blockers).toContain("deployment-completion")
+
+    const skeletal = structuredClone(valid)
+    skeletal.certifiedDeployment.certifiedManifest = {
+      contractVersion: "fundloop.environment-delivery-manifest/v1",
+      environment: "dev", projectRef: schema.projectRef, observation: { mode: "deploy" },
+      manifestSha256: schema.certifiedDeployment.completion.deploymentManifestSha256,
+    }
+    restoreManifestIntegrity(skeletal)
+    expect(verifyEnvironmentManifest(skeletal).blockers).toContain("deployment-completion")
+
+    const sameShaSchema = { ...schema, candidateGitSha: deployContext.gitSha }
+    const sameShaFunctions = { ...functions, candidateGitSha: deployContext.gitSha }
+    const sameShaContext = { ...context, gitSha: deployContext.gitSha }
+    expect(() => buildEnvironmentManifest({ schema: sameShaSchema, functions: sameShaFunctions, smoke: deploySmoke, context: sameShaContext })).toThrow("observation-smoke-not-fresh")
+  })
+
   it("accepts deploy provenance only when deployment and observation are identical", () => {
-    const deployContext = { ...context, gitSha: schema.certifiedDeployment.gitSha, githubRunId: schema.certifiedDeployment.githubRunId, githubRunAttempt: schema.certifiedDeployment.githubRunAttempt, mode: "deploy" }
+    const localDeployContext = { ...context, gitSha: schema.certifiedDeployment.gitSha, githubRunId: schema.certifiedDeployment.githubRunId, githubRunAttempt: schema.certifiedDeployment.githubRunAttempt, mode: "deploy" }
     const { completion: _completion, ...deployCertifiedDeployment } = schema.certifiedDeployment
-    const deploySchema = { ...schema, candidateGitSha: deployContext.gitSha, certifiedDeployment: deployCertifiedDeployment }
-    const deployFunctions = { ...functions, candidateGitSha: deployContext.gitSha }
-    const deploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: deployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
-    expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: deploySchema, functions: deployFunctions, smoke: deploySmoke, context: deployContext }))).toEqual({ ok: true, blockers: [] })
+    delete deployCertifiedDeployment.certifiedManifest
+    const localDeploySchema = { ...schema, candidateGitSha: localDeployContext.gitSha, certifiedDeployment: deployCertifiedDeployment }
+    const localDeployFunctions = { ...functions, candidateGitSha: localDeployContext.gitSha }
+    const localDeploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: localDeployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
+    expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: localDeploySchema, functions: localDeployFunctions, smoke: localDeploySmoke, context: localDeployContext }))).toEqual({ ok: true, blockers: [] })
   })
 
   it("requires semantic RFC3339 timestamps when building and independently verifying manifests", () => {
-    for (const recordedAt of ["2026-08-12T23:28:57.708226+00:00", "2026-08-12T23:28:57Z"]) {
-      const positiveSchema = { ...schema, observedAt: "2026-08-12T23:40:00Z", certifiedDeployment: { ...schema.certifiedDeployment, recordedAt, completion: { ...schema.certifiedDeployment.completion, completedAt: "2026-08-12T23:35:00Z" } } }
+    for (const recordedAt of ["2026-08-12T18:28:57.708226+00:00", "2026-08-12T18:28:57Z"]) {
+      const positiveSchema = { ...schema, observedAt: "2026-08-12T23:40:00Z", certifiedDeployment: withCertifiedChronology(schema, recordedAt, "2026-08-12T23:35:00Z").certifiedDeployment }
       const positiveFunctions = { ...functions, observedAt: "2026-08-12T23:45:00Z" }
       const positiveSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T23:50:00Z" })
       const manifest = buildEnvironmentManifest({ schema: positiveSchema, functions: positiveFunctions, smoke: positiveSmoke, context: { ...context, observedAt: "2026-08-13T00:00:00Z" } })
@@ -112,7 +172,7 @@ describe("immutable Supabase environment manifests", () => {
     const preciseSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T20:00:00.000001Z" })
     expect(() => buildEnvironmentManifest({ schema: preciseSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext })).toThrow("deployment-after-observation")
 
-    const equalSchema = { ...preciseSchema, certifiedDeployment: { ...preciseSchema.certifiedDeployment, recordedAt: preciseContext.observedAt, completion: { ...preciseSchema.certifiedDeployment.completion, completedAt: preciseContext.observedAt } } }
+    const equalSchema = { ...schema, observedAt: preciseContext.observedAt, certifiedDeployment: { ...schema.certifiedDeployment, completion: { ...schema.certifiedDeployment.completion, completedAt: preciseContext.observedAt } } }
     expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: equalSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext }))).toEqual({ ok: true, blockers: [] })
   })
 

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -23,9 +23,10 @@ const schema = {
   expectedSha256: "d".repeat(64), observedSha256: "d".repeat(64), migrationInventorySha256: migrationDigest,
   migrationInventory: [migration], migrationHistory: [migration.version], enabledProductionValueFlowControlCount: 0,
   productionValueFlowControlTableCount: 4,
+  candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:30:00Z",
   certifiedDeployment: { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, recordedAt: "2026-08-12T19:00:00Z", environment: "dev", projectRef: "a".repeat(20) },
 }
-const functions = { candidateGitSha: "2".repeat(40), environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
+const functions = { candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:45:00Z", environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
 const context = { gitSha: "2".repeat(40), githubRunId: "200", githubRunAttempt: 3, observedAt: "2026-08-12T20:00:00Z", trigger: "push", mode: "drift" }
 const smoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: "a".repeat(20), observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
 
@@ -51,14 +52,18 @@ describe("immutable Supabase environment manifests", () => {
 
   it("accepts deploy provenance only when deployment and observation are identical", () => {
     const deployContext = { ...context, gitSha: schema.certifiedDeployment.gitSha, githubRunId: schema.certifiedDeployment.githubRunId, githubRunAttempt: schema.certifiedDeployment.githubRunAttempt, mode: "deploy" }
+    const deploySchema = { ...schema, candidateGitSha: deployContext.gitSha }
     const deployFunctions = { ...functions, candidateGitSha: deployContext.gitSha }
     const deploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: deployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
-    expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema, functions: deployFunctions, smoke: deploySmoke, context: deployContext }))).toEqual({ ok: true, blockers: [] })
+    expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: deploySchema, functions: deployFunctions, smoke: deploySmoke, context: deployContext }))).toEqual({ ok: true, blockers: [] })
   })
 
   it("requires semantic RFC3339 timestamps when building and independently verifying manifests", () => {
     for (const recordedAt of ["2026-08-12T23:28:57.708226+00:00", "2026-08-12T23:28:57Z"]) {
-      const manifest = buildEnvironmentManifest({ schema: { ...schema, certifiedDeployment: { ...schema.certifiedDeployment, recordedAt } }, functions, smoke, context: { ...context, observedAt: "2026-08-13T00:00:00Z" } })
+      const positiveSchema = { ...schema, observedAt: "2026-08-12T23:40:00Z", certifiedDeployment: { ...schema.certifiedDeployment, recordedAt } }
+      const positiveFunctions = { ...functions, observedAt: "2026-08-12T23:45:00Z" }
+      const positiveSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T23:50:00Z" })
+      const manifest = buildEnvironmentManifest({ schema: positiveSchema, functions: positiveFunctions, smoke: positiveSmoke, context: { ...context, observedAt: "2026-08-13T00:00:00Z" } })
       expect(verifyEnvironmentManifest(manifest), recordedAt).toEqual({ ok: true, blockers: [] })
     }
 
@@ -77,6 +82,50 @@ describe("immutable Supabase environment manifests", () => {
     expect(() => buildEnvironmentManifest({ schema, functions, smoke, context: { ...context, observedAt: "2026-08-12T20:00:00" } })).toThrow("observation-time")
     const timezoneLessSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00" })
     expect(() => buildEnvironmentManifest({ schema, functions, smoke: timezoneLessSmoke, context })).toThrow("runtime-smoke")
+  })
+
+  it("binds every component to one checkout and exact deployment-to-observation chronology", () => {
+    const valid = buildEnvironmentManifest({ schema, functions, smoke, context })
+    expect(valid.schema).toMatchObject({ candidateGitSha: context.gitSha, observedAt: schema.observedAt })
+    expect(valid.functions).toMatchObject({ candidateGitSha: context.gitSha, observedAt: functions.observedAt })
+
+    expect(() => buildEnvironmentManifest({ schema: { ...schema, candidateGitSha: "9".repeat(40) }, functions, smoke, context })).toThrow("schema-observation-sha")
+    expect(() => buildEnvironmentManifest({ schema, functions: { ...functions, candidateGitSha: "9".repeat(40) }, smoke, context })).toThrow("function-observation-sha")
+    expect(() => buildEnvironmentManifest({ schema, functions, smoke: { ...smoke, observationGitSha: "9".repeat(40) }, context })).toThrow("hosted-smoke-observation-sha")
+    expect(() => buildEnvironmentManifest({ schema: { ...schema, observedAt: "2026-08-12T18:00:00Z" }, functions, smoke, context })).toThrow("schema-before-deployment")
+    expect(() => buildEnvironmentManifest({ schema, functions: { ...functions, observedAt: "2026-08-12T20:01:00Z" }, smoke, context })).toThrow("function-after-observation")
+    const staleSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T18:00:00Z" })
+    expect(() => buildEnvironmentManifest({ schema, functions, smoke: staleSmoke, context })).toThrow("hosted-smoke-before-deployment")
+  })
+
+  it("orders accepted fractional timestamps without millisecond truncation", () => {
+    const preciseContext = { ...context, observedAt: "2026-08-12T20:00:00.000001Z" }
+    const preciseSchema = { ...schema, observedAt: "2026-08-12T20:00:00.000001Z", certifiedDeployment: { ...schema.certifiedDeployment, recordedAt: "2026-08-12T20:00:00.000999Z" } }
+    const preciseFunctions = { ...functions, observedAt: "2026-08-12T20:00:00.000001Z" }
+    const preciseSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T20:00:00.000001Z" })
+    expect(() => buildEnvironmentManifest({ schema: preciseSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext })).toThrow("deployment-after-observation")
+
+    const equalSchema = { ...preciseSchema, certifiedDeployment: { ...preciseSchema.certifiedDeployment, recordedAt: preciseContext.observedAt } }
+    expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: equalSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext }))).toEqual({ ok: true, blockers: [] })
+  })
+
+  it("independently rejects digest-consistent component provenance forgeries", () => {
+    const base = buildEnvironmentManifest({ schema, functions, smoke, context })
+    const cases: Array<[string, (manifest: any) => void, string]> = [
+      ["schema checkout", (manifest) => { manifest.schema.candidateGitSha = "9".repeat(40) }, "schema-observation-sha"],
+      ["function checkout", (manifest) => { manifest.functions.candidateGitSha = "9".repeat(40); manifest.observation.functionCandidateGitSha = "9".repeat(40) }, "function-observation-sha"],
+      ["hosted-smoke checkout", (manifest) => { manifest.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: "9".repeat(40), statusCode: 401, observedAt: smoke.observedAt }) }, "hosted-smoke-observation-sha"],
+      ["schema predates deployment", (manifest) => { manifest.schema.observedAt = "2026-08-12T18:00:00Z" }, "schema-before-deployment"],
+      ["function follows observation", (manifest) => { manifest.functions.observedAt = "2026-08-12T20:00:00.000001Z" }, "function-after-observation"],
+      ["smoke predates deployment", (manifest) => { manifest.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T18:00:00Z" }) }, "hosted-smoke-before-deployment"],
+      ["microsecond reversal", (manifest) => { manifest.certifiedDeployment.recordedAt = "2026-08-12T20:00:00.000999Z"; manifest.schema.observedAt = "2026-08-12T20:00:00.000001Z"; manifest.functions.observedAt = "2026-08-12T20:00:00.000001Z"; manifest.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T20:00:00.000001Z" }); manifest.observation.observedAt = "2026-08-12T20:00:00.000001Z" }, "deployment-after-observation"],
+    ]
+    for (const [name, mutate, blocker] of cases) {
+      const forged = structuredClone(base)
+      mutate(forged)
+      restoreManifestIntegrity(forged)
+      expect(verifyEnvironmentManifest(forged).blockers, name).toContain(blocker)
+    }
   })
 
   it("fails precisely for changed, reordered, missing, stale, and enabled assets", () => {

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -92,6 +92,7 @@ describe("immutable Supabase environment manifests", () => {
       expect(paths).toEqual(SUPABASE_DEPLOY_PATH_GLOBS)
     }
     expect(workflow).toContain("repository.full_name == github.repository")
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'")
     expect(workflow).toContain("group: supabase-${{ matrix.target }}")
     expect(workflow).not.toContain("group: supabase-drift-")
     expect(workflow).toContain("github.event_name == 'schedule' && 'dev'")
@@ -109,6 +110,15 @@ describe("immutable Supabase environment manifests", () => {
     expect(workflow).not.toContain("::add-mask::")
     expect(workflow).toContain("if: ${{ always() }}")
     expect(workflow).toContain("${{ runner.temp }}/supabase-schema-diagnostic.json")
+  })
+
+  it("observes push deploys by branch but never infers a manual cross-target deploy", () => {
+    const workflow = readFileSync(".github/workflows/supabase-drift.yml", "utf8")
+    expect(workflow).toContain("github.event.workflow_run.head_branch || github.ref_name")
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'")
+    expect(workflow).not.toContain("github.event.workflow_run.event == 'workflow_dispatch'")
+    expect(workflow).toContain("inputs.target_environment")
+    expect(workflow).toContain("options: [dev, main]")
   })
 
   it("selects exact pooler credentials and rejects hostile connection targets", () => {

--- a/tests/supabase-environment-manifest.test.ts
+++ b/tests/supabase-environment-manifest.test.ts
@@ -24,7 +24,12 @@ const schema = {
   migrationInventory: [migration], migrationHistory: [migration.version], enabledProductionValueFlowControlCount: 0,
   productionValueFlowControlTableCount: 4,
   candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:30:00Z",
-  certifiedDeployment: { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, recordedAt: "2026-08-12T19:00:00Z", environment: "dev", projectRef: "a".repeat(20) },
+  certifiedDeployment: { gitSha: "1".repeat(40), githubRunId: "100", githubRunAttempt: 2, recordedAt: "2026-08-12T19:00:00Z", environment: "dev", projectRef: "a".repeat(20), completion: {
+    contractVersion: "fundloop.deploy-completion-evidence/v1", candidateGitSha: "1".repeat(40), actionsRunId: "100", runAttempt: 2,
+    environment: "dev", projectRef: "a".repeat(20), inventorySha256: migrationDigest,
+    schemaExpectedSha256: "d".repeat(64), schemaObservedSha256: "d".repeat(64), functionInventorySha256: "e".repeat(64),
+    hostedSmokeEvidenceSha256: "f".repeat(64), deploymentManifestSha256: "1".repeat(64), completedAt: "2026-08-12T19:15:00Z",
+  } },
 }
 const functions = { candidateGitSha: "2".repeat(40), observedAt: "2026-08-12T19:45:00Z", environment: "dev", projectRef: "a".repeat(20), functions: Array.from({ length: 62 }, (_, index) => functionEntry(index)) }
 const context = { gitSha: "2".repeat(40), githubRunId: "200", githubRunAttempt: 3, observedAt: "2026-08-12T20:00:00Z", trigger: "push", mode: "drift" }
@@ -52,7 +57,8 @@ describe("immutable Supabase environment manifests", () => {
 
   it("accepts deploy provenance only when deployment and observation are identical", () => {
     const deployContext = { ...context, gitSha: schema.certifiedDeployment.gitSha, githubRunId: schema.certifiedDeployment.githubRunId, githubRunAttempt: schema.certifiedDeployment.githubRunAttempt, mode: "deploy" }
-    const deploySchema = { ...schema, candidateGitSha: deployContext.gitSha }
+    const { completion: _completion, ...deployCertifiedDeployment } = schema.certifiedDeployment
+    const deploySchema = { ...schema, candidateGitSha: deployContext.gitSha, certifiedDeployment: deployCertifiedDeployment }
     const deployFunctions = { ...functions, candidateGitSha: deployContext.gitSha }
     const deploySmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: deployContext.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00Z" })
     expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: deploySchema, functions: deployFunctions, smoke: deploySmoke, context: deployContext }))).toEqual({ ok: true, blockers: [] })
@@ -60,7 +66,7 @@ describe("immutable Supabase environment manifests", () => {
 
   it("requires semantic RFC3339 timestamps when building and independently verifying manifests", () => {
     for (const recordedAt of ["2026-08-12T23:28:57.708226+00:00", "2026-08-12T23:28:57Z"]) {
-      const positiveSchema = { ...schema, observedAt: "2026-08-12T23:40:00Z", certifiedDeployment: { ...schema.certifiedDeployment, recordedAt } }
+      const positiveSchema = { ...schema, observedAt: "2026-08-12T23:40:00Z", certifiedDeployment: { ...schema.certifiedDeployment, recordedAt, completion: { ...schema.certifiedDeployment.completion, completedAt: "2026-08-12T23:35:00Z" } } }
       const positiveFunctions = { ...functions, observedAt: "2026-08-12T23:45:00Z" }
       const positiveSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T23:50:00Z" })
       const manifest = buildEnvironmentManifest({ schema: positiveSchema, functions: positiveFunctions, smoke: positiveSmoke, context: { ...context, observedAt: "2026-08-13T00:00:00Z" } })
@@ -82,6 +88,7 @@ describe("immutable Supabase environment manifests", () => {
     expect(() => buildEnvironmentManifest({ schema, functions, smoke, context: { ...context, observedAt: "2026-08-12T20:00:00" } })).toThrow("observation-time")
     const timezoneLessSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T19:59:00" })
     expect(() => buildEnvironmentManifest({ schema, functions, smoke: timezoneLessSmoke, context })).toThrow("runtime-smoke")
+    expect(() => buildEnvironmentManifest({ schema: { ...schema, certifiedDeployment: { ...schema.certifiedDeployment, recordedAt: "2026-08-12T19:00:00-00:00" } }, functions, smoke, context })).toThrow("deployment-time")
   })
 
   it("binds every component to one checkout and exact deployment-to-observation chronology", () => {
@@ -105,7 +112,7 @@ describe("immutable Supabase environment manifests", () => {
     const preciseSmoke = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T20:00:00.000001Z" })
     expect(() => buildEnvironmentManifest({ schema: preciseSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext })).toThrow("deployment-after-observation")
 
-    const equalSchema = { ...preciseSchema, certifiedDeployment: { ...preciseSchema.certifiedDeployment, recordedAt: preciseContext.observedAt } }
+    const equalSchema = { ...preciseSchema, certifiedDeployment: { ...preciseSchema.certifiedDeployment, recordedAt: preciseContext.observedAt, completion: { ...preciseSchema.certifiedDeployment.completion, completedAt: preciseContext.observedAt } } }
     expect(verifyEnvironmentManifest(buildEnvironmentManifest({ schema: equalSchema, functions: preciseFunctions, smoke: preciseSmoke, context: preciseContext }))).toEqual({ ok: true, blockers: [] })
   })
 
@@ -119,6 +126,7 @@ describe("immutable Supabase environment manifests", () => {
       ["function follows observation", (manifest) => { manifest.functions.observedAt = "2026-08-12T20:00:00.000001Z" }, "function-after-observation"],
       ["smoke predates deployment", (manifest) => { manifest.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T18:00:00Z" }) }, "hosted-smoke-before-deployment"],
       ["microsecond reversal", (manifest) => { manifest.certifiedDeployment.recordedAt = "2026-08-12T20:00:00.000999Z"; manifest.schema.observedAt = "2026-08-12T20:00:00.000001Z"; manifest.functions.observedAt = "2026-08-12T20:00:00.000001Z"; manifest.prerequisites.hostedUnauthenticatedDenial.evidence = buildSafeSmokeEvidence({ environment: "dev", projectRef: schema.projectRef, observationGitSha: context.gitSha, statusCode: 401, observedAt: "2026-08-12T20:00:00.000001Z" }); manifest.observation.observedAt = "2026-08-12T20:00:00.000001Z" }, "deployment-after-observation"],
+      ["unknown deployment offset", (manifest) => { manifest.certifiedDeployment.recordedAt = "2026-08-12T19:00:00-00:00" }, "deployment-time"],
     ]
     for (const [name, mutate, blocker] of cases) {
       const forged = structuredClone(base)

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -11045,6 +11045,7 @@ export type Database = {
           completed_at: string
           contract_version: string
           deployment_environment: string
+          deployment_manifest: Json
           deployment_manifest_sha256: string
           function_inventory_sha256: string
           hosted_smoke_evidence_sha256: string
@@ -11061,6 +11062,7 @@ export type Database = {
           completed_at?: string
           contract_version?: string
           deployment_environment: string
+          deployment_manifest: Json
           deployment_manifest_sha256: string
           function_inventory_sha256: string
           hosted_smoke_evidence_sha256: string
@@ -11077,6 +11079,7 @@ export type Database = {
           completed_at?: string
           contract_version?: string
           deployment_environment?: string
+          deployment_manifest?: Json
           deployment_manifest_sha256?: string
           function_inventory_sha256?: string
           hosted_smoke_evidence_sha256?: string

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -9142,45 +9142,6 @@ export type Database = {
           },
         ]
       }
-      supabase_deploy_migration_evidence: {
-        Row: {
-          actions_run_id: number
-          candidate_git_sha: string
-          contract_version: string
-          deployment_environment: string
-          id: number
-          inventory_sha256: string
-          migration_inventory: Json
-          project_ref: string
-          recorded_at: string
-          run_attempt: number
-        }
-        Insert: {
-          actions_run_id: number
-          candidate_git_sha: string
-          contract_version?: string
-          deployment_environment: string
-          id?: never
-          inventory_sha256: string
-          migration_inventory: Json
-          project_ref: string
-          recorded_at?: string
-          run_attempt: number
-        }
-        Update: {
-          actions_run_id?: number
-          candidate_git_sha?: string
-          contract_version?: string
-          deployment_environment?: string
-          id?: never
-          inventory_sha256?: string
-          migration_inventory?: Json
-          project_ref?: string
-          recorded_at?: string
-          run_attempt?: number
-        }
-        Relationships: []
-      }
       stripe_acss_debit_commands: {
         Row: {
           accounting_period_id: number
@@ -11074,6 +11035,116 @@ export type Database = {
           provider_event_id?: string
           provider_object_id?: string
           signature_timestamp?: number
+        }
+        Relationships: []
+      }
+      supabase_deploy_completion_evidence: {
+        Row: {
+          actions_run_id: number
+          candidate_git_sha: string
+          completed_at: string
+          contract_version: string
+          deployment_environment: string
+          deployment_manifest_sha256: string
+          function_inventory_sha256: string
+          hosted_smoke_evidence_sha256: string
+          id: number
+          inventory_sha256: string
+          project_ref: string
+          run_attempt: number
+          schema_expected_sha256: string
+          schema_observed_sha256: string
+        }
+        Insert: {
+          actions_run_id: number
+          candidate_git_sha: string
+          completed_at?: string
+          contract_version?: string
+          deployment_environment: string
+          deployment_manifest_sha256: string
+          function_inventory_sha256: string
+          hosted_smoke_evidence_sha256: string
+          id?: never
+          inventory_sha256: string
+          project_ref: string
+          run_attempt: number
+          schema_expected_sha256: string
+          schema_observed_sha256: string
+        }
+        Update: {
+          actions_run_id?: number
+          candidate_git_sha?: string
+          completed_at?: string
+          contract_version?: string
+          deployment_environment?: string
+          deployment_manifest_sha256?: string
+          function_inventory_sha256?: string
+          hosted_smoke_evidence_sha256?: string
+          id?: never
+          inventory_sha256?: string
+          project_ref?: string
+          run_attempt?: number
+          schema_expected_sha256?: string
+          schema_observed_sha256?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "supabase_deploy_completion_ev_candidate_git_sha_actions_ru_fkey"
+            columns: [
+              "candidate_git_sha",
+              "actions_run_id",
+              "run_attempt",
+              "deployment_environment",
+              "project_ref",
+            ]
+            isOneToOne: true
+            referencedRelation: "supabase_deploy_migration_evidence"
+            referencedColumns: [
+              "candidate_git_sha",
+              "actions_run_id",
+              "run_attempt",
+              "deployment_environment",
+              "project_ref",
+            ]
+          },
+        ]
+      }
+      supabase_deploy_migration_evidence: {
+        Row: {
+          actions_run_id: number
+          candidate_git_sha: string
+          contract_version: string
+          deployment_environment: string
+          id: number
+          inventory_sha256: string
+          migration_inventory: Json
+          project_ref: string
+          recorded_at: string
+          run_attempt: number
+        }
+        Insert: {
+          actions_run_id: number
+          candidate_git_sha: string
+          contract_version?: string
+          deployment_environment: string
+          id?: never
+          inventory_sha256: string
+          migration_inventory: Json
+          project_ref: string
+          recorded_at?: string
+          run_attempt: number
+        }
+        Update: {
+          actions_run_id?: number
+          candidate_git_sha?: string
+          contract_version?: string
+          deployment_environment?: string
+          id?: never
+          inventory_sha256?: string
+          migration_inventory?: Json
+          project_ref?: string
+          recorded_at?: string
+          run_attempt?: number
         }
         Relationships: []
       }


### PR DESCRIPTION
## Summary
- Preserve the immutable remote deployment evidence timestamp in certified environment manifests.
- Require semantically valid RFC3339 timestamps with explicit timezones in deploy and drift evidence.
- Prevent automatic drift observations from inferring an environment for manually dispatched deploys.

## Objective
Close the remaining Task #161 provenance and routing gaps so CI-owned Dev deployment and read-only observation manifests certify the same immutable deployment record without cross-target ambiguity.

## Changes
- Bind the validated remote migration evidence `recordedAt` value into deploy-time schema parity and the resulting certified manifest.
- Validate timezone-bearing RFC3339 timestamps with leap-aware calendar and clock component checks in both deploy and drift paths.
- Restrict automatic `workflow_run` observations to successful same-repository push deploys on `dev` or `main`; explicit manual drift selection remains available.
- Add adversarial provenance, malformed timestamp, and routing coverage; update the deployment runbook and Goal 1 session log.

## Validation
- Node 22 focused Vitest: 23/23 passed.
- Focused ESLint passed.
- Typecheck passed.
- Node syntax checks passed.
- Workflow YAML parse passed.
- `git diff --check` passed.
- Independent issue validation passed with a 7-positive/24-negative timestamp matrix across deploy and drift validators.

## Reviewer Notes
Review the evidence binding in `scripts/verify-supabase-schema-parity.mjs` first, then the `workflow_run` guard in `.github/workflows/supabase-drift.yml`. The timestamp parser intentionally rejects leap seconds, lowercase separators, whitespace, timezone-less values, and JavaScript-normalizable invalid dates.

## Follow-ups
- After merge, require a CI-owned Dev deploy manifest and a separate read-only Dev drift manifest at the exact merge SHA before Task #161 advances.
- Task #162 remains blocked until that hosted outcome validation passes.
- No Production deployment, value-flow activation, migration rewrite, or remote reset is included.
