### PR TITLE
[codex] normalize Supabase-root function readback

### DIFF
--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-2.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-2.md
@@ -321,3 +321,15 @@
 - Validation: focused MCP/readiness tests, scoped ESLint, Node 22 typecheck, Deno module check, migration replay through CI fresh-schema validation, workflow dry-run, and `git diff --check` follow this entry. No local Supabase restart, hosted mutation, Production action, provider enablement, payout, or real-value flow is authorized by this review fix.
 - Reflections: a privileged audience must have one consistent authorization rule across direct Edge and MCP read paths, and readiness must bind behavior-changing constraints rather than only the tables/functions that surround them.
 - Next steps: commit and push one review-fix changeset, reply to and resolve both original PR threads, wait for exact-head CI, then merge #206 to `dev` only under the reviewed non-squash policy. Keep #205 blocked until Cubid #77 is confirmed merged to Cubid `dev`.
+
+### session v28: normalize Supabase-root function readback (#188)
+
+- Timestamp: 2026-08-14T05:21:00Z
+- Agent: Codex (`sprint-orchestrator` post-merge recovery)
+- Branch: `codex/155-goal-2-function-readback-recovery`
+- Head before commit: `3078cd15f4fb`
+- Objective: recover merged-SHA Dev certification after the provider deployed all 64 functions but returned a different documented archive root for the self-contained persona readiness closure.
+- Actions: used the sanitized postdeploy error hashes to prove the three remote paths were exactly `functions/_shared/command-runtime.ts`, `functions/persona-readiness-identity/index.ts`, and `functions/persona-readiness-identity/source-contracts.json`. Added a single strict normalization from the provider's Supabase-root `functions/` namespace to the reviewed repository `supabase/functions/` namespace, while preserving repo-root normalization, unsafe-path rejection, exact missing/extra checks, byte/digest comparison, and duplicate/case/Unicode collision denial. Added positive self-contained closure coverage and an adversarial mixed-root alias collision.
+- Validation: focused source-readback and delivery-parity suites, scoped ESLint, Node 22 typecheck, Node syntax, workflow YAML, and `git diff --check` follow this entry. The failed CI-owned run applied the database migrations and deployed all 64 functions, then failed closed before smoke/manifest/completion; no retry, Production action, payout, or real-value flow occurred.
+- Reflections: the provider chooses the repository root when a function imports app modules and the `supabase/` root when a closure stays inside Supabase. Canonicalization must recognize both exact provider roots without accepting arbitrary prefixes or weakening path provenance.
+- Next steps: publish one consolidated recovery PR to `dev`, use the existing Codex review policy without serial recovery PRs, and require a fresh merged-SHA deploy plus read-only drift manifest before #188 advances. Keep #205 blocked pending Cubid #77's dev merge.

--- a/agent-context/session-log/2026-08-11-codex-sprint-155-goal-2.md
+++ b/agent-context/session-log/2026-08-11-codex-sprint-155-goal-2.md
@@ -333,3 +333,15 @@
 - Validation: focused source-readback and delivery-parity suites, scoped ESLint, Node 22 typecheck, Node syntax, workflow YAML, and `git diff --check` follow this entry. The failed CI-owned run applied the database migrations and deployed all 64 functions, then failed closed before smoke/manifest/completion; no retry, Production action, payout, or real-value flow occurred.
 - Reflections: the provider chooses the repository root when a function imports app modules and the `supabase/` root when a closure stays inside Supabase. Canonicalization must recognize both exact provider roots without accepting arbitrary prefixes or weakening path provenance.
 - Next steps: publish one consolidated recovery PR to `dev`, use the existing Codex review policy without serial recovery PRs, and require a fresh merged-SHA deploy plus read-only drift manifest before #188 advances. Keep #205 blocked pending Cubid #77's dev merge.
+
+### session v29: document the exact provider archive roots (#188)
+
+- Timestamp: 2026-08-14T05:25:00Z
+- Agent: Codex (`sprint-orchestrator` recovery review follow-up)
+- Branch: `codex/155-goal-2-function-readback-recovery`
+- Head before commit: `84c06f6b10ee`
+- Objective: make the deployment runbook match the reviewed source-readback provenance boundary introduced by recovery PR #207.
+- Actions: documented the two exact provider archive roots, the one-way `functions/` to `supabase/functions/` canonicalization, mixed-root alias collision rejection, and continued refusal to normalize arbitrary prefixes or exempt any source path/byte.
+- Validation: Markdown review, focused source-readback tests, scoped lint, and `git diff --check` follow this entry. This documentation-only follow-up does not change deployment behavior or authorize any remote action.
+- Reflections: the verifier and runbook are one security contract; undocumented normalization is operational ambiguity even when implementation and tests are fail-closed.
+- Next steps: push this one review follow-up, reply to and resolve the existing thread without rereview, require exact-head CI, then merge and obtain fresh Dev deployment/drift manifests.

--- a/docs/engineering/supabase-deployments.md
+++ b/docs/engineering/supabase-deployments.md
@@ -196,9 +196,13 @@ status, project ref, environment, candidate Git SHA, and observation time. The
 reader rejects redirects and non-200 responses without logging response bodies,
 validates project/function identifiers, bounds the response, file count, and each
 file, and rejects absolute/traversal paths, symlink/non-regular markers, duplicate or
-case/Unicode-colliding paths, and missing/extra closure members. Only the known
-`fundloop-website/` archive prefix is stripped; no source path or byte is allowlisted
-out of comparison. The contract follows Supabase CLI tag `v2.113.0`,
+case/Unicode-colliding paths, and missing/extra closure members. The reader recognizes
+exactly two provider archive roots: it strips the known `fundloop-website/` monorepo
+prefix, and it maps an unprefixed `functions/` path from a closure rooted by the CLI at
+`supabase/` to the reviewed repository path `supabase/functions/`. A repo-root and
+Supabase-root alias of the same file is rejected as a duplicate/collision; arbitrary
+prefixes are not normalized. No source path or byte is allowlisted out of comparison.
+The contract follows Supabase CLI tag `v2.113.0`,
 `apps/cli-go/internal/functions/download/download.go` (`readForm` and `getPartPath`).
 This is multipart source read-back, not ZIP extraction. The database verifier
 independently replays all tracked migrations into a randomized

--- a/scripts/verify-supabase-function-parity.mjs
+++ b/scripts/verify-supabase-function-parity.mjs
@@ -11,6 +11,7 @@ const maxResponseBytes = 16 * 1024 * 1024
 const maxFileBytes = 2 * 1024 * 1024
 const maxFileCount = 256
 const knownRepoRootPrefix = "fundloop-website/"
+const knownSupabaseRootPrefix = "functions/"
 
 export function expectedFunctionNames(root = repoRoot) {
   return readdirSync(path.join(root, "supabase/functions"), { withFileTypes: true })
@@ -184,8 +185,9 @@ function safeArchivePath(rawPath) {
   }
   const segments = rawPath.split("/")
   if (segments.some((segment) => !segment || segment === "." || segment === "..")) throw new Error("Remote function archive contains an unsafe path")
-  const relative = rawPath.startsWith(knownRepoRootPrefix) ? rawPath.slice(knownRepoRootPrefix.length) : rawPath
-  return relative
+  if (rawPath.startsWith(knownRepoRootPrefix)) return rawPath.slice(knownRepoRootPrefix.length)
+  if (rawPath.startsWith(knownSupabaseRootPrefix)) return `supabase/${rawPath}`
+  return rawPath
 }
 
 function multipartBoundary(contentType) {

--- a/tests/supabase-function-source-readback.test.ts
+++ b/tests/supabase-function-source-readback.test.ts
@@ -142,6 +142,28 @@ describe("Supabase Management API function source read-back", () => {
     expect(parsed.get(expected[0])?.toString()).toBe("result\n")
   })
 
+  it("normalizes the provider Supabase archive root for self-contained closures", async () => {
+    const expected = [
+      "supabase/functions/_shared/command-runtime.ts",
+      "supabase/functions/persona-readiness-identity/index.ts",
+      "supabase/functions/persona-readiness-identity/source-contracts.json",
+    ]
+    const parsed = await parseFunctionSourceResponse(multipart([
+      file("functions/_shared/command-runtime.ts", "runtime\n"),
+      file("functions/persona-readiness-identity/index.ts", "entry\n"),
+      file("functions/persona-readiness-identity/source-contracts.json", "{}\n"),
+    ]), "persona-readiness-identity", expected)
+    expect([...parsed.keys()].sort()).toEqual(expected)
+  })
+
+  it("rejects repo-root and Supabase-root aliases of the same reviewed file", async () => {
+    await expect(parseFunctionSourceResponse(multipart([
+      file("functions/example/index.ts"),
+      file("fundloop-website/supabase/functions/example/index.ts"),
+    ]), "example", ["supabase/functions/example/index.ts"]))
+      .rejects.toThrow("duplicate or colliding paths")
+  })
+
   it("accepts legal multipart parameter ordering and gives Supabase-Path precedence", async () => {
     const response = multipart([file("wrong.ts", "right\n", { "Supabase-Path": "fundloop-website/safe.ts" })])
     response.headers.set("content-type", "multipart/form-data; charset=utf-8; boundary=\"fundloop-source-boundary\"")


### PR DESCRIPTION
## Summary

- Fixes the sole post-merge Goal 2 deployment failure without changing product behavior.
- Recognizes Supabase's exact `functions/` archive root for closures contained entirely under `supabase/`.
- Preserves exact expected-path, byte, digest, unsafe-path, and collision enforcement.

## Objective

Allow CI to certify the already-deployed `persona-readiness-identity` function while retaining fail-closed source provenance.

## Changes

- Canonicalize only an unprefixed provider `functions/...` path to the reviewed repository `supabase/functions/...` path.
- Keep the existing `fundloop-website/...` monorepo-root normalization unchanged.
- Reject mixed provider-root and repo-root aliases of the same reviewed file as duplicate/colliding paths.
- Add positive self-contained closure and adversarial alias tests.

## Validation

- Focused source-readback and delivery-parity suites: 51/51 passed.
- Scoped ESLint and Node 22 typecheck passed.
- Verifier Node syntax, workflow YAML parse, and `git diff --check` passed.
- Hosted failure evidence: run 31771937672 applied migrations and deployed all 64 functions, then failed closed on the three exact `functions/...` path aliases before smoke, manifests, or completion.

## Reviewer Notes

Review the two-line canonicalization first, then its positive and collision tests. The provider path hashes in the sanitized failure match exactly the three reviewed `functions/...` names; no unknown path is allowlisted.

## Follow-ups

After merge, require a new exact-SHA Dev deploy manifest and a separate read-only drift manifest before advancing #188. No rereview will be requested after actionable fixes.

Related to #188, #163, #155, and PR #206.

Intentionally not included: product/schema/function changes; Cubid integration; Production mutation; provider enablement; payouts; real-value flow.

